### PR TITLE
Add CRC checks when uploading to GCS

### DIFF
--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"log"
 	"sync/atomic"
@@ -111,12 +112,23 @@ func uploadBundle(ctx context.Context, bundle *Bundle) error {
 				if e != nil {
 					return e
 				}
-				err = bundle.MetaStore.Put(ctx,
-					model.GetArchivePathToBundleFileList(
-						bundle.RepoID,
-						bundle.BundleID,
-						bundle.BundleDescriptor.BundleEntriesFileCount),
-					bytes.NewReader(buffer), storage.IfNotPresent)
+				msCRC, ok := bundle.MetaStore.(storage.StoreCRC)
+				if ok {
+					crc := crc32.Checksum(buffer, crc32.MakeTable(crc32.Castagnoli))
+					err = msCRC.PutCRC(ctx,
+						model.GetArchivePathToBundleFileList(
+							bundle.RepoID,
+							bundle.BundleID,
+							bundle.BundleDescriptor.BundleEntriesFileCount),
+						bytes.NewReader(buffer), storage.IfNotPresent, crc)
+				} else {
+					err = bundle.MetaStore.Put(ctx,
+						model.GetArchivePathToBundleFileList(
+							bundle.RepoID,
+							bundle.BundleID,
+							bundle.BundleDescriptor.BundleEntriesFileCount),
+						bytes.NewReader(buffer), storage.IfNotPresent)
+				}
 				if err != nil {
 					return err
 				}
@@ -142,10 +154,18 @@ func uploadBundleDescriptor(ctx context.Context, bundle *Bundle) error {
 	if err != nil {
 		return err
 	}
+	msCRC, ok := bundle.MetaStore.(storage.StoreCRC)
+	if ok {
+		crc := crc32.Checksum(buffer, crc32.MakeTable(crc32.Castagnoli))
+		err = msCRC.PutCRC(ctx,
+			model.GetArchivePathToBundle(bundle.RepoID, bundle.BundleID),
+			bytes.NewReader(buffer), storage.IfNotPresent, crc)
 
-	err = bundle.MetaStore.Put(ctx,
-		model.GetArchivePathToBundle(bundle.RepoID, bundle.BundleID),
-		bytes.NewReader(buffer), storage.IfNotPresent)
+	} else {
+		err = bundle.MetaStore.Put(ctx,
+			model.GetArchivePathToBundle(bundle.RepoID, bundle.BundleID),
+			bytes.NewReader(buffer), storage.IfNotPresent)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/core/bundle_test.go
+++ b/pkg/core/bundle_test.go
@@ -139,14 +139,15 @@ func generateDataFile(test *testing.T, store storage.Store) model.BundleEntry {
 	ksuid, err := ksuid.NewRandom()
 	require.NoError(test, err)
 	var size int = 2 * leafSize
-	require.NoError(test, cafs.GenerateFile(original+ksuid.String(), size, leafSize))
+	file := original + ksuid.String()
+	require.NoError(test, cafs.GenerateFile(file, size, leafSize))
 	// Write individual blobs
 	fs, err := cafs.New(
 		cafs.LeafSize(leafSize),
 		cafs.Backend(store),
 	)
 	require.NoError(test, err)
-	keys, err := cafs.GenerateCAFSChunks(original+ksuid.String(), fs)
+	keys, err := cafs.GenerateCAFSChunks(file, fs)
 	require.NoError(test, err)
 	// return the Bundle Entry
 	return model.BundleEntry{

--- a/pkg/core/repo_create.go
+++ b/pkg/core/repo_create.go
@@ -3,6 +3,8 @@ package core
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/oneconcern/datamon/pkg/model"
 	"github.com/oneconcern/datamon/pkg/storage"
@@ -21,6 +23,9 @@ func CreateRepo(repo model.RepoDescriptor, store storage.Store) error {
 	path := model.GetArchivePathToRepoDescriptor(repo.Name)
 	err = store.Put(context.Background(), path, bytes.NewReader(r), storage.IfNotPresent)
 	if err != nil {
+		if strings.Contains(err.Error(), "googleapi: Error 412: Precondition Failed, conditionNotMet") {
+			return fmt.Errorf("repo already exists: %s", repo.Name)
+		}
 		return err
 	}
 	return nil

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -43,6 +43,10 @@ type Store interface {
 	KeysPrefix(ctx context.Context, pageToken string, prefix string, delimiter string, count int) ([]string, string, error)
 }
 
+type StoreCRC interface {
+	PutCRC(context.Context, string, io.Reader, bool, uint32) error
+}
+
 func ReadTee(ctx context.Context, sStore Store, source string, dStore Store, destination string) ([]byte, error) {
 	reader, err := sStore.Get(ctx, source)
 	if err != nil {


### PR DESCRIPTION
To allow for end to end checksummig on data, on upload uses CRC checks.

Signed-off-by: Ritesh H Shukla <ritesh@oneconcern.com>