### PR TITLE
CI lint test

### DIFF
--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -178,7 +178,6 @@ func uploadBundle(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint
 				firstUploadBundleEntryIndex = uint(len(fileList))
 			}
 		case e := <-eC:
-			count--
 			fmt.Printf("Bundle upload failed. Failed to upload file %s err: %s", e.file, e.error)
 			return e.error
 		}


### PR DESCRIPTION
the CI lint test started to flag this sometime since the last merge:

the `count--` isn't used b/c of the `return`.