### PR TITLE
test filelist upload

### DIFF
--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/oneconcern/datamon/pkg/core"
@@ -69,19 +70,19 @@ var uploadBundleCmd = &cobra.Command{
 			logFatalln(err)
 		}
 
-		if params.label.Name == "" {
-			return
+		if params.label.Name != "" {
+			labelDescriptor := core.NewLabelDescriptor(
+				core.LabelContributor(contributor),
+			)
+			label := core.NewLabel(labelDescriptor,
+				core.LabelName(params.label.Name),
+			)
+			err = label.UploadDescriptor(ctx, bundle)
+			if err != nil {
+				logFatalln(err)
+			}
 		}
-		labelDescriptor := core.NewLabelDescriptor(
-			core.LabelContributor(contributor),
-		)
-		label := core.NewLabel(labelDescriptor,
-			core.LabelName(params.label.Name),
-		)
-		err = label.UploadDescriptor(ctx, bundle)
-		if err != nil {
-			logFatalln(err)
-		}
+		log.Printf("Uploaded bundle id:%s ", bundle.BundleID)
 	},
 }
 

--- a/cmd/metrics/cmd/flags.go
+++ b/cmd/metrics/cmd/flags.go
@@ -12,48 +12,61 @@ type paramsT struct {
 		memProfPath string
 	}
 	upload struct {
-		max       int
+		max       float64
 		numFiles  int
 		numChunks int
 		fileType  string
+		mockDest  bool
 	}
 }
 
 var params paramsT = paramsT{}
 
 func addCpuProfPath(cmd *cobra.Command) string {
-	const cpuprof = "cpuprof"
-	cmd.Flags().StringVar(&params.root.cpuProfPath, cpuprof, "cpu.prof", "The path to output the pprof cpu information.")
-	return cpuprof
+	const flagName = "cpuprof"
+	cmd.Flags().StringVar(&params.root.cpuProfPath, flagName, "cpu.prof",
+		"The path to output the pprof cpu information.")
+	return flagName
 }
 
 func addMemProfPath(cmd *cobra.Command) string {
-	const memprof = "memprof"
-	cmd.Flags().StringVar(&params.root.memProfPath, memprof, "mem.prof", "The path to output the pprof mem information.")
-	return memprof
+	const flagName = "memprof"
+	cmd.Flags().StringVar(&params.root.memProfPath, flagName, "mem.prof",
+		"The path to output the pprof mem information.")
+	return flagName
 }
 
 func addUploadFilesize(cmd *cobra.Command) string {
-	const filesize = "filesize"
-	cmd.Flags().IntVar(&params.upload.max, filesize, 16, "File size (approx MiB) to upload")
-	return filesize
+	const flagName = "filesize"
+	cmd.Flags().Float64Var(&params.upload.max, flagName, 16,
+		"File size (approx MiB) to upload")
+	return flagName
 }
 
 func addUploadNumFiles(cmd *cobra.Command) string {
-	const numFiles = "num-files"
-	cmd.Flags().IntVar(&params.upload.numFiles, numFiles, 40, "Number of files to upload")
-	return numFiles
+	const flagName = "num-files"
+	cmd.Flags().IntVar(&params.upload.numFiles, flagName, 40,
+		"Number of files to upload")
+	return flagName
 }
 
 func addUploadNumChunks(cmd *cobra.Command) string {
-	const numChunks = "num-chunks"
-	cmd.Flags().IntVar(&params.upload.numChunks, numChunks, 40, "Number of chunks to upload in case of chunked file")
-	return numChunks
+	const flagName = "num-chunks"
+	cmd.Flags().IntVar(&params.upload.numChunks, flagName, 40,
+		"Number of chunks to upload in case of chunked file")
+	return flagName
 }
 
 func addUploadFileType(cmd *cobra.Command) string {
-	const fileType = "file-type"
-	cmd.Flags().StringVar(&params.upload.fileType, fileType, "stripe",
+	const flagName = "file-type"
+	cmd.Flags().StringVar(&params.upload.fileType, flagName, "stripe",
 		"type of file to upload among 'chunks', 'stripe', 'rand'")
-	return fileType
+	return flagName
+}
+
+func addUploadMockDest(cmd *cobra.Command) string {
+	const flagName = "mock-dest"
+	cmd.Flags().BoolVar(&params.upload.mockDest, flagName, true,
+		"whether to use GCS or a mock/stub/spy storage.Store")
+	return flagName
 }

--- a/cmd/metrics/cmd/mock_dest_store.go
+++ b/cmd/metrics/cmd/mock_dest_store.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/oneconcern/datamon/pkg/storage"
+
+	"go.uber.org/zap"
+)
+
+type mockDestStore struct {
+	name                 string
+	l                    *zap.Logger
+	fileListUploadPutCnt int
+}
+
+func (mds *mockDestStore) String() string {
+	return "mock destination store"
+}
+
+func (mds *mockDestStore) Has(ctx context.Context, key string) (bool, error) {
+	// detect and respond to RepoExists() call
+	if strings.HasPrefix(key, "repos/") && strings.HasSuffix(key, "/repo.json") {
+		return true, nil
+	}
+	return false, errors.New("mock destination store Has() unimpl (other than for RepoExists calls)")
+}
+
+func (mds *mockDestStore) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	return nil, errors.New("mock destination store Get() unimpl")
+}
+
+func (mds *mockDestStore) GetAt(ctx context.Context, key string) (io.ReaderAt, error) {
+	return nil, errors.New("mock destination store GetAt() unimpl")
+}
+
+var fileListRe *regexp.Regexp
+
+func init() {
+	fileListRe = regexp.MustCompile(`bundle-files-\d+.json$`)
+}
+
+func (mds *mockDestStore) Put(ctx context.Context, key string, source io.Reader, exclusive bool) error {
+	// strings.HasPrefix(key, "bundles/") &&
+	isFilelist := fileListRe.MatchString(key)
+	if isFilelist {
+		mds.fileListUploadPutCnt++
+		fmt.Println("mock dest store Put got filelist")
+	}
+	mds.l.Info("mock destination store Put()",
+		zap.String("key", key),
+		zap.Bool("isFilelist", isFilelist),
+		zap.String("store name", mds.name),
+		zap.Int("fileListUploadPutCnt", mds.fileListUploadPutCnt),
+	)
+	return nil
+}
+
+func (mds *mockDestStore) Delete(ctx context.Context, key string) error {
+	return errors.New("mock destination store Delete() unimpl")
+}
+
+func (mds *mockDestStore) Keys(ctx context.Context) ([]string, error) {
+	return nil, errors.New("mock destination store Keys() unimpl")
+}
+
+func (mds *mockDestStore) KeysPrefix(ctx context.Context, token, prefix, delimiter string, count int) ([]string, string, error) {
+	return nil, "", errors.New("mock destination store KeysPrefix() unimpl")
+}
+
+func (mds *mockDestStore) Clear(ctx context.Context) error {
+	return errors.New("mock destination store Clear() unimpl")
+}
+
+func newMockDestStore(name string, l *zap.Logger) storage.Store {
+	return &mockDestStore{
+		name: name,
+		l:    l,
+	}
+}

--- a/cmd/metrics/cmd/root.go
+++ b/cmd/metrics/cmd/root.go
@@ -62,8 +62,7 @@ func Execute() {
 func init() {
 	var err error
 	log.SetFlags(0)
-	logLevel := "info"
-	logger, err = dlogger.GetLogger(logLevel)
+	logger, err = dlogger.GetLogger(dlogger.LogLevelDebug)
 	if err != nil {
 		log.Fatalln("Failed to set log level:" + err.Error())
 	}

--- a/pkg/dlogger/logger.go
+++ b/pkg/dlogger/logger.go
@@ -5,6 +5,11 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+const (
+	LogLevelInfo  = "info"
+	LogLevelDebug = "debug"
+)
+
 func GetLogger(logLevel string) (*zap.Logger, error) {
 	zapConfig := zap.NewProductionConfig()
 	var lvl zapcore.Level


### PR DESCRIPTION
this diff uses a mock destination (blob and metadata) `storage.Store` in `cmd/metrics` in order to debug #239 .

additionally, several debug-level logging statements are added to the bundle upload implementation.