### PR TITLE
init version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ YELLOW := $(shell tput -Txterm setaf 3)
 WHITE  := $(shell tput -Txterm setaf 7)
 RESET  := $(shell tput -Txterm sgr0)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+VERSION=$(shell git describe --tags)
+COMMIT=$(shell git rev-parse HEAD)
+GITDIRTY=$(shell git diff --quiet || echo 'dirty')
 LOCAL_KUBECTX ?= "docker-for-desktop"
 TARGET_MAX_CHAR_NUM=25
 ## Show help
@@ -62,7 +65,10 @@ build-datamon:
 		--pull \
 		--build-arg github_user=$(GITHUB_USER) \
 		--build-arg github_token=$(GITHUB_TOKEN) \
-		-t reg.onec.co/datamon:${GITHUB_USER}-$$(date '+%Y%m%d') \
+		--build-arg version=$(VERSION) \
+		--build-arg commit=$(COMMIT) \
+	  --build-arg dirty=$(GITDIRTY) \
+	  -t reg.onec.co/datamon:${GITHUB_USER}-$$(date '+%Y%m%d') \
 		-t reg.onec.co/datamon:$(subst /,_,$(GIT_BRANCH)) \
 		.
 

--- a/cmd/datamon/cmd/bundle_mutable_mount.go
+++ b/cmd/datamon/cmd/bundle_mutable_mount.go
@@ -23,6 +23,12 @@ var mutableMountBundleCmd = &cobra.Command{
 	Short: "Create a bundle incrementally with filesystem operations",
 	Long:  "Write directories and files to the mountpoint.  Unmount to discard or send SIGINT to this process to save.",
 	Run: func(cmd *cobra.Command, args []string) {
+		if repoParams.ContributorEmail == "" {
+			logFatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
+		}
+		if repoParams.ContributorName == "" {
+			logFatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
+		}
 
 		DieIfNotDirectory(bundleOptions.DataPath)
 

--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -22,6 +22,12 @@ var uploadBundleCmd = &cobra.Command{
 	Short: "Upload a bundle",
 	Long:  "Upload a bundle consisting of all files stored in a directory",
 	Run: func(cmd *cobra.Command, args []string) {
+		if repoParams.ContributorEmail == "" {
+			logFatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
+		}
+		if repoParams.ContributorName == "" {
+			logFatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
+		}
 
 		fmt.Println(config.Credential)
 		MetaStore, err := gcs.New(repoParams.MetadataBucket, config.Credential)

--- a/cmd/datamon/cmd/config.go
+++ b/cmd/datamon/cmd/config.go
@@ -30,16 +30,10 @@ func newConfig() (*Config, error) {
 func (c *Config) setContributor(params *RepoParams) {
 	if params.ContributorEmail == "" {
 		params.ContributorEmail = config.Email
-		if params.ContributorEmail == "" {
-			log.Fatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
-		}
 	}
 
 	if params.ContributorName == "" {
 		params.ContributorName = config.Name
-		if params.ContributorName == "" {
-			log.Fatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
-		}
 	}
 }
 

--- a/cmd/datamon/cmd/config_generate.go
+++ b/cmd/datamon/cmd/config_generate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -15,6 +16,12 @@ var configGen = &cobra.Command{
 	Short: "Create a config",
 	Long:  "Create a config to use for datamon. Config file will be placed in $HOME/.datamon/datamon.yaml",
 	Run: func(cmd *cobra.Command, args []string) {
+		if repoParams.ContributorEmail == "" {
+			logFatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
+		}
+		if repoParams.ContributorName == "" {
+			logFatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
+		}
 		user, err := user.Current()
 		if user == nil || err != nil {
 			logFatalln("Could not get home directory for user")

--- a/cmd/datamon/cmd/repo_create.go
+++ b/cmd/datamon/cmd/repo_create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/oneconcern/datamon/pkg/storage/gcs"
@@ -18,6 +19,12 @@ var repoCreate = &cobra.Command{
 	Long: "Create a repo. Repo names must not contain special characters. " +
 		"Allowed characters Unicode characters, digits and hyphen. Example: dm-test-repo-1",
 	Run: func(cmd *cobra.Command, args []string) {
+		if repoParams.ContributorEmail == "" {
+			logFatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
+		}
+		if repoParams.ContributorName == "" {
+			logFatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
+		}
 		store, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
 			logFatalln(err)

--- a/cmd/datamon/cmd/version.go
+++ b/cmd/datamon/cmd/version.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	Version   string
+	BuildDate string
+	GitCommit string
+	GitState  string
+)
+
+type VersionInfo struct {
+	Version   string `json:"version,omitempty"`
+	BuildDate string `json:"buildDate,omitempty"`
+	GitCommit string `json:"gitCommit,omitempty"`
+	GitState  string `json:"gitState,omitempty"`
+}
+
+func NewVersionInfo() VersionInfo {
+	ver := VersionInfo{
+		Version:   "dev",
+		BuildDate: BuildDate,
+		GitCommit: GitCommit,
+		GitState:  "",
+	}
+	if Version != "" {
+		ver.Version = Version
+		ver.GitState = "clean"
+	}
+	if GitState != "" {
+		ver.GitState = GitState
+	}
+	return ver
+}
+
+func (v VersionInfo) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("Version: ")
+	buf.WriteString(v.Version)
+	buf.WriteString("\n")
+	buf.WriteString("Build date: ")
+	buf.WriteString(v.BuildDate)
+	buf.WriteString("\n")
+	buf.WriteString("Commit: ")
+	buf.WriteString(v.GitCommit)
+	buf.WriteString("\n")
+	buf.WriteString("Working tree: ")
+	buf.WriteString(v.GitState)
+	buf.WriteString("\n")
+	return buf.String()
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "prints the version of this datamon",
+	Long: `Prints the version of datamon. It includes the following components:
+	* Semver (output of git describe --tags)
+	* Build Date (date at which the binary was built)
+	* Git Commit (the git commit hash this binary was built from
+	* Git State (when dirty there were uncommitted changes during the build)
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Print(NewVersionInfo().String())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
this request (at least partially) addresses the versioning requirement of #142 by adding a `version` command, as in

```
% make build-datamon
...
% docker run reg.onec.co/datamon:i142-versioncmd--wip 'version'
Version: 0.2.1-60-g26ab977
Build date: Mon, 13 May 2019 23:38:49 UTC
Commit: 26ab9777a0f6f7d382a8607fd0fd9e6f0822e3b8
```

meanwhile

```
cmd/datamon % go build
cmd/datamon % datamon version
Version: dev
Build date:
Commit:
```

that's because the `-X` [linker flag](https://golang.org/cmd/link/) is used to set some string variables at build time.

----

meanwhile, this commit also makes the contributor name and email optional for commands that don't require these parameters (or at least i'm pretty sure i've caught such commands, do check the diff).  so in particular, it's possible to check `version` without either `init` or passing contributor info to the `version` command (where it isn't particularly applicable to begin with).