### PR TITLE
Key prefix in Store interface

### DIFF
--- a/pkg/storage/instrumented.go
+++ b/pkg/storage/instrumented.go
@@ -26,6 +26,14 @@ type instrumentedStore struct {
 	logs  log.Factory
 }
 
+func (i *instrumentedStore) KeysPrefix(ctx context.Context, token, prefix, delimiter string) ([]string, string, error) {
+	span := i.spanFromContext(ctx, i.opName("KeysPrefix"))
+	defer span.Finish()
+	i.logs.Bg().Info("storage keys with Prefix")
+
+	return i.store.KeysPrefix(ctx, token, prefix, delimiter)
+}
+
 func (i *instrumentedStore) opName(name string) string {
 	return strings.Join([]string{"storage", i.String(), name}, ".")
 }

--- a/pkg/storage/localfs/store.go
+++ b/pkg/storage/localfs/store.go
@@ -4,6 +4,7 @@ package localfs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -106,6 +107,11 @@ func (l *localFS) Keys(ctx context.Context) ([]string, error) {
 		return nil, e
 	}
 	return res, nil
+}
+
+//TODO discuss the implementation with @Ivan & @Ritesh
+func (l *localFS) KeysPrefix(ctx context.Context, token, prefix, delimiter string) ([]string, string, error) {
+	return nil, "", errors.New("unimplemented")
 }
 
 func (l *localFS) Clear(ctx context.Context) error {

--- a/pkg/storage/sthree/store_test.go
+++ b/pkg/storage/sthree/store_test.go
@@ -99,6 +99,16 @@ func TestPut(t *testing.T) {
 	assert.Len(t, k, 3)
 }
 
+func TestKeysPrefix(t *testing.T) {
+	bs, cleanup := setupStore(t)
+	defer cleanup()
+
+	keys, token, err := bs.KeysPrefix(context.Background(), "", "", "")
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+	require.Equal(t, token, "")
+}
+
 func setupStore(t testing.TB) (storage.Store, func()) {
 	t.Helper()
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -33,6 +33,7 @@ type Store interface {
 	Put(context.Context, string, io.Reader) error
 	Delete(context.Context, string) error
 	Keys(context.Context) ([]string, error)
+	KeysPrefix(ctx context.Context, token, prefix, delimiter string) ([]string, string, error)
 	Clear(context.Context) error
 }
 


### PR DESCRIPTION
1. Addition of KeyPrefix method in Store interface
2. Implementation of KeyPrefix in localfs, sthree, gcs
3. Pagination support in S3 with Prefix, Delimiter
4. Unit test of KeyPrefix in sthree

Signed-off-by: chandresh-pancholi <chandresh@oneconcern.com>