### PR TITLE
bundle Upload api tuning

### DIFF
--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -68,10 +68,8 @@ var uploadBundleCmd = &cobra.Command{
 			core.SkipMissing(bundleOptions.SkipOnError),
 		)
 
-		var fn func() ([]string, error)
-
 		if bundleOptions.FileList != "" {
-			fn = func() ([]string, error) {
+			getKeys := func() ([]string, error) {
 				var file afero.File
 				file, err = os.Open(bundleOptions.FileList)
 				if err != nil {
@@ -84,9 +82,10 @@ var uploadBundleCmd = &cobra.Command{
 				}
 				return files, nil
 			}
+			err = core.UploadSpecificKeys(context.Background(), bundle, getKeys)
+		} else {
+			err = core.Upload(context.Background(), bundle)
 		}
-
-		err = core.Upload(context.Background(), bundle, fn)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/pkg/core/bundle.go
+++ b/pkg/core/bundle.go
@@ -198,7 +198,12 @@ func PublishMetadata(ctx context.Context, bundle *Bundle) error {
 }
 
 // Upload an bundle to archive
-func Upload(ctx context.Context, bundle *Bundle, getKeys func() ([]string, error)) error {
+func Upload(ctx context.Context, bundle *Bundle) error {
+	return implUpload(ctx, bundle, defaultBundleEntriesPerFile, nil)
+}
+
+// Upload specified keys (files) within a bundle's consumable store
+func UploadSpecificKeys(ctx context.Context, bundle *Bundle, getKeys func() ([]string, error)) error {
 	return implUpload(ctx, bundle, defaultBundleEntriesPerFile, getKeys)
 }
 


### PR DESCRIPTION
this is a quick code-design proposal:  the suggestion is to keep the `Upload(context.Context, core.Bundle)` sig as-is, then add additional `Upload*` funcs around `implUpload` as additional parameters are needed.