### PR TITLE
'list' commands cleanup

### DIFF
--- a/cmd/datamon/cmd/bundle_list.go
+++ b/cmd/datamon/cmd/bundle_list.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"log"
+	"text/template"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/storage/gcs"
@@ -14,16 +16,23 @@ var BundleListCommand = &cobra.Command{
 	Short: "List bundles",
 	Long:  "List the bundles in a repo",
 	Run: func(cmd *cobra.Command, args []string) {
+		const listLineTemplateString = `{{.ID}} , {{.Timestamp}} , {{.Message}}`
+		listLineTemplate := template.Must(template.New("list line").Parse(listLineTemplateString))
 		store, err := gcs.New(repoParams.MetadataBucket, config.Credential)
 		if err != nil {
 			logFatalln(err)
 		}
-		keys, err := core.ListBundles(repoParams.RepoName, store)
+		bundleDescriptors, err := core.ListBundles(repoParams.RepoName, store)
 		if err != nil {
 			logFatalln(err)
 		}
-		for _, key := range keys {
-			log.Println(key)
+		for _, bd := range bundleDescriptors {
+			var buf bytes.Buffer
+			err := listLineTemplate.Execute(&buf, bd)
+			if err != nil {
+				log.Println("executing template:", err)
+			}
+			log.Println(buf.String())
 		}
 	},
 }

--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -178,7 +178,6 @@ func uploadBundle(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint
 				firstUploadBundleEntryIndex = uint(len(fileList))
 			}
 		case e := <-eC:
-			count--
 			fmt.Printf("Bundle upload failed. Failed to upload file %s err: %s", e.file, e.error)
 			return e.error
 		}

--- a/pkg/core/label.go
+++ b/pkg/core/label.go
@@ -14,7 +14,6 @@ import (
 )
 
 type Label struct {
-	Name       string
 	Descriptor model.LabelDescriptor
 }
 
@@ -38,8 +37,8 @@ func NewLabelDescriptor(descriptorOps ...LabelDescriptorOption) *model.LabelDesc
 }
 
 func LabelName(name string) LabelOption {
-	return func(b *Label) {
-		b.Name = name
+	return func(l *Label) {
+		l.Descriptor.Name = name
 	}
 }
 
@@ -70,12 +69,12 @@ func (label *Label) UploadDescriptor(ctx context.Context, bundle *Bundle) error 
 	if ok {
 		crc := crc32.Checksum(buffer, crc32.MakeTable(crc32.Castagnoli))
 		err = lsCRC.PutCRC(ctx,
-			model.GetArchivePathToLabel(bundle.RepoID, label.Name),
+			model.GetArchivePathToLabel(bundle.RepoID, label.Descriptor.Name),
 			bytes.NewReader(buffer), storage.OverWrite, crc)
 
 	} else {
 		err = bundle.MetaStore.Put(ctx,
-			model.GetArchivePathToLabel(bundle.RepoID, label.Name),
+			model.GetArchivePathToLabel(bundle.RepoID, label.Descriptor.Name),
 			bytes.NewReader(buffer), storage.OverWrite)
 	}
 	if err != nil {
@@ -91,7 +90,7 @@ func (label *Label) DownloadDescriptor(ctx context.Context, bundle *Bundle, chec
 			return e
 		}
 	}
-	rdr, err := bundle.MetaStore.Get(context.Background(), model.GetArchivePathToLabel(bundle.RepoID, label.Name))
+	rdr, err := bundle.MetaStore.Get(context.Background(), model.GetArchivePathToLabel(bundle.RepoID, label.Descriptor.Name))
 	if err != nil {
 		return err
 	}

--- a/pkg/model/label.go
+++ b/pkg/model/label.go
@@ -6,6 +6,7 @@ import (
 )
 
 type LabelDescriptor struct {
+	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
 	BundleID     string        `json:"id" yaml:"id"`
 	Timestamp    time.Time     `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
 	Contributors []Contributor `json:"contributors" yaml:"contributors"`


### PR DESCRIPTION
mentioned in #153 , this is (at least the start of) a quick cleanup of some todos:

several commands are used to display metadata.  this is a cleanup to make the implementation incrementally more maintainable:  the `core/` api returns types rather than strings (this was part of the original todo), and the `datamon/cmd/` implementation uses `text/template` to format the strings (this is my bright idea 😒 ).