### PR TITLE
Limit the concurrency during uploads.

### DIFF
--- a/pkg/cafs/cafs.go
+++ b/pkg/cafs/cafs.go
@@ -148,8 +148,8 @@ func (d *defaultFs) writer(prefix string) Writer {
 		pather:        nil,
 		prefix:        prefix,
 		count:         0,
-		flushChan:     make(chan blobFlush, 100000),
-		errC:          make(chan error, 1000000),
+		flushChan:     make(chan blobFlush, sizeOfFlushChan),
+		errC:          make(chan error, sizeOfFlushChan),
 		maxGoRoutines: make(chan struct{}, maxGoRoutinesPerPut),
 		wg:            sync.WaitGroup{},
 	}


### PR DESCRIPTION
For large file counts or large files, the concurrency needs to be
reduced to keep memory usage in check which is critical for k8s
deployment.

Signed-off-by: Ritesh H Shukla <ritesh@oneconcern.com>