### PR TITLE
Reduce concurrency on bundle download path.

### DIFF
--- a/pkg/core/bundle_unpack.go
+++ b/pkg/core/bundle_unpack.go
@@ -56,7 +56,7 @@ type errorHit struct {
 	file  string
 }
 
-const maxConcurrentDownloads = 100
+const maxConcurrentDownloads = 10
 
 func unpackDataFiles(ctx context.Context, bundle *Bundle, file string) error {
 	ls := bundle.BundleDescriptor.LeafSize


### PR DESCRIPTION
The bundle download currently can be more aggressive than what the
system can handle.

Signed-off-by: Ritesh H Shukla <ritesh@oneconcern.com>