### PR TITLE
configurable concurrency/memory bounds

### DIFF
--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -66,6 +66,7 @@ var uploadBundleCmd = &cobra.Command{
 			core.ConsumableStore(sourceStore),
 			core.MetaStore(MetaStore),
 			core.SkipMissing(params.bundle.SkipOnError),
+			core.ConcurrentFileUploads(params.bundle.ConcurrentFileUploads),
 		)
 
 		if params.bundle.FileList != "" {
@@ -114,6 +115,7 @@ func init() {
 	addFileListFlag(uploadBundleCmd)
 	addLabelNameFlag(uploadBundleCmd)
 	addSkipMissingFlag(uploadBundleCmd)
+	addConcurrentFileUploadsFlag(uploadBundleCmd)
 	for _, flag := range requiredFlags {
 		err := uploadBundleCmd.MarkFlagRequired(flag)
 		if err != nil {

--- a/cmd/datamon/cmd/cli_test.go
+++ b/cmd/datamon/cmd/cli_test.go
@@ -320,6 +320,7 @@ func testUploadBundle(t *testing.T, file uploadTree) {
 		"--path", dirPathStr(t, file),
 		"--message", "The initial commit for the repo",
 		"--repo", repo1,
+		"--num-file-uploads", "20",
 	}, "upload bundle at "+dirPathStr(t, file), false)
 	//
 	log.SetOutput(os.Stdout)
@@ -365,6 +366,7 @@ func TestUploadBundle_filePath(t *testing.T) {
 		"--path", filePathStr(t, file),
 		"--message", "The initial commit for the repo",
 		"--repo", repo1,
+		"--num-file-uploads", "20",
 	}, "observe error on bundle upload path as file rather than directory", true)
 }
 
@@ -381,6 +383,7 @@ func testUploadBundleLabel(t *testing.T, file uploadTree, label string) {
 		"--message", "The initial commit for the repo",
 		"--repo", repo1,
 		"--label", label,
+		"--num-file-uploads", "20",
 	}, "upload bundle at "+dirPathStr(t, file), false)
 	//
 	log.SetOutput(os.Stdout)
@@ -458,6 +461,7 @@ func testListBundle(t *testing.T, file uploadTree, bcnt int) {
 		"--path", dirPathStr(t, file),
 		"--message", msg,
 		"--repo", repo1,
+		"--num-file-uploads", "20",
 	}, "upload bundle at "+dirPathStr(t, file), false)
 	ll, err := listBundles(t, repo2)
 	require.NoError(t, err, "error out of listBundles() test helper")
@@ -565,6 +569,7 @@ func TestListLabels(t *testing.T) {
 		"--message", "label test bundle",
 		"--repo", repo1,
 		"--label", label,
+		"--num-file-uploads", "20",
 	}, "upload bundle at "+dirPathStr(t, file), false)
 	ll = listLabels(t, repo2)
 	require.Equal(t, 0, len(ll), "no labels in secondary repo")
@@ -599,6 +604,7 @@ func TestSetLabel(t *testing.T) {
 		"--path", dirPathStr(t, file),
 		"--message", msg,
 		"--repo", repo1,
+		"--num-file-uploads", "20",
 	}, "upload bundle at "+dirPathStr(t, file), false)
 	ll = listLabels(t, repo1)
 	require.Equal(t, len(ll), 0, "no labels created yet")
@@ -631,6 +637,7 @@ func testDownloadBundle(t *testing.T, files []uploadTree, bcnt int) {
 		"--path", dirPathStr(t, files[0]),
 		"--message", msg,
 		"--repo", repo1,
+		"--num-file-uploads", "20",
 	}, "upload bundle at "+dirPathStr(t, files[0]), false)
 
 	ll, err := listBundles(t, repo1)
@@ -698,6 +705,7 @@ func TestDownloadBundleByLabel(t *testing.T) {
 		"--message", "label test bundle",
 		"--repo", repo1,
 		"--label", label,
+		"--num-file-uploads", "20",
 	}, "upload bundle at "+dirPathStr(t, file), false)
 	// dupe: testDownloadBundle()
 	destFS := afero.NewBasePathFs(afero.NewOsFs(), consumedData)
@@ -794,6 +802,7 @@ func testListBundleFiles(t *testing.T, files []uploadTree, bcnt int) {
 		"--path", dirPathStr(t, files[0]),
 		"--message", msg,
 		"--repo", repo1,
+		"--num-file-uploads", "20",
 	}, "create second test repo", false)
 
 	rll, err := listBundles(t, repo1)
@@ -873,6 +882,7 @@ func testBundleDownloadFiles(t *testing.T, files []uploadTree, bcnt int) {
 		"--path", dirPathStr(t, files[0]),
 		"--message", msg,
 		"--repo", repo1,
+		"--num-file-uploads", "20",
 	}, "upload bundle in order to test downloading individual files", false)
 	rll, err := listBundles(t, repo1)
 	require.NoError(t, err, "error out of listBundles() test helper")

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -8,16 +8,17 @@ import (
 
 type paramsT struct {
 	bundle struct {
-		ID               string
-		DataPath         string
-		Message          string
-		ContributorEmail string
-		MountPath        string
-		File             string
-		Daemonize        bool
-		Stream           bool
-		FileList         string
-		SkipOnError      bool
+		ID                    string
+		DataPath              string
+		Message               string
+		ContributorEmail      string
+		MountPath             string
+		File                  string
+		Daemonize             bool
+		Stream                bool
+		FileList              string
+		SkipOnError           bool
+		ConcurrentFileUploads int
 	}
 	web struct {
 		port int
@@ -105,6 +106,14 @@ func addSkipMissingFlag(cmd *cobra.Command) string {
 	cmd.Flags().BoolVar(&params.bundle.SkipOnError, skipOnError, false, "Skip files encounter errors while reading."+
 		"The list of files is either generated or passed in. During upload files can be deleted or encounter an error. Setting this flag will skip those files. Default to false")
 	return skipOnError
+}
+
+func addConcurrentFileUploadsFlag(cmd *cobra.Command) string {
+	concurrentFileUploads := "num-file-uploads"
+	cmd.Flags().IntVar(&params.bundle.ConcurrentFileUploads, concurrentFileUploads, 20,
+		"Number of files to upload at a time.  "+
+			"If uploads consume too much memory, turn this value down.")
+	return concurrentFileUploads
 }
 
 func addWebPortFlag(cmd *cobra.Command) string {

--- a/pkg/cafs/writer.go
+++ b/pkg/cafs/writer.go
@@ -13,10 +13,6 @@ import (
 	"github.com/minio/blake2b-simd"
 )
 
-const (
-	maxGoRoutinesPerPut = 10
-)
-
 // Writer interface for a content addressable FS
 type Writer interface {
 	io.WriteCloser

--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	defaultBundleEntriesPerFile = 1000
+	fileUploadsPerFlush         = 4
 )
 
 type filePacked struct {
@@ -93,6 +94,7 @@ func uploadBundle(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint
 	cafsArchive, err := cafs.New(
 		cafs.LeafSize(bundle.BundleDescriptor.LeafSize),
 		cafs.Backend(bundle.BlobStore),
+		cafs.ConcurrentFlushes(bundle.concurrentFileUploads/fileUploadsPerFlush),
 	)
 	if err != nil {
 		return err
@@ -108,7 +110,7 @@ func uploadBundle(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint
 
 	fC := make(chan filePacked, len(files))
 	eC := make(chan errorHit, len(files))
-	cC := make(chan struct{}, 20)
+	cC := make(chan struct{}, bundle.concurrentFileUploads)
 	var count int64
 	for _, file := range files {
 		// Check to see if the file is to be skipped.


### PR DESCRIPTION
towards #171 , this request is about making the number of goroutines (hence the amount of memory used by the program) during upload configurable at runtime rather than statically parameterized.