### PR TITLE
fine-grain CI static analysis decisions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run:
           name: Run golang linter
           command: |
-            golangci-lint run --build-tags fuse_cli --max-same-issues 0 --verbose
+            golangci-lint run --disable golint --build-tags fuse_cli --max-same-issues 0 --verbose
   go_build:
     working_directory: ~/project
     docker:
@@ -100,7 +100,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      # - go_lint:
-      #    context: "OC Common"
+      - go_lint:
+         context: "OC Common"
       - go_build:
           context: "OC Common"

--- a/cmd/datamon/cmd/bundle_mount.go
+++ b/cmd/datamon/cmd/bundle_mount.go
@@ -72,6 +72,8 @@ func init() {
 	addBlobBucket(mountBundleCmd)
 	addBundleFlag(mountBundleCmd)
 	addLogLevel(mountBundleCmd)
+	// todo: #165 add --cpuprof to all commands via root
+	addCPUProfFlag(mountBundleCmd)
 	requiredFlags = append(requiredFlags, addDataPathFlag(mountBundleCmd))
 	requiredFlags = append(requiredFlags, addMountPathFlag(mountBundleCmd))
 

--- a/cmd/datamon/main.go
+++ b/cmd/datamon/main.go
@@ -3,27 +3,9 @@
 package main
 
 import (
-	"log"
-	"os"
-	"runtime/pprof"
-
 	"github.com/oneconcern/datamon/cmd/datamon/cmd"
 )
 
 func main() {
-	// startCpuProf()
-	// defer stopCpuProf()
 	cmd.Execute()
-}
-
-func startCPUProf() {
-	f, err := os.Create("cpu.prof")
-	if err != nil {
-		log.Fatal(err)
-	}
-	_ = pprof.StartCPUProfile(f)
-}
-
-func stopCPUProf() {
-	pprof.StopCPUProfile()
 }

--- a/pkg/core/fs_ro_ops.go
+++ b/pkg/core/fs_ro_ops.go
@@ -3,9 +3,9 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path"
-	"reflect"
 	"time"
 
 	iradix "github.com/hashicorp/go-immutable-radix"
@@ -25,49 +25,44 @@ func (fs *readOnlyFsInternal) StatFS(
 }
 
 func (fs *readOnlyFsInternal) opStart(op interface{}) {
-	opType := reflect.TypeOf(op)
-	switch op.(type) {
+	switch t := op.(type) {
 	case *fuseops.ReadFileOp:
-		r := op.(*fuseops.ReadFileOp)
 		fs.l.Info("Start",
-			zap.String("Request", opType.String()),
+			zap.String("Request", fmt.Sprintf("%T", op)),
 			zap.String("repo", fs.bundle.RepoID),
 			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(r.Inode)),
+			zap.Uint64("inode", uint64(t.Inode)),
 		)
 		return
 	case *fuseops.WriteFileOp:
-		w := op.(*fuseops.WriteFileOp)
 		fs.l.Info("Start",
-			zap.String("Request", opType.String()),
+			zap.String("Request", fmt.Sprintf("%T", op)),
 			zap.String("repo", fs.bundle.RepoID),
 			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(w.Inode)),
+			zap.Uint64("inode", uint64(t.Inode)),
 		)
 		return
 	case *fuseops.ReadDirOp:
-		r := op.(*fuseops.ReadDirOp)
 		fs.l.Info("Start",
-			zap.String("Request", opType.String()),
+			zap.String("Request", fmt.Sprintf("%T", op)),
 			zap.String("repo", fs.bundle.RepoID),
 			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(r.Inode)),
+			zap.Uint64("inode", uint64(t.Inode)),
 		)
 		return
 	}
 	fs.l.Info("Start",
-		zap.String("Request", opType.String()),
+		zap.String("Request", fmt.Sprintf("%T", op)),
 		zap.String("repo", fs.bundle.RepoID),
 		zap.String("bundle", fs.bundle.BundleID),
 		zap.Any("op", op),
 	)
 }
 func (fs *readOnlyFsInternal) opEnd(op interface{}, err error) {
-	opType := reflect.TypeOf(op)
 	switch t := op.(type) {
 	case *fuseops.ReadFileOp:
 		fs.l.Info("End",
-			zap.String("Request", opType.String()),
+			zap.String("Request", fmt.Sprintf("%T", op)),
 			zap.String("repo", fs.bundle.RepoID),
 			zap.String("bundle", fs.bundle.BundleID),
 			zap.Uint64("inode", uint64(t.Inode)),
@@ -76,7 +71,7 @@ func (fs *readOnlyFsInternal) opEnd(op interface{}, err error) {
 		return
 	case *fuseops.WriteFileOp:
 		fs.l.Info("End",
-			zap.String("Request", opType.String()),
+			zap.String("Request", fmt.Sprintf("%T", op)),
 			zap.String("repo", fs.bundle.RepoID),
 			zap.String("bundle", fs.bundle.BundleID),
 			zap.Uint64("inode", uint64(t.Inode)),
@@ -85,7 +80,7 @@ func (fs *readOnlyFsInternal) opEnd(op interface{}, err error) {
 		return
 	case *fuseops.ReadDirOp:
 		fs.l.Info("End",
-			zap.String("Request", opType.String()),
+			zap.String("Request", fmt.Sprintf("%T", op)),
 			zap.String("repo", fs.bundle.RepoID),
 			zap.String("bundle", fs.bundle.BundleID),
 			zap.Uint64("inode", uint64(t.Inode)),
@@ -94,7 +89,7 @@ func (fs *readOnlyFsInternal) opEnd(op interface{}, err error) {
 		return
 	}
 	fs.l.Info("End",
-		zap.String("Request", reflect.TypeOf(op).String()),
+		zap.String("Request", fmt.Sprintf("%T", op)),
 		zap.String("repo", fs.bundle.RepoID),
 		zap.String("bundle", fs.bundle.BundleID),
 		zap.Any("op", op),


### PR DESCRIPTION
after #137 , `golangci-lint` was disabled in `.circleci/config.yml`.  this re-enables [`golangci-lint`](https://github.com/golangci/golangci-lint), the "linters aggregator" -- i.e. a program that runs a variety of static analysis programs -- with [`golint`](https://github.com/golang/lint#purpose) disabled since it

> is not, and will never be, trustworthy enough for its suggestions to be enforced automatically, for example as part of a build process