### PR TITLE
lru bug fix

### DIFF
--- a/pkg/cafs/reader.go
+++ b/pkg/cafs/reader.go
@@ -222,9 +222,7 @@ func (r *chunkReader) ReadAt(p []byte, off int64) (n int, err error) {
 		// Fetch Blob
 		var buffer []byte
 		key := r.keys[index]
-		if r.lru.Contains(key.StringWithPrefix(r.prefix)) {
-
-			b, _ := r.lru.Get(key.StringWithPrefix(r.prefix))
+		if b, ok := r.lru.Get(key.StringWithPrefix(r.prefix)); ok {
 			buffer = b.([]byte)
 			seekAhead()
 		} else {


### PR DESCRIPTION
this debugs a [lru cache](https://github.com/hashicorp/golang-lru) usage wherein `Contains` and `Get`, while each is thread-safe individually, are not mutually thread safe in that cache eviction can occur between a `Contains` and `Get`. [here](https://github.com/hashicorp/golang-lru/blob/master/simplelru/lru.go#L73) are the reference implementations of each.