### PR TITLE
parallelize bundle file list download

### DIFF
--- a/cmd/datamon/cmd/bundle_download.go
+++ b/cmd/datamon/cmd/bundle_download.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	fileDownloadsByConcurrencyFactor = 10
+	fileDownloadsByConcurrencyFactor     = 10
+	filelistDownloadsByConcurrencyFactor = 10
 )
 
 var BundleDownloadCmd = &cobra.Command{
@@ -40,6 +41,8 @@ var BundleDownloadCmd = &cobra.Command{
 			core.BlobStore(remoteStores.blob),
 			core.BundleID(params.bundle.ID),
 			core.ConcurrentFileDownloads(params.bundle.ConcurrencyFactor/fileDownloadsByConcurrencyFactor),
+			core.ConcurrentFilelistDownloads(
+				params.bundle.ConcurrencyFactor/filelistDownloadsByConcurrencyFactor),
 		)
 
 		err = core.Publish(context.Background(), bundle)

--- a/cmd/datamon/cmd/bundle_mount.go
+++ b/cmd/datamon/cmd/bundle_mount.go
@@ -110,6 +110,8 @@ var mountBundleCmd = &cobra.Command{
 			core.ConsumableStore(consumableStore),
 			core.MetaStore(remoteStores.meta),
 			core.Streaming(params.bundle.Stream),
+			core.ConcurrentFilelistDownloads(
+				params.bundle.ConcurrencyFactor/filelistDownloadsByConcurrencyFactor),
 		)
 		logger, err := dlogger.GetLogger(params.root.logLevel)
 		if err != nil {
@@ -143,6 +145,7 @@ func init() {
 	addLogLevel(mountBundleCmd)
 	addStreamFlag(mountBundleCmd)
 	addLabelNameFlag(mountBundleCmd)
+	addConcurrencyFactorFlag(mountBundleCmd)
 	// todo: #165 add --cpuprof to all commands via root
 	addCPUProfFlag(mountBundleCmd)
 	addDataPathFlag(mountBundleCmd)


### PR DESCRIPTION
part of [3] on #226 , originally started as part of #227 , this diff parallelizes the download of filelists, the bulk of a bundle's metadata.  so although it's not strictly part of parallelizing `populateFS` as mentioned in [3], it's within the spirit of what that item is about:  decreasing the time from starting `bundle mount` to the FUSE mount occurring.

it will also speed up `bundle download`  somewhat as well as (wip at time of creating merge request) `bundle update`.