### PR TITLE
dedupe cmd Run funcs (stores)

### DIFF
--- a/cmd/datamon/cmd/bundle_list.go
+++ b/cmd/datamon/cmd/bundle_list.go
@@ -6,7 +6,6 @@ import (
 	"text/template"
 
 	"github.com/oneconcern/datamon/pkg/core"
-	"github.com/oneconcern/datamon/pkg/storage/gcs"
 
 	"github.com/spf13/cobra"
 )
@@ -18,11 +17,11 @@ var BundleListCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		const listLineTemplateString = `{{.ID}} , {{.Timestamp}} , {{.Message}}`
 		listLineTemplate := template.Must(template.New("list line").Parse(listLineTemplateString))
-		store, err := gcs.New(params.repo.MetadataBucket, config.Credential)
+		remoteStores, err := paramsToRemoteCmdStores(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		bundleDescriptors, err := core.ListBundles(params.repo.RepoName, store)
+		bundleDescriptors, err := core.ListBundles(params.repo.RepoName, remoteStores.meta)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/bundle_list_file.go
+++ b/cmd/datamon/cmd/bundle_list_file.go
@@ -7,7 +7,6 @@ import (
 	"github.com/oneconcern/datamon/pkg/core"
 
 	"github.com/oneconcern/datamon/pkg/model"
-	"github.com/oneconcern/datamon/pkg/storage/gcs"
 	"github.com/spf13/cobra"
 )
 
@@ -16,19 +15,18 @@ var bundleFileList = &cobra.Command{
 	Short: "List files in a bundle",
 	Long:  "List all the files in a bundle",
 	Run: func(cmd *cobra.Command, args []string) {
-
-		store, err := gcs.New(params.repo.MetadataBucket, config.Credential)
+		remoteStores, err := paramsToRemoteCmdStores(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		err = setLatestOrLabelledBundle(store)
+		err = setLatestOrLabelledBundle(remoteStores.meta)
 		if err != nil {
 			logFatalln(err)
 		}
 		bundle := core.Bundle{
 			RepoID:           params.repo.RepoName,
 			BundleID:         params.bundle.ID,
-			MetaStore:        store,
+			MetaStore:        remoteStores.meta,
 			ConsumableStore:  nil,
 			BlobStore:        nil,
 			BundleDescriptor: model.BundleDescriptor{},

--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -5,15 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
-
-	"github.com/oneconcern/datamon/pkg/storage"
-
-	"github.com/oneconcern/datamon/pkg/model"
 
 	"github.com/oneconcern/datamon/pkg/core"
-	"github.com/oneconcern/datamon/pkg/storage/gcs"
-	"github.com/oneconcern/datamon/pkg/storage/localfs"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -28,47 +21,27 @@ var uploadBundleCmd = &cobra.Command{
 	Short: "Upload a bundle",
 	Long:  "Upload a bundle consisting of all files stored in a directory",
 	Run: func(cmd *cobra.Command, args []string) {
-		if params.repo.ContributorEmail == "" {
-			logFatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
-		}
-		if params.repo.ContributorName == "" {
-			logFatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
-		}
-
-		fmt.Println(config.Credential)
-		MetaStore, err := gcs.New(params.repo.MetadataBucket, config.Credential)
+		contributor, err := paramsToContributor(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		blobStore, err := gcs.New(params.repo.BlobBucket, config.Credential)
+		remoteStores, err := paramsToRemoteCmdStores(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		var sourceStore storage.Store
-		if strings.HasPrefix(params.bundle.DataPath, "gs://") {
-			fmt.Println(params.bundle.DataPath[4:])
-			sourceStore, err = gcs.New(params.bundle.DataPath[5:], config.Credential)
-			if err != nil {
-				logFatalln(err)
-			}
-		} else {
-			DieIfNotAccessible(params.bundle.DataPath)
-			DieIfNotDirectory(params.bundle.DataPath)
-			sourceStore = localfs.New(afero.NewBasePathFs(afero.NewOsFs(), params.bundle.DataPath))
+		sourceStore, err := paramsToSrcStore(params, false)
+		if err != nil {
+			logFatalln(err)
 		}
-		contributors := []model.Contributor{{
-			Name:  params.repo.ContributorName,
-			Email: params.repo.ContributorEmail,
-		}}
 		bd := core.NewBDescriptor(
 			core.Message(params.bundle.Message),
-			core.Contributors(contributors),
+			core.Contributor(contributor),
 		)
 		bundle := core.New(bd,
 			core.Repo(params.repo.RepoName),
-			core.BlobStore(blobStore),
+			core.BlobStore(remoteStores.blob),
 			core.ConsumableStore(sourceStore),
-			core.MetaStore(MetaStore),
+			core.MetaStore(remoteStores.meta),
 			core.SkipMissing(params.bundle.SkipOnError),
 			core.ConcurrentFileUploads(params.bundle.ConcurrencyFactor/fileUploadsByConcurrencyFactor),
 		)
@@ -99,7 +72,7 @@ var uploadBundleCmd = &cobra.Command{
 			return
 		}
 		labelDescriptor := core.NewLabelDescriptor(
-			core.LabelContributors(contributors),
+			core.LabelContributor(contributor),
 		)
 		label := core.NewLabel(labelDescriptor,
 			core.LabelName(params.label.Name),

--- a/cmd/datamon/cmd/config_generate.go
+++ b/cmd/datamon/cmd/config_generate.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -17,11 +16,9 @@ var configGen = &cobra.Command{
 	Short: "Create a config",
 	Long:  "Create a config to use for datamon. Config file will be placed in $HOME/.datamon/datamon.yaml",
 	Run: func(cmd *cobra.Command, args []string) {
-		if params.repo.ContributorEmail == "" {
-			logFatalln(fmt.Errorf("contributor email must be set in config or as a cli param"))
-		}
-		if params.repo.ContributorName == "" {
-			logFatalln(fmt.Errorf("contributor name must be set in config or as a cli param"))
+		_, err := paramsToContributor(params)
+		if err != nil {
+			logFatalln(err)
 		}
 		user, err := user.Current()
 		if user == nil || err != nil {

--- a/cmd/datamon/cmd/fsops.go
+++ b/cmd/datamon/cmd/fsops.go
@@ -17,6 +17,7 @@ func DieIfNotAccessible(path string) {
 }
 
 func createPath(path string) {
+	// todo: determine proper permission bits.  previously 0700.
 	err := os.MkdirAll(path, 0777)
 	fmt.Println(err)
 }

--- a/cmd/datamon/cmd/label_list.go
+++ b/cmd/datamon/cmd/label_list.go
@@ -6,7 +6,6 @@ import (
 	"text/template"
 
 	"github.com/oneconcern/datamon/pkg/core"
-	"github.com/oneconcern/datamon/pkg/storage/gcs"
 
 	"github.com/spf13/cobra"
 )
@@ -18,11 +17,11 @@ var LabelListCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		const listLineTemplateString = `{{.Name}} , {{.BundleID}} , {{.Timestamp}}`
 		listLineTemplate := template.Must(template.New("list line").Parse(listLineTemplateString))
-		metaStore, err := gcs.New(params.repo.MetadataBucket, config.Credential)
+		remoteStores, err := paramsToRemoteCmdStores(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		labelDescriptors, err := core.ListLabels(params.repo.RepoName, metaStore)
+		labelDescriptors, err := core.ListLabels(params.repo.RepoName, remoteStores.meta)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/repo_list.go
+++ b/cmd/datamon/cmd/repo_list.go
@@ -6,7 +6,6 @@ import (
 	"text/template"
 
 	"github.com/oneconcern/datamon/pkg/core"
-	"github.com/oneconcern/datamon/pkg/storage/gcs"
 	"github.com/spf13/cobra"
 )
 
@@ -17,11 +16,11 @@ var repoList = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		const listLineTemplateString = `{{.Name}} , {{.Description}} , {{with .Contributor}}{{.Name}} , {{.Email}}{{end}} , {{.Timestamp}}`
 		listLineTemplate := template.Must(template.New("list line").Parse(listLineTemplateString))
-		store, err := gcs.New(params.repo.MetadataBucket, config.Credential)
+		remoteStores, err := paramsToRemoteCmdStores(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		repos, err := core.ListRepos(store)
+		repos, err := core.ListRepos(remoteStores.meta)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/web.go
+++ b/cmd/datamon/cmd/web.go
@@ -19,6 +19,7 @@ var webSrv = &cobra.Command{
 	Long:  "A webserver process to browse Datamon data",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("begin webserver")
+		// todo: pass storage.Store
 		s, err := web.NewServer(web.ServerParams{
 			MetadataBucket: params.repo.MetadataBucket,
 			Credential:     config.Credential,

--- a/pkg/core/bundle.go
+++ b/pkg/core/bundle.go
@@ -74,6 +74,10 @@ func Contributors(c []model.Contributor) BundleDescriptorOption {
 	}
 }
 
+func Contributor(c model.Contributor) BundleDescriptorOption {
+	return Contributors([]model.Contributor{c})
+}
+
 func Parents(p []string) BundleDescriptorOption {
 	return func(b *model.BundleDescriptor) {
 		b.Parents = p

--- a/pkg/core/label.go
+++ b/pkg/core/label.go
@@ -26,6 +26,10 @@ func LabelContributors(c []model.Contributor) LabelDescriptorOption {
 	}
 }
 
+func LabelContributor(c model.Contributor) LabelDescriptorOption {
+	return LabelContributors([]model.Contributor{c})
+}
+
 func NewLabelDescriptor(descriptorOps ...LabelDescriptorOption) *model.LabelDescriptor {
 	ld := model.LabelDescriptor{
 		Timestamp: time.Now(),


### PR DESCRIPTION
nominally toward #165 , this diff deduplicates creation of objects based on parameters in the `Run:` functions of the various `cobra.Command` structs in the `cmd`/CLI package.

this harmonization might in particular have implications for implementing IPC as discussed in [this comment](https://github.com/oneconcern/datamon/issues/214#issuecomment-506448369) on #214 , the `bundle update` iss.