### PR TITLE
test CLI according to readme

### DIFF
--- a/cmd/datamon/cmd/bundle_download.go
+++ b/cmd/datamon/cmd/bundle_download.go
@@ -4,7 +4,6 @@ package cmd
 
 import (
 	"context"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -24,31 +23,31 @@ var BundleDownloadCmd = &cobra.Command{
 
 		sourceStore, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		blobStore, err := gcs.New(repoParams.BlobBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		path, err := filepath.Abs(filepath.Clean(bundleOptions.DataPath))
 		if err != nil {
-			log.Fatalf("Failed path validation: %s", err)
+			log_Fatalf("Failed path validation: %s", err)
 		}
 		// Ignore error
 		_ = os.MkdirAll(path, 0700)
 		fs := afero.NewBasePathFs(afero.NewOsFs(), path)
 		empty, err := afero.IsEmpty(fs, "/")
 		if err != nil {
-			log.Fatalf("Failed path validation: %s", err)
+			log_Fatalf("Failed path validation: %s", err)
 		}
 		if !empty {
-			log.Fatalf("%s should be empty", path)
+			log_Fatalf("%s should be empty", path)
 		}
 		destinationStore := localfs.New(fs)
 
 		err = setLatestBundle(sourceStore)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		bd := core.NewBDescriptor()
 		bundle := core.New(bd,
@@ -61,7 +60,7 @@ var BundleDownloadCmd = &cobra.Command{
 
 		err = core.Publish(context.Background(), bundle)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	},
 }
@@ -83,7 +82,7 @@ func init() {
 	for _, flag := range requiredFlags {
 		err := BundleDownloadCmd.MarkFlagRequired(flag)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	}
 

--- a/cmd/datamon/cmd/bundle_download_file.go
+++ b/cmd/datamon/cmd/bundle_download_file.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -21,21 +20,21 @@ var bundleDownloadFileCmd = &cobra.Command{
 
 		sourceStore, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		blobStore, err := gcs.New(repoParams.BlobBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		path, err := filepath.Abs(filepath.Clean(bundleOptions.DataPath))
 		if err != nil {
-			log.Fatalf("Failed path validation: %s", err)
+			log_Fatalf("Failed path validation: %s", err)
 		}
 		_ = os.MkdirAll(path, 0700)
 		destinationStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), path))
 		err = setLatestBundle(sourceStore)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		bd := core.NewBDescriptor()
 		bundle := core.New(bd,
@@ -48,7 +47,7 @@ var bundleDownloadFileCmd = &cobra.Command{
 
 		err = core.PublishFile(context.Background(), bundle, bundleOptions.File)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	},
 }
@@ -66,7 +65,7 @@ func init() {
 	for _, flag := range requiredFlags {
 		err := bundleDownloadFileCmd.MarkFlagRequired(flag)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	}
 

--- a/cmd/datamon/cmd/bundle_list.go
+++ b/cmd/datamon/cmd/bundle_list.go
@@ -16,11 +16,11 @@ var BundleListCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		store, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		keys, err := core.ListBundles(repoParams.RepoName, store)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		for _, key := range keys {
 			log.Println(key)
@@ -38,7 +38,7 @@ func init() {
 	for _, flag := range requiredFlags {
 		err := BundleListCommand.MarkFlagRequired(flag)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	}
 

--- a/cmd/datamon/cmd/bundle_list_file.go
+++ b/cmd/datamon/cmd/bundle_list_file.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/oneconcern/datamon/pkg/core"
 
@@ -20,11 +19,11 @@ var bundleFileList = &cobra.Command{
 
 		store, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		err = setLatestBundle(store)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		bundle := core.Bundle{
 			RepoID:           repoParams.RepoName,
@@ -37,7 +36,7 @@ var bundleFileList = &cobra.Command{
 		}
 		err = core.PopulateFiles(context.Background(), &bundle)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		for _, e := range bundle.BundleEntries {
 			fmt.Printf("name:%s, size:%d, hash:%s\n", e.NameWithPath, e.Size, e.Hash)
@@ -59,7 +58,7 @@ func init() {
 	for _, flag := range requiredFlags {
 		err := BundleDownloadCmd.MarkFlagRequired(flag)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	}
 	BundleListCommand.AddCommand(bundleFileList)

--- a/cmd/datamon/cmd/bundle_mount.go
+++ b/cmd/datamon/cmd/bundle_mount.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"log"
 	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
@@ -25,11 +24,11 @@ var mountBundleCmd = &cobra.Command{
 
 		metadataSource, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		blobStore, err := gcs.New(repoParams.BlobBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		consumableStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), bundleOptions.DataPath))
 
@@ -44,11 +43,11 @@ var mountBundleCmd = &cobra.Command{
 
 		fs, err := core.NewReadOnlyFS(bundle)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		err = fs.MountReadOnly(bundleOptions.MountPath)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		for {
 			time.Sleep(time.Hour)
@@ -68,7 +67,7 @@ func init() {
 	for _, flag := range requiredFlags {
 		err := mountBundleCmd.MarkFlagRequired(flag)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	}
 

--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/oneconcern/datamon/pkg/storage"
@@ -27,18 +26,18 @@ var uploadBundleCmd = &cobra.Command{
 		fmt.Println(config.Credential)
 		MetaStore, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		blobStore, err := gcs.New(repoParams.BlobBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		var sourceStore storage.Store
 		if strings.HasPrefix(bundleOptions.DataPath, "gs://") {
 			fmt.Println(bundleOptions.DataPath[4:])
 			sourceStore, err = gcs.New(bundleOptions.DataPath[5:], config.Credential)
 			if err != nil {
-				log.Fatalln(err)
+				log_Fatalln(err)
 			}
 		} else {
 			DieIfNotAccessible(bundleOptions.DataPath)
@@ -61,7 +60,7 @@ var uploadBundleCmd = &cobra.Command{
 
 		err = core.Upload(context.Background(), bundle)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	},
 }
@@ -75,7 +74,7 @@ func init() {
 	for _, flag := range requiredFlags {
 		err := uploadBundleCmd.MarkFlagRequired(flag)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	}
 

--- a/cmd/datamon/cmd/cli_test.go
+++ b/cmd/datamon/cmd/cli_test.go
@@ -3,9 +3,15 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
+	"time"
+	"strconv"
 
 	"github.com/oneconcern/datamon/pkg/storage"
 
@@ -16,47 +22,20 @@ import (
 
 	gcsStorage "cloud.google.com/go/storage"
 	"github.com/oneconcern/datamon/internal"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
 const (
 	destinationDir = "../../../testdata/cli"
 	sourceData     = destinationDir + "/data"
+	consumedData   = destinationDir + "/downloads"
 	repo1          = "test-repo1"
 	repo2          = "test-repo2"
+	timeForm = "2006-01-02 15:04:05.999999999 -0700 MST"
 )
-
-func setupTests() func() {
-	os.RemoveAll(destinationDir)
-	ctx := context.Background()
-	bucket := "datamontest-" + internal.RandStringBytesMaskImprSrc(15)
-
-	client, err := gcsStorage.NewClient(context.TODO(), option.WithScopes(gcsStorage.ScopeFullControl))
-	err = client.Bucket(bucket).Create(ctx, "oneconcern-1509", nil)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	createTree()
-	cleanup := func() {
-		os.RemoveAll(destinationDir)
-		log.Printf("Delete bucket %s ", bucket)
-		_ = client.Bucket(bucket).Delete(ctx)
-	}
-	return cleanup
-}
-
-func TestCreateRepo(t *testing.T) {
-	cleanup := setupTests()
-	defer cleanup()
-	rootCmd.SetArgs([]string{"repo",
-		"create",
-		"--description", "testing",
-		"--repo", "ritesh-datamon-test-repo",
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
-	})
-	rootCmd.Execute()
-}
 
 type uploadTree struct {
 	path string
@@ -64,11 +43,12 @@ type uploadTree struct {
 	data []byte
 }
 
-var testUploadTree = []uploadTree{
+var testUploadTrees = [][]uploadTree{{
 	{
 		path: "/small/1k",
 		size: 1024,
 	},
+}, {
 	{
 		path: "/leafs/leafsize",
 		size: cafs.DefaultLeafSize,
@@ -89,6 +69,7 @@ var testUploadTree = []uploadTree{
 		path: "/leafs/root",
 		size: 1,
 	},
+}, {
 	{
 		path: "/1/2/3/4/5/6/deep",
 		size: 100,
@@ -97,17 +78,692 @@ var testUploadTree = []uploadTree{
 		path: "/1/2/3/4/5/6/7/deeper",
 		size: 200,
 	},
+},
 }
+
+type ExitMocks struct {
+	mock.Mock
+	fatalCalls int
+}
+
+func (m *ExitMocks) Fatalf(format string, v ...interface{}) {
+	m.fatalCalls++
+}
+
+func (m *ExitMocks) Fatalln(v ...interface{}) {
+	m.fatalCalls++
+}
+
+// https://github.com/stretchr/testify/issues/610
+func MakeFatalfMock(m *ExitMocks) func(string, ...interface{}) {
+	return func(format string, v ...interface{}) {
+		m.Fatalf(format, v...)
+	}
+}
+
+func MakeFatallnMock(m *ExitMocks) func(...interface{}) {
+	return func(v ...interface{}) {
+		m.Fatalln(v...)
+	}
+}
+
+var exitMocks *ExitMocks
+
+func setupTests(t *testing.T) func() {
+	os.RemoveAll(destinationDir)
+	ctx := context.Background()
+	exitMocks = new(ExitMocks)
+	log_Fatalf = MakeFatalfMock(exitMocks)
+	log_Fatalln = MakeFatallnMock(exitMocks)
+	btag := internal.RandStringBytesMaskImprSrc(15)
+	bucketMeta := "datamontestmeta-" + btag
+	bucketBlob := "datamontestblob-" + btag
+
+	client, err := gcsStorage.NewClient(context.TODO(), option.WithScopes(gcsStorage.ScopeFullControl))
+	err = client.Bucket(bucketMeta).Create(ctx, "onec-co", nil)
+	require.NoError(t, err)
+	err = client.Bucket(bucketBlob).Create(ctx, "onec-co", nil)
+	require.NoError(t, err)
+	repoParams.MetadataBucket = bucketMeta
+	repoParams.BlobBucket = bucketBlob
+	createTree()
+	cleanup := func() {
+		os.RemoveAll(destinationDir)
+		deleteBucket(t, ctx, client, bucketMeta)
+		deleteBucket(t, ctx, client, bucketBlob)
+	}
+	return cleanup
+}
+
+func TestCreateRepo(t *testing.T) {
+	cleanup := setupTests(t)
+	defer cleanup()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo2,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	// negative test
+	require.Equal(t, exitMocks.fatalCalls, 0)
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	require.Equal(t, exitMocks.fatalCalls, 1)
+}
+
+type repoListEntry struct {
+	rawLine     string
+	repo        string
+	name        string
+	description string
+	email       string
+	time        time.Time
+}
+
+func listRepos(t *testing.T) ([]repoListEntry, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	log.SetOutput(w)
+	//
+	rootCmd.SetArgs([]string{"repo",
+		"list",
+	})
+	require.NoError(t, rootCmd.Execute())
+	//
+	log.SetOutput(os.Stdout)
+	w.Close()
+	//
+	lb, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	ls := string(lb)
+	ll := strings.Split(strings.TrimSpace(ls), "\n")
+	//
+	m, err := regexp.MatchString(`Using config file`, ll[0])
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	//
+	rles := make([]repoListEntry, 0)
+	for _, line := range ll[1:] {
+		sl := strings.Split(line, ",")
+		t, err := time.Parse(timeForm, strings.TrimSpace(sl[4]))
+		if err != nil {
+			return nil, err
+		}
+		rle := repoListEntry{
+			rawLine:     line,
+			repo:        strings.TrimSpace(sl[0]),
+			name:        strings.TrimSpace(sl[2]),
+			description: strings.TrimSpace(sl[1]),
+			email:       strings.TrimSpace(sl[3]),
+			time: t,
+		}
+		rles = append(rles, rle)
+	}
+	return rles, nil
+}
+
+func TestRepoList(t *testing.T) {
+	cleanup := setupTests(t)
+	defer cleanup()
+	ll, err := listRepos(t)
+	require.NoError(t, err)
+	require.Equal(t, len(ll), 0)
+	testNow := time.Now()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	ll, err = listRepos(t)
+	require.NoError(t, err)
+	require.Equal(t, len(ll), 1)
+	require.Equal(t, ll[0].repo, repo1)
+	require.Equal(t, ll[0].description, "testing")
+	require.Equal(t, ll[0].name, "tests")
+	require.Equal(t, ll[0].email, "datamon@oneconcern.com")
+	require.True(t, testNow.Sub(ll[0].time).Seconds() < 3)
+	testNow = time.Now()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing too",
+		"--repo", repo2,
+		"--name", "tests2",
+		"--email", "datamon2@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	ll, err = listRepos(t)
+	require.NoError(t, err)
+	require.Equal(t, len(ll), 2)
+	require.Equal(t, ll[0].repo, repo1)
+	require.Equal(t, ll[0].description, "testing")
+	require.Equal(t, ll[0].name, "tests")
+	require.Equal(t, ll[0].email, "datamon@oneconcern.com")
+	require.Equal(t, ll[1].repo, repo2)
+	require.Equal(t, ll[1].description, "testing too")
+	require.Equal(t, ll[1].name, "tests2")
+	require.Equal(t, ll[1].email, "datamon2@oneconcern.com")
+	require.True(t, testNow.Sub(ll[1].time).Seconds() < 3)
+}
+
+func testUploadBundle(t *testing.T, file uploadTree) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	log.SetOutput(w)
+	//
+	cmd := []string{"bundle",
+		"upload",
+		"--path", dirPathStr(t, file),
+		"--message", "The initial commit for the repo",
+		"--repo", repo1,
+	}
+	rootCmd.SetArgs(cmd)
+	require.NoError(t, rootCmd.Execute())
+	//
+	log.SetOutput(os.Stdout)
+	w.Close()
+	//
+	lb, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	ls := string(lb)
+	//
+	m, err := regexp.MatchString(`Uploaded bundle`, ls)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+}
+
+func TestUploadBundle(t *testing.T) {
+	cleanup := setupTests(t)
+	defer cleanup()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	for _, tree := range testUploadTrees {
+		testUploadBundle(t, tree[0])
+	}
+}
+
+func TestUploadBundle_filePath(t *testing.T) {
+	cleanup := setupTests(t)
+	defer cleanup()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	file := testUploadTrees[0][0]
+	cmd := []string{"bundle",
+		"upload",
+		"--path", filePathStr(t, file),
+		"--message", "The initial commit for the repo",
+		"--repo", repo1,
+	}
+	rootCmd.SetArgs(cmd)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Logf("todo: there's currently no error on file bundle upload")
+		bcnt := 1
+		rll, err := listBundles(t, repo1)
+		require.NoError(t, err)
+		require.Equal(t, len(rll), bcnt)
+		bll, err := listBundleFiles(t, repo1, rll[len(rll)-1].hash)
+		require.NoError(t, err)
+		if len(bll) == 0 {
+			t.Logf("even though the resultant bundle contains no files...")
+		}
+	}
+}
+
+type bundleListEntry struct {
+	rawLine     string
+	hash        string
+	message        string
+	time        time.Time
+}
+
+func listBundles(t *testing.T, repoName string) ([]bundleListEntry, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	log.SetOutput(w)
+	//
+	rootCmd.SetArgs([]string{"bundle",
+		"list",
+		"--repo", repoName,
+	})
+	require.NoError(t, rootCmd.Execute())
+	//
+	log.SetOutput(os.Stdout)
+	w.Close()
+	//
+	lb, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	ls := string(lb)
+	ll := strings.Split(strings.TrimSpace(ls), "\n")
+	//
+	m, err := regexp.MatchString(`Using config file`, ll[0])
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	//
+	bles := make([]bundleListEntry, 0)
+	for _, line := range ll[1:] {
+		sl := strings.Split(line, ",")
+		t, err := time.Parse(timeForm, strings.TrimSpace(sl[1]))
+		if err != nil {
+			return nil, err
+		}
+		rle := bundleListEntry{
+			rawLine:     line,
+			hash:        strings.TrimSpace(sl[0]),
+			message: strings.TrimSpace(sl[2]),
+			time: t,
+		}
+		bles = append(bles, rle)
+	}
+	return bles, nil
+}
+
+func testListBundle(t *testing.T, file uploadTree, bcnt int) {
+	msg := internal.RandStringBytesMaskImprSrc(15)
+	testNow := time.Now()
+	rootCmd.SetArgs([]string{"bundle",
+		"upload",
+		"--path", dirPathStr(t, file),
+		"--message", msg,
+		"--repo", repo1,
+	})
+	require.NoError(t, rootCmd.Execute())
+	ll, err := listBundles(t, repo2)
+	require.NoError(t, err)
+	require.Equal(t, len(ll), 0, "no bundles created yet")
+	ll, err = listBundles(t, repo1)
+	require.NoError(t, err)
+	require.Equal(t, len(ll), bcnt)
+	require.Equal(t, ll[len(ll)-1].message, msg)
+	require.True(t, testNow.Sub(ll[len(ll)-1].time).Seconds() < 3)
+}
+
+func TestListBundles(t *testing.T) {
+	cleanup := setupTests(t)
+	defer cleanup()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo2,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	ll, err := listBundles(t, repo1)
+	require.NoError(t, err)
+	require.Equal(t, len(ll), 0, "no bundles created yet")
+	ll, err = listBundles(t, repo2)
+	require.NoError(t, err)
+	require.Equal(t, len(ll), 0, "no bundles created yet")
+
+	for i, tree := range testUploadTrees {
+		testListBundle(t, tree[0], i+1)
+	}
+}
+
+func testDownloadBundle(t *testing.T, files []uploadTree, bcnt int) {
+	msg := internal.RandStringBytesMaskImprSrc(15)
+	rootCmd.SetArgs([]string{"bundle",
+		"upload",
+		"--path", dirPathStr(t, files[0]),
+		"--message", msg,
+		"--repo", repo1,
+	})
+	require.NoError(t, rootCmd.Execute())
+	ll, err := listBundles(t, repo1)
+	require.NoError(t, err)
+	require.Equal(t, len(ll), bcnt)
+	//
+	destFS := afero.NewBasePathFs(afero.NewOsFs(), consumedData)
+	dpc := "bundle-dl-" + ll[len(ll)-1].hash
+	dp, err := filepath.Abs(filepath.Join(consumedData, dpc))
+	if err != nil {
+		t.Errorf("couldn't build file path: %v", err)
+	}
+	exists, err := afero.Exists(destFS, dpc)
+	require.NoError(t, err)
+	require.False(t, exists)
+	rootCmd.SetArgs([]string{"bundle",
+		"download",
+		"--repo", repo1,
+		"--destination", dp,
+		"--bundle", ll[len(ll)-1].hash,
+	})
+	require.NoError(t, rootCmd.Execute())
+	exists, err = afero.Exists(destFS, dpc)
+	require.NoError(t, err)
+	require.True(t, exists)
+	//
+	for _, file := range files {
+		expected := readTextFile(t, filePathStr(t, file))
+		actual := readTextFile(t, filepath.Join(dp, pathInBundle(t, file)))
+		require.Equal(t, len(expected), len(actual))
+		require.Equal(t, expected, actual)
+	}
+}
+
+func TestDownloadBundles(t *testing.T) {
+	cleanup := setupTests(t)
+	defer cleanup()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	for i, tree := range testUploadTrees {
+		testDownloadBundle(t, tree, i+1)
+	}
+}
+
+type bundleFileListEntry struct {
+	rawLine     string
+	hash        string
+	name        string
+	size        int
+}
+
+
+func listBundleFiles(t *testing.T, repoName string, bid string) ([]bundleFileListEntry, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	stdout := os.Stdout
+	os.Stdout = w
+	//
+	rootCmd.SetArgs([]string{"bundle",
+		"list",
+		"files",
+		"--repo", repoName,
+		"--bundle", bid,
+	})
+	require.NoError(t, rootCmd.Execute())
+	//
+	os.Stdout = stdout
+	w.Close()
+	//
+	lb, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	ls := string(lb)
+	ll := strings.Split(strings.TrimSpace(ls), "\n")
+	//
+	m, err := regexp.MatchString(`Using config file`, ll[0])
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	//
+	lms := make([]map[string]string, 0)
+	for _, line := range ll[1:] {
+		lm :=  make(map[string]string)
+		sl := strings.Split(line, ",")
+		for _, kvstr := range sl {
+			kvslice := strings.Split(strings.TrimSpace(kvstr), ":")
+			require.Equal(t, len(kvslice), 2)
+			lm[kvslice[0]] = kvslice[1]
+		}
+		lm["_line"] = line
+		lms = append(lms, lm)
+	}
+	bfles := make([]bundleFileListEntry, 0)
+	for _, lm := range lms {
+		name, has := lm["name"]
+		require.True(t, has)
+		hash, has := lm["hash"]
+		require.True(t, has)
+		sizeStr, has := lm["size"]
+		require.True(t, has)
+		size, err := strconv.Atoi(sizeStr)
+		require.NoError(t, err)
+		bfle := bundleFileListEntry{
+			rawLine:     lm["_line"],
+			hash: hash,
+			name: name,
+			size: size,
+		}
+		bfles = append(bfles, bfle)
+	}
+	return bfles, nil
+}
+
+func testListBundleFiles(t *testing.T, files []uploadTree, bcnt int) {
+	msg := internal.RandStringBytesMaskImprSrc(15)
+	rootCmd.SetArgs([]string{"bundle",
+		"upload",
+		"--path", dirPathStr(t, files[0]),
+		"--message", msg,
+		"--repo", repo1,
+	})
+	require.NoError(t, rootCmd.Execute())
+	rll, err := listBundles(t, repo1)
+	require.NoError(t, err)
+	require.Equal(t, len(rll), bcnt)
+	//
+	bfles, err := listBundleFiles(t, repo1, rll[len(rll)-1].hash)
+	require.NoError(t, err)
+	require.Equal(t, len(bfles), len(files))
+	/* test set equality of names while setting up maps to test data by name */
+	bnsAc := make(map[string]bool)
+	bflesM := make(map[string]bundleFileListEntry)
+	for _, bfle := range bfles {
+		bnsAc[bfle.name] = true
+		bflesM[bfle.name] = bfle
+	}
+	bEx := make(map[string]bool)
+	filesM := make(map[string]uploadTree)
+	for _, file := range files {
+		bEx[pathInBundle(t, file)] = true
+		filesM[pathInBundle(t, file)] = file
+	}
+	require.Equal(t, bnsAc, bEx)
+	for name, bfle := range bflesM {
+		require.Equal(t, bfle.size, filesM[name].size)
+	}
+}
+
+func TestListBundlesFiles(t *testing.T) {
+	cleanup := setupTests(t)
+	defer cleanup()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+
+	for i, tree := range testUploadTrees {
+		testListBundleFiles(t, tree, i+1)
+	}
+}
+
+func testBundleDownloadFile(t *testing.T, file uploadTree, bid string) {
+	dpc := "file-dl"
+	dp, err := filepath.Abs(filepath.Join(consumedData, dpc))
+	destFS := afero.NewBasePathFs(afero.NewOsFs(), filepath.Join(consumedData, dpc))
+	if err != nil {
+		t.Errorf("couldn't build file path: %v", err)
+	}
+	cmd := []string{"bundle",
+		"download",
+		"file",
+		"--file", pathInBundle(t, file),
+		"--repo", repo1,
+		"--bundle", bid,
+		"--destination", dp,
+	}
+	rootCmd.SetArgs(cmd)
+	require.NoError(t, rootCmd.Execute())
+	// see iss #111 re. pathInBundle() use here and per-file cleanup below
+	exists, err := afero.Exists(destFS, pathInBundle(t, file))
+	require.NoError(t, err)
+	require.True(t, exists)
+	//
+	expected := readTextFile(t, filePathStr(t, file))
+	actual := readTextFile(t, filepath.Join(dp, pathInBundle(t, file)))
+	require.Equal(t, len(expected), len(actual))
+	require.Equal(t, expected, actual)
+	/* per-file cleanup */
+	err = destFS.RemoveAll(".datamon")
+	require.NoError(t, err)
+}
+
+func testBundleDownloadFiles(t *testing.T, files []uploadTree, bcnt int) {
+	msg := internal.RandStringBytesMaskImprSrc(15)
+	rootCmd.SetArgs([]string{"bundle",
+		"upload",
+		"--path", dirPathStr(t, files[0]),
+		"--message", msg,
+		"--repo", repo1,
+	})
+	require.NoError(t, rootCmd.Execute())
+	rll, err := listBundles(t, repo1)
+	require.NoError(t, err)
+	require.Equal(t, len(rll), bcnt)
+	//
+	for _, file := range files {
+		testBundleDownloadFile(t, file, rll[len(rll)-1].hash)
+	}
+}
+
+func TestBundlesDownloadFiles(t *testing.T) {
+	cleanup := setupTests(t)
+	defer cleanup()
+	rootCmd.SetArgs([]string{"repo",
+		"create",
+		"--description", "testing",
+		"--repo", repo1,
+		"--name", "tests",
+		"--email", "datamon@oneconcern.com",
+	})
+	require.NoError(t, rootCmd.Execute())
+	testBundleDownloadFiles(t, testUploadTrees[0], 1)
+	testBundleDownloadFiles(t, testUploadTrees[1], 2)
+	testBundleDownloadFiles(t, testUploadTrees[2], 3)
+}
+
+/** untested:
+ * - bundle_mount.go
+ * - config_generate.go
+ */
 
 func createTree() {
 	sourceFS := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), sourceData))
-	for _, file := range testUploadTree {
-		err := sourceFS.Put(context.Background(),
-			file.path,
-			bytes.NewReader(internal.RandBytesMaskImprSrc(file.size)),
-			storage.IfNotPresent)
-		if err != nil {
-			log.Fatalln(err)
+	for _, tree := range testUploadTrees {
+		for _, file := range tree {
+			err := sourceFS.Put(context.Background(),
+				file.path,
+				bytes.NewReader(internal.RandBytesMaskImprSrc(file.size)),
+				storage.IfNotPresent)
+			if err != nil {
+				log.Fatalln(err)
+			}
 		}
+	}
+}
+
+/** util */
+/* absolute uploaded (to test file contents) */
+func filePathStr(t *testing.T, file uploadTree) (path string) {
+	path, err := filepath.Abs(filepath.Join(sourceData, file.path))
+	if err != nil {
+		t.Errorf("couldn't build file path: %v", err)
+	}
+	return
+}
+
+/* absolute path to root directory (to upload bundle) */
+func dirPathStr(t *testing.T, file uploadTree) (path string) {
+	/* the strings.Split gets the root directory name.
+	 * would be cleaner to iterate on filepath.Split,
+	 * although even in this case `os.PathSeparator` appears necessary.
+	 */
+	path, err := filepath.Abs(filepath.Join(sourceData, strings.Split(file.path, string(os.PathSeparator))[1]))
+	if err != nil {
+		t.Errorf("couldn't build file path: %v", err)
+	}
+	return
+}
+
+func pathInBundle(t *testing.T, file uploadTree) string {
+	pathComp := strings.Split(file.path, string(os.PathSeparator))
+	return filepath.Join(pathComp[2:]...)
+}
+
+// dupe: cafs/reader_test.go
+// comparing large files could be faster by reading chunks and failing on the first chunk that differs
+func readTextFile(t testing.TB, pth string) string {
+	v, err := ioutil.ReadFile(pth)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	return string(v)
+}
+
+/* objects can be deleted recursively.  non-empty buckets cannot be deleted. */
+func deleteBucket(t *testing.T, ctx context.Context, client *gcsStorage.Client, bucketName string) {
+	mb := client.Bucket(bucketName)
+	oi := mb.Objects(ctx, &gcsStorage.Query{})
+	for {
+		objAttrs, err := oi.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Errorf("error iterating: %v", err)
+		}
+		obj := mb.Object(objAttrs.Name)
+		if err := obj.Delete(ctx); err != nil {
+			t.Errorf("error deleting object: %v", err)
+		}
+	}
+	if err := mb.Delete(ctx); err != nil {
+		t.Errorf("error deleting bucket %v", err)
 	}
 }

--- a/cmd/datamon/cmd/config.go
+++ b/cmd/datamon/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/spf13/cobra"
 
@@ -31,14 +30,14 @@ func (c *Config) setContributor(repoParams *RepoParams) {
 	if repoParams.ContributorEmail == "" {
 		repoParams.ContributorEmail = config.Email
 		if repoParams.ContributorEmail == "" {
-			log.Fatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
+			log_Fatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
 		}
 	}
 
 	if repoParams.ContributorName == "" {
 		repoParams.ContributorName = config.Name
 		if repoParams.ContributorName == "" {
-			log.Fatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
+			log_Fatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
 		}
 	}
 }
@@ -48,13 +47,13 @@ func (c *Config) setRepoParams(params *RepoParams) {
 	if repoParams.MetadataBucket == "" {
 		repoParams.MetadataBucket = config.Metadata
 		if repoParams.MetadataBucket == "" {
-			log.Fatalln(fmt.Errorf("metadata bucket not set in config or as a cli param"))
+			log_Fatalln(fmt.Errorf("metadata bucket not set in config or as a cli param"))
 		}
 	}
 	if repoParams.BlobBucket == "" {
 		repoParams.BlobBucket = config.Blob
 		if repoParams.BlobBucket == "" {
-			log.Fatalln(fmt.Errorf("blob bucket not set in config or as a cli param"))
+			log_Fatalln(fmt.Errorf("blob bucket not set in config or as a cli param"))
 		}
 	}
 }

--- a/cmd/datamon/cmd/config_generate.go
+++ b/cmd/datamon/cmd/config_generate.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"os/user"
 
@@ -18,7 +17,7 @@ var configGen = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		user, err := user.Current()
 		if user == nil || err != nil {
-			log.Fatalln("Could not get home directory for user")
+			log_Fatalln("Could not get home directory for user")
 		}
 		config := Config{
 			Email:      repoParams.ContributorEmail,
@@ -29,12 +28,12 @@ var configGen = &cobra.Command{
 		}
 		o, e := yaml.Marshal(config)
 		if e != nil {
-			log.Fatalln(e)
+			log_Fatalln(e)
 		}
 		_ = os.Mkdir(user.HomeDir+"/.datamon", 0700)
 		err = ioutil.WriteFile(user.HomeDir+"/.datamon/datamon.yaml", o, 0600)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	},
 }
@@ -50,7 +49,7 @@ func init() {
 	for _, flag := range requiredFlags {
 		err := configGen.MarkFlagRequired(flag)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	}
 

--- a/cmd/datamon/cmd/fschecks.go
+++ b/cmd/datamon/cmd/fschecks.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"log"
 	"os"
 )
 
@@ -11,6 +10,6 @@ import (
 func DieIfNotAccessible(path string) {
 	_, err := os.Stat(path)
 	if err != nil {
-		log.Fatalln(err)
+		log_Fatalln(err)
 	}
 }

--- a/cmd/datamon/cmd/repo_create.go
+++ b/cmd/datamon/cmd/repo_create.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"log"
 	"time"
 
 	"github.com/oneconcern/datamon/pkg/storage/gcs"
@@ -21,7 +20,7 @@ var repoCreate = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		store, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 
 		repo := model.RepoDescriptor{
@@ -35,7 +34,7 @@ var repoCreate = &cobra.Command{
 		}
 		err = core.CreateRepo(repo, store)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	},
 }
@@ -54,7 +53,7 @@ func init() {
 	for _, flag := range requiredFlags {
 		err := repoCreate.MarkFlagRequired(flag)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 	}
 

--- a/cmd/datamon/cmd/repo_list.go
+++ b/cmd/datamon/cmd/repo_list.go
@@ -15,11 +15,11 @@ var repoList = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		store, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		keys, err := core.ListRepos(store)
 		if err != nil {
-			log.Fatalln(err)
+			log_Fatalln(err)
 		}
 		for _, key := range keys {
 			log.Println(key)

--- a/cmd/datamon/cmd/root.go
+++ b/cmd/datamon/cmd/root.go
@@ -46,6 +46,10 @@ It executes pipelines by scheduling the processors as serverless functions on ei
 var config *Config
 var credFile string
 
+// used to patch over calls to os.Exit() during test
+var log_Fatalln = log.Fatalln
+var log_Fatalf = log.Fatalf
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -81,7 +85,7 @@ func initConfig() {
 	var err error
 	config, err = newConfig()
 	if err != nil {
-		log.Fatalln(err)
+		log_Fatalln(err)
 	}
 	config.setRepoParams(&repoParams)
 	if config.Credential != "" {

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/pkg/core/bundle_unpack.go
+++ b/pkg/core/bundle_unpack.go
@@ -76,7 +76,7 @@ func unpackDataFiles(ctx context.Context, bundle *Bundle, file string) error {
 			continue
 		}
 		go func(bundleEntry model.BundleEntry) {
-			fmt.Println("started " + b.NameWithPath)
+			fmt.Println("started " + bundleEntry.NameWithPath)
 			key, err := cafs.KeyFromString(bundleEntry.Hash)
 			if err != nil {
 				errC <- errorHit{


### PR DESCRIPTION
this diff takes the test stubs, most notably the `testUploadTree` data for generating fixtures, started by Ritesh in 613641b and impedance matches it to the functionality documented in the README (except for `config create`).  so in particular uploading and downloading the bundles defined by `testUploadTree` is tested.

the goal here is a smoke test at the UI layer, nothing exhaustive.

also, i've added all the reviewers from Ritesh's most recent merge request instead of only adding Ritesh as a reviewer as i had on my previous merge requests.