### PR TITLE
Add path validation and cleaning up.

### DIFF
--- a/cmd/datamon/cmd/bundle_download_file.go
+++ b/cmd/datamon/cmd/bundle_download_file.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/storage/gcs"
@@ -26,9 +27,12 @@ var bundleDownloadFileCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalln(err)
 		}
-
-		_ = os.MkdirAll(bundleOptions.DataPath, 0700)
-		destinationStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), bundleOptions.DataPath))
+		path, err := filepath.Abs(filepath.Clean(bundleOptions.DataPath))
+		if err != nil {
+			log.Fatalf("Failed path validation: %s", err)
+		}
+		_ = os.MkdirAll(path, 0700)
+		destinationStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), path))
 
 		bd := core.NewBDescriptor()
 		bundle := core.New(bd,


### PR DESCRIPTION
Fixes #90

tested manualy
```
➜  tmp git:(master) ✗ ../../datamon  bundle download --repo ritesh-test-repo --bundle 1ISwIzeAR6m3aOVltAsj1kfQaml --destination .  
Using config file: /Users/ritesh/.datamon/datamon.yaml
/Users/ritesh/src/go/src/github.com/oneconcern/datamon/tmp/tmpstarted backup2blobs/cmd/generateFileList.go~
started datamon/cmd/repo_list.go
started backup2blobs/cmd/file2blobs.go~
started datamon/cmd/.bundle_upload.go.un~
started backup2blobs/cmd/generateFileList.go
started datamon/cmd/bundle_upload.go
started datamon/cmd/repo_create.go
started datamon/cmd/completion.go
started datamon/cmd/bundle_upload.go~
started datamon/cmd/fschecks.go
started backup2blobs/cmd/.generateFileList.go.un~
started backup2blobs/cmd/.file2blobs.go.un~
started backup2blobs/main.go
started datamon/cmd/.bundle_download.go.un~
started datamon/cmd/bundle_download.go~
started datamon/cmd/.bundle.go.un~
started datamon/cmd/bundle.go~
started datamon/main.go
started datamon/cmd/bundle_mount.go
started backup2blobs/cmd/file2blobs.go
started datamon/cmd/bundle_download.go
started datamon/cmd/root.go
started datamon/cmd/config_generate.go
started datamon/cmd/bundle.go
started backup2blobs/cmd/blob2file.go
started datamon/cmd/bundle_list_file.go
started datamon/cmd/bundle_download_file.go
started datamon/cmd/bundle_list.go
started datamon/cmd/repo.go
started datamon/cmd/config.go
downloaded datamon/cmd/bundle.go
downloaded datamon/cmd/completion.go
downloaded datamon/cmd/bundle_list_file.go
downloaded datamon/cmd/root.go
downloaded datamon/cmd/bundle.go~
downloaded datamon/cmd/bundle_list.go
downloaded datamon/cmd/bundle_download.go~
downloaded datamon/cmd/fschecks.go
downloaded backup2blobs/cmd/generateFileList.go~
downloaded datamon/main.go
downloaded datamon/cmd/repo.go
downloaded backup2blobs/cmd/blob2file.go
downloaded datamon/cmd/bundle_download_file.go
downloaded datamon/cmd/.bundle_download.go.un~
downloaded datamon/cmd/bundle_upload.go
downloaded backup2blobs/cmd/generateFileList.go
downloaded backup2blobs/cmd/.generateFileList.go.un~
downloaded datamon/cmd/repo_list.go
downloaded backup2blobs/main.go
downloaded datamon/cmd/.bundle_upload.go.un~
downloaded backup2blobs/cmd/file2blobs.go
downloaded datamon/cmd/bundle_upload.go~
downloaded datamon/cmd/.bundle.go.un~
downloaded datamon/cmd/config_generate.go
downloaded datamon/cmd/config.go
downloaded datamon/cmd/repo_create.go
downloaded backup2blobs/cmd/.file2blobs.go.un~
downloaded datamon/cmd/bundle_download.go
downloaded backup2blobs/cmd/file2blobs.go~
downloaded datamon/cmd/bundle_mount.go

```