### PR TITLE
Download concurrency control and skip zero size files.

### DIFF
--- a/cmd/datamon/cmd/cli_test.go
+++ b/cmd/datamon/cmd/cli_test.go
@@ -68,6 +68,10 @@ var testUploadTrees = [][]uploadTree{{
 		path: "/leafs/root",
 		size: 1,
 	},
+	{
+		path: "/leafs/zero",
+		size: 0,
+	},
 }, {
 	{
 		path: "/1/2/3/4/5/6/deep",

--- a/pkg/cafs/reader.go
+++ b/pkg/cafs/reader.go
@@ -96,7 +96,9 @@ func (r *chunkReader) WriteTo(writer io.Writer) (n int64, err error) {
 	errC := make(chan error, len(r.keys))
 	writtenC := make(chan int64, len(r.keys))
 	var wg sync.WaitGroup
-
+	if len(r.keys) == 0 {
+		return 0, nil
+	}
 	// Start a go routine for each key and give the offset to write at.
 	for index, key := range r.keys {
 		wg.Add(1)

--- a/pkg/core/fs_integration_test.go
+++ b/pkg/core/fs_integration_test.go
@@ -208,7 +208,7 @@ func TestMutableMountCommitError(t *testing.T) {
 	require.NoError(t, err)
 	/* add files to filesystem */
 	afs := afero.NewBasePathFs(afero.NewOsFs(), pathToMount)
-	for idx, _ := range testUploadTree {
+	for idx := range testUploadTree {
 		testUploadTree[idx].data = internal.RandBytesMaskImprSrc(testUploadTree[idx].size)
 	}
 	for _, uf := range testUploadTree {


### PR DESCRIPTION
For large bundles, datamon will run into ulimit limitations that will
need customers to fiddle with ulimit. Limit the numbe of concurrent
downloads.

Zero size files should be skipped to fix stuck downloads.

Signed-off-by: Ritesh H Shukla <ritesh@oneconcern.com>