### PR TITLE
ensure metrics build in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,10 @@ jobs:
           command: |
             golangci-lint run --disable golint --build-tags fuse_cli --max-same-issues 0 --verbose
             shellcheck hack/fuse-demo/wrap_*.sh
+      - run:
+          name: Ensure metrics
+          command: |
+            go build -o datamon.metrics ./cmd/metrics
   go_build:
     working_directory: ~/project
     docker:


### PR DESCRIPTION
quick housekeeping to ensure the metrics binary build remains coherent.

it's grouped with lint because the linter ought already catch any errors that the build would throw, yet just in case and for clarity it's included as a separate item here.