### PR TITLE
gcs store use cleanups

### DIFF
--- a/cmd/backup2blobs/cmd/blob2file.go
+++ b/cmd/backup2blobs/cmd/blob2file.go
@@ -129,13 +129,13 @@ var download = &cobra.Command{
 		// Create CAFS based on the blob store
 		localStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), b2fParams.destination))
 
-		backupStore, err := gcs.New(b2fParams.backendStoreBucket, "")
+		backupStore, err := gcs.New(context.TODO(), b2fParams.backendStoreBucket, "")
 
 		if err != nil {
 			log.Fatalln(err)
 		}
 
-		cafsStore, err := gcs.New(b2fParams.blobStoreBucket, "")
+		cafsStore, err := gcs.New(context.TODO(), b2fParams.blobStoreBucket, "")
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/backup2blobs/cmd/file2blobs.go
+++ b/cmd/backup2blobs/cmd/file2blobs.go
@@ -157,11 +157,11 @@ var upload = &cobra.Command{
 	Long:  `Tool to bulk import files into CAFS with a record of the files in the backing store.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		localStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), params.pathToMount))
-		backupStore, err := gcs.New(params.backendStoreBucket, "")
+		backupStore, err := gcs.New(context.TODO(), params.backendStoreBucket, "")
 		if err != nil {
 			log.Fatalln(err)
 		}
-		cafsStore, err := gcs.New(params.blobStoreBucket, "")
+		cafsStore, err := gcs.New(context.TODO(), params.blobStoreBucket, "")
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/csi/cmd/root.go
+++ b/cmd/csi/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -48,11 +49,11 @@ var rootCmd = &cobra.Command{
 			Logger:        logger,
 			LocalFS:       csiOpts.localFS,
 		}
-		metadataStore, err := gcs.New(csiOpts.metadataBucket, csiOpts.credentialFile)
+		metadataStore, err := gcs.New(context.TODO(), csiOpts.metadataBucket, csiOpts.credentialFile)
 		if err != nil {
 			log.Fatalln(err)
 		}
-		blobStore, err := gcs.New(csiOpts.blobBucket, csiOpts.credentialFile)
+		blobStore, err := gcs.New(context.TODO(), csiOpts.blobBucket, csiOpts.credentialFile)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/cmd/datamon/cmd/bundle.go
+++ b/cmd/datamon/cmd/bundle.go
@@ -28,7 +28,7 @@ func init() {
 	addBlobBucket(bundleCmd)
 }
 
-func setLatestOrLabelledBundle(store storage.Store) error {
+func setLatestOrLabelledBundle(ctx context.Context, store storage.Store) error {
 	switch {
 	case params.bundle.ID != "" && params.label.Name != "":
 		return fmt.Errorf("--" + addBundleFlag(nil) + " and --" + addLabelNameFlag(nil) + " flags are mutually exclusive")
@@ -46,7 +46,7 @@ func setLatestOrLabelledBundle(store storage.Store) error {
 			core.Repo(params.repo.RepoName),
 			core.MetaStore(store),
 		)
-		if err := label.DownloadDescriptor(context.Background(), bundle, true); err != nil {
+		if err := label.DownloadDescriptor(ctx, bundle, true); err != nil {
 			return err
 		}
 		params.bundle.ID = label.Descriptor.BundleID

--- a/cmd/datamon/cmd/bundle_download.go
+++ b/cmd/datamon/cmd/bundle_download.go
@@ -20,7 +20,8 @@ var BundleDownloadCmd = &cobra.Command{
 	Long: "Download a readonly, non-interactive view of the entire data that is part of a bundle. If --bundle is not specified" +
 		" the latest bundle will be downloaded",
 	Run: func(cmd *cobra.Command, args []string) {
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		ctx := context.Background()
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -29,7 +30,7 @@ var BundleDownloadCmd = &cobra.Command{
 			logFatalln(err)
 		}
 
-		err = setLatestOrLabelledBundle(remoteStores.meta)
+		err = setLatestOrLabelledBundle(ctx, remoteStores.meta)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -45,7 +46,7 @@ var BundleDownloadCmd = &cobra.Command{
 				params.bundle.ConcurrencyFactor/filelistDownloadsByConcurrencyFactor),
 		)
 
-		err = core.Publish(context.Background(), bundle)
+		err = core.Publish(ctx, bundle)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/bundle_download_file.go
+++ b/cmd/datamon/cmd/bundle_download_file.go
@@ -12,7 +12,8 @@ var bundleDownloadFileCmd = &cobra.Command{
 	Short: "Download a file from bundle",
 	Long:  "Download a readonly, non-interactive view of a single file from a bundle",
 	Run: func(cmd *cobra.Command, args []string) {
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		ctx := context.Background()
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -21,7 +22,7 @@ var bundleDownloadFileCmd = &cobra.Command{
 			logFatalln(err)
 		}
 
-		err = setLatestOrLabelledBundle(remoteStores.meta)
+		err = setLatestOrLabelledBundle(ctx, remoteStores.meta)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -34,7 +35,7 @@ var bundleDownloadFileCmd = &cobra.Command{
 			core.BundleID(params.bundle.ID),
 		)
 
-		err = core.PublishFile(context.Background(), bundle, params.bundle.File)
+		err = core.PublishFile(ctx, bundle, params.bundle.File)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/bundle_list.go
+++ b/cmd/datamon/cmd/bundle_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"text/template"
 
@@ -16,8 +17,9 @@ var BundleListCommand = &cobra.Command{
 	Long:  "List the bundles in a repo",
 	Run: func(cmd *cobra.Command, args []string) {
 		const listLineTemplateString = `{{.ID}} , {{.Timestamp}} , {{.Message}}`
+		ctx := context.Background()
 		listLineTemplate := template.Must(template.New("list line").Parse(listLineTemplateString))
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/bundle_list_file.go
+++ b/cmd/datamon/cmd/bundle_list_file.go
@@ -15,11 +15,12 @@ var bundleFileList = &cobra.Command{
 	Short: "List files in a bundle",
 	Long:  "List all the files in a bundle",
 	Run: func(cmd *cobra.Command, args []string) {
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		ctx := context.Background()
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}
-		err = setLatestOrLabelledBundle(remoteStores.meta)
+		err = setLatestOrLabelledBundle(ctx, remoteStores.meta)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -32,7 +33,7 @@ var bundleFileList = &cobra.Command{
 			BundleDescriptor: model.BundleDescriptor{},
 			BundleEntries:    nil,
 		}
-		err = core.PopulateFiles(context.Background(), &bundle)
+		err = core.PopulateFiles(ctx, &bundle)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/bundle_mount.go
+++ b/cmd/datamon/cmd/bundle_mount.go
@@ -84,12 +84,13 @@ var mountBundleCmd = &cobra.Command{
 	Short: "Mount a bundle",
 	Long:  "Mount a readonly, non-interactive view of the entire data that is part of a bundle",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
 		// cf. comments on runDaemonized
 		if params.bundle.Daemonize {
 			runDaemonized()
 			return
 		}
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			onDaemonError(err)
 		}
@@ -98,7 +99,7 @@ var mountBundleCmd = &cobra.Command{
 			onDaemonError(err)
 		}
 
-		err = setLatestOrLabelledBundle(remoteStores.meta)
+		err = setLatestOrLabelledBundle(ctx, remoteStores.meta)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -129,7 +130,7 @@ var mountBundleCmd = &cobra.Command{
 		if err = daemonizer.SignalOutcome(nil); err != nil {
 			logFatalln(err)
 		}
-		if err = fs.JoinMount(context.Background()); err != nil {
+		if err = fs.JoinMount(ctx); err != nil {
 			logFatalln(err)
 		}
 	},

--- a/cmd/datamon/cmd/bundle_mutable_mount.go
+++ b/cmd/datamon/cmd/bundle_mutable_mount.go
@@ -18,6 +18,7 @@ var mutableMountBundleCmd = &cobra.Command{
 	Short: "Create a bundle incrementally with filesystem operations",
 	Long:  "Write directories and files to the mountpoint.  Unmount or send SIGINT to this process to save.",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
 		contributor, err := paramsToContributor(params)
 		if err != nil {
 			logFatalln(err)
@@ -27,11 +28,11 @@ var mutableMountBundleCmd = &cobra.Command{
 			runDaemonized()
 			return
 		}
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			onDaemonError(err)
 		}
-		consumableStore, err := paramsToSrcStore(params, true)
+		consumableStore, err := paramsToSrcStore(ctx, params, true)
 		if err != nil {
 			onDaemonError(err)
 		}
@@ -58,7 +59,7 @@ var mutableMountBundleCmd = &cobra.Command{
 		if err = daemonizer.SignalOutcome(nil); err != nil {
 			logFatalln(err)
 		}
-		if err = fs.JoinMount(context.Background()); err != nil {
+		if err = fs.JoinMount(ctx); err != nil {
 			logFatalln(err)
 		}
 		if err = fs.Commit(); err != nil {

--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -21,15 +21,16 @@ var uploadBundleCmd = &cobra.Command{
 	Short: "Upload a bundle",
 	Long:  "Upload a bundle consisting of all files stored in a directory",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
 		contributor, err := paramsToContributor(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}
-		sourceStore, err := paramsToSrcStore(params, false)
+		sourceStore, err := paramsToSrcStore(ctx, params, false)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -60,9 +61,9 @@ var uploadBundleCmd = &cobra.Command{
 				}
 				return files, nil
 			}
-			err = core.UploadSpecificKeys(context.Background(), bundle, getKeys)
+			err = core.UploadSpecificKeys(ctx, bundle, getKeys)
 		} else {
-			err = core.Upload(context.Background(), bundle)
+			err = core.Upload(ctx, bundle)
 		}
 		if err != nil {
 			logFatalln(err)
@@ -77,7 +78,7 @@ var uploadBundleCmd = &cobra.Command{
 		label := core.NewLabel(labelDescriptor,
 			core.LabelName(params.label.Name),
 		)
-		err = label.UploadDescriptor(context.Background(), bundle)
+		err = label.UploadDescriptor(ctx, bundle)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/cli_test.go
+++ b/cmd/datamon/cmd/cli_test.go
@@ -149,7 +149,7 @@ func setupTests(t *testing.T) func() {
 	bucketMeta := "datamontestmeta-" + btag
 	bucketBlob := "datamontestblob-" + btag
 
-	client, err := gcsStorage.NewClient(context.TODO(), option.WithScopes(gcsStorage.ScopeFullControl))
+	client, err := gcsStorage.NewClient(ctx, option.WithScopes(gcsStorage.ScopeFullControl))
 	require.NoError(t, err, "couldn't create bucket client")
 	err = client.Bucket(bucketMeta).Create(ctx, "onec-co", nil)
 	require.NoError(t, err, "couldn't create metadata bucket")

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -198,15 +199,15 @@ type cmdStoresRemote struct {
 	blob storage.Store
 }
 
-func paramsToRemoteCmdStores(params paramsT) (cmdStoresRemote, error) {
+func paramsToRemoteCmdStores(ctx context.Context, params paramsT) (cmdStoresRemote, error) {
 	stores := cmdStoresRemote{}
-	meta, err := gcs.New(params.repo.MetadataBucket, config.Credential)
+	meta, err := gcs.New(ctx, params.repo.MetadataBucket, config.Credential)
 	if err != nil {
 		return cmdStoresRemote{}, err
 	}
 	stores.meta = meta
 	if params.repo.BlobBucket != "" {
-		blob, err := gcs.New(params.repo.BlobBucket, config.Credential)
+		blob, err := gcs.New(ctx, params.repo.BlobBucket, config.Credential)
 		if err != nil {
 			return cmdStoresRemote{}, err
 		}
@@ -215,7 +216,7 @@ func paramsToRemoteCmdStores(params paramsT) (cmdStoresRemote, error) {
 	return stores, nil
 }
 
-func paramsToSrcStore(params paramsT, create bool) (storage.Store, error) {
+func paramsToSrcStore(ctx context.Context, params paramsT, create bool) (storage.Store, error) {
 	var err error
 	var consumableStorePath string
 
@@ -242,7 +243,7 @@ func paramsToSrcStore(params paramsT, create bool) (storage.Store, error) {
 	var sourceStore storage.Store
 	if strings.HasPrefix(consumableStorePath, "gs://") {
 		fmt.Println(consumableStorePath[4:])
-		sourceStore, err = gcs.New(consumableStorePath[5:], config.Credential)
+		sourceStore, err = gcs.New(ctx, consumableStorePath[5:], config.Credential)
 		if err != nil {
 			return sourceStore, err
 		}

--- a/cmd/datamon/cmd/label_get.go
+++ b/cmd/datamon/cmd/label_get.go
@@ -20,7 +20,8 @@ var GetLabelCommand = &cobra.Command{
 Prints corresponding bundle information if the label exists,
 exits with ENOENT status otherwise.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		ctx := context.Background()
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -31,7 +32,7 @@ exits with ENOENT status otherwise.`,
 		label := core.NewLabel(core.NewLabelDescriptor(),
 			core.LabelName(params.label.Name),
 		)
-		err = label.DownloadDescriptor(context.Background(), bundle, true)
+		err = label.DownloadDescriptor(ctx, bundle, true)
 		if err == core.ErrNotFound {
 			fmt.Fprintf(os.Stderr, "didn't find label '%v'\n", params.label.Name)
 			osExit(int(unix.ENOENT))

--- a/cmd/datamon/cmd/label_list.go
+++ b/cmd/datamon/cmd/label_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"log"
 
 	"github.com/oneconcern/datamon/pkg/core"
@@ -14,7 +15,8 @@ var LabelListCommand = &cobra.Command{
 	Short: "List labels",
 	Long:  "List the labels in a repo",
 	Run: func(cmd *cobra.Command, args []string) {
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		ctx := context.Background()
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/label_set.go
+++ b/cmd/datamon/cmd/label_set.go
@@ -13,11 +13,12 @@ var SetLabelCommand = &cobra.Command{
 	Short: "Set labels",
 	Long:  "Set the label corresponding to a bundle",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
 		contributor, err := paramsToContributor(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -26,7 +27,7 @@ var SetLabelCommand = &cobra.Command{
 			core.MetaStore(remoteStores.meta),
 			core.BundleID(params.bundle.ID),
 		)
-		bundleExists, err := bundle.Exists(context.Background())
+		bundleExists, err := bundle.Exists(ctx)
 		if err != nil {
 			logFatalln(err)
 		}
@@ -39,7 +40,7 @@ var SetLabelCommand = &cobra.Command{
 		label := core.NewLabel(labelDescriptor,
 			core.LabelName(params.label.Name),
 		)
-		err = label.UploadDescriptor(context.Background(), bundle)
+		err = label.UploadDescriptor(ctx, bundle)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/repo_create.go
+++ b/cmd/datamon/cmd/repo_create.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
@@ -16,11 +17,12 @@ var repoCreate = &cobra.Command{
 	Long: "Create a repo. Repo names must not contain special characters. " +
 		"Allowed characters Unicode characters, digits and hyphen. Example: dm-test-repo-1",
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
 		contributor, err := paramsToContributor(params)
 		if err != nil {
 			logFatalln(err)
 		}
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/datamon/cmd/repo_list.go
+++ b/cmd/datamon/cmd/repo_list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"text/template"
 
@@ -15,8 +16,9 @@ var repoList = &cobra.Command{
 	Long:  "List repos that have been created",
 	Run: func(cmd *cobra.Command, args []string) {
 		const listLineTemplateString = `{{.Name}} , {{.Description}} , {{with .Contributor}}{{.Name}} , {{.Email}}{{end}} , {{.Timestamp}}`
+		ctx := context.Background()
 		listLineTemplate := template.Must(template.New("list line").Parse(listLineTemplateString))
-		remoteStores, err := paramsToRemoteCmdStores(params)
+		remoteStores, err := paramsToRemoteCmdStores(ctx, params)
 		if err != nil {
 			logFatalln(err)
 		}

--- a/cmd/metrics/cmd/upload.go
+++ b/cmd/metrics/cmd/upload.go
@@ -87,11 +87,11 @@ var uploadCmd = &cobra.Command{
 		}
 		defer deleteBuckets()
 
-		metaStore, err := gcs.New(gcsParams.MetadataBucket, gcsParams.Credential)
+		metaStore, err := gcs.New(context.TODO(), gcsParams.MetadataBucket, gcsParams.Credential)
 		if err != nil {
 			log.Fatalln(err)
 		}
-		blobStore, err := gcs.New(gcsParams.BlobBucket, gcsParams.Credential)
+		blobStore, err := gcs.New(context.TODO(), gcsParams.BlobBucket, gcsParams.Credential)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/pkg/storage/gcs/store_test.go
+++ b/pkg/storage/gcs/store_test.go
@@ -38,7 +38,7 @@ func setup(t testing.TB) (storage.Store, func()) {
 	err = client.Bucket(bucket).Create(ctx, "onec-co", nil)
 	require.NoError(t, err)
 
-	gcs, err := New(bucket, "") // Use GOOGLE_APPLICATION_CREDENTIALS env variable
+	gcs, err := New(context.TODO(), bucket, "") // Use GOOGLE_APPLICATION_CREDENTIALS env variable
 	require.NoError(t, err)
 
 	err = gcs.Put(ctx, testObject1, bytes.NewBufferString(testObject1Content), storage.IfNotPresent)

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -112,7 +112,7 @@ type Server struct {
 
 func (s *Server) metadataStore() storage.Store {
 	var err error
-	store, err := gcs.New(s.params.MetadataBucket, s.params.Credential)
+	store, err := gcs.New(context.TODO(), s.params.MetadataBucket, s.params.Credential)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
this diff is started according to the suggestion in #223 , where a very specific change was made to debug the `storage/gcs` package.

overall, it there's some cleanup that can be done throughout `storage/gcs` .. and possibly wherever `cloud.google.com/go/storage` is used.  exact scope tbd, although there's certainly more to this "one idea per commit" than the suggested change in #233 :  `context.TODO()` calls, for instance, are suggestive that the functions in `storage/gcs` can be parameterized.