### PR TITLE
allow specifying buckets from config file

### DIFF
--- a/cmd/datamon/cmd/config.go
+++ b/cmd/datamon/cmd/config.go
@@ -26,34 +26,34 @@ func newConfig() (*Config, error) {
 	return &config, nil
 }
 
-func (c *Config) setContributor(repoParams *RepoParams) {
-	if repoParams.ContributorEmail == "" {
-		repoParams.ContributorEmail = config.Email
-		if repoParams.ContributorEmail == "" {
-			log_Fatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
+func (c *Config) setContributor(params *RepoParams) {
+	if params.ContributorEmail == "" {
+		params.ContributorEmail = config.Email
+		if params.ContributorEmail == "" {
+			log.Fatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
 		}
 	}
 
-	if repoParams.ContributorName == "" {
-		repoParams.ContributorName = config.Name
-		if repoParams.ContributorName == "" {
-			log_Fatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
+	if params.ContributorName == "" {
+		params.ContributorName = config.Name
+		if params.ContributorName == "" {
+			log.Fatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
 		}
 	}
 }
 
 func (c *Config) setRepoParams(params *RepoParams) {
 	c.setContributor(params)
-	if repoParams.MetadataBucket == "" {
-		repoParams.MetadataBucket = config.Metadata
-		if repoParams.MetadataBucket == "" {
-			log_Fatalln(fmt.Errorf("metadata bucket not set in config or as a cli param"))
+	if params.MetadataBucket == "" {
+		params.MetadataBucket = config.Metadata
+		if params.MetadataBucket == "" {
+			log.Fatalln(fmt.Errorf("metadata bucket not set in config or as a cli param"))
 		}
 	}
-	if repoParams.BlobBucket == "" {
-		repoParams.BlobBucket = config.Blob
-		if repoParams.BlobBucket == "" {
-			log_Fatalln(fmt.Errorf("blob bucket not set in config or as a cli param"))
+	if params.BlobBucket == "" {
+		params.BlobBucket = config.Blob
+		if params.BlobBucket == "" {
+			log.Fatalln(fmt.Errorf("blob bucket not set in config or as a cli param"))
 		}
 	}
 }

--- a/cmd/datamon/cmd/repo.go
+++ b/cmd/datamon/cmd/repo.go
@@ -37,7 +37,7 @@ func addRepoNameOptionFlag(cmd *cobra.Command) string {
 }
 
 func addBucketNameFlag(cmd *cobra.Command) string {
-	cmd.Flags().StringVar(&repoParams.MetadataBucket, meta, "datamon-meta-data", "The name of the bucket used by datamon metadata")
+	cmd.Flags().StringVar(&repoParams.MetadataBucket, meta, "", "The name of the bucket used by datamon metadata")
 	_ = cmd.Flags().MarkHidden(meta)
 	return meta
 }
@@ -48,7 +48,7 @@ func addRepoDescription(cmd *cobra.Command) string {
 }
 
 func addBlobBucket(cmd *cobra.Command) string {
-	cmd.Flags().StringVar(&repoParams.BlobBucket, blob, "datamon-blob-data", "The name of the bucket hosting the datamon blobs")
+	cmd.Flags().StringVar(&repoParams.BlobBucket, blob, "", "The name of the bucket hosting the datamon blobs")
 	_ = cmd.Flags().MarkHidden(blob)
 	return blob
 }

--- a/cmd/datamon/cmd/root.go
+++ b/cmd/datamon/cmd/root.go
@@ -67,6 +67,8 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	viper.SetDefault("metadata", "datamon-meta-data")
+	viper.SetDefault("blob", "datamon-blob-data")
 	if os.Getenv("DATAMON_CONFIG") != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(os.Getenv("DATAMON_CONFIG"))


### PR DESCRIPTION
Signed-off-by: Ransom Williams <rwilliams@oneconcern.net>

that changing bucket names in `.datamon/config.yaml` doesn't affect `repoParams` in the various `Run` functions was something that i noticed when testing the command-line interface.  here's the comment i initially made in #108 on `setRepoParams`

> because of the order that init() functions run in, `addBucketNameFlag` always gets called before
> this function, which is called via init() in root.go, and `addBucketNameFlag` sets the `MetadataBucket`
> field to a default value.
> so probably what's intended here is to also check and see if the data read from the yaml file differs from
> the default?
> regression: change the yaml file and see if the values used at runtime change.

i tried the regression with the `bundle list` command and found that changes to `config.yaml` in fact do not affect `repoParams` without this change.