### PR TITLE
init datamover image and demo yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,25 @@ build-and-push-fuse-sidecar:
 		.
 	docker push gcr.io/onec-co/datamon-fuse-sidecar
 
+
+.PHONY: build-and-push-datamover
+## build sidecar container used in Argo workflows
+build-and-push-datamover:
+	@echo 'building fuse sidecar container'
+	docker build \
+		--progress plain \
+		--build-arg version_import_path=$(VERSION_INFO_IMPORT_PATH) \
+		--build-arg version=$(VERSION) \
+		--build-arg commit=$(COMMIT) \
+		--build-arg dirty=$(GITDIRTY) \
+		-t gcr.io/onec-co/datamon-datamover \
+		-t gcr.io/onec-co/datamon-datamover:${GITHUB_USER}-$$(date '+%Y%m%d') \
+		-t gcr.io/onec-co/datamon-datamover:$(subst /,_,$(GIT_BRANCH)) \
+		--ssh default \
+		-f datamover.Dockerfile \
+		.
+	docker push gcr.io/onec-co/datamon-datamover
+
 .PHONY: build-datamon
 ## Build datamon docker container (datamon)
 build-datamon:

--- a/README.md
+++ b/README.md
@@ -223,6 +223,37 @@ chmod +x datamon
 It's probably most convenient to have the wrapper script placed somewhere on your
 shell's path, of course.
 
+
+# Datamover container guide
+
+As with the [Kubernetes sidecar guide](#kubernetes-sidecar-guide), this section covers
+a particular operationalization of Datamon at One Concern wherein we use the program
+along with some auxilliary programs, all parameterized via a shell script and shipped
+in a Docker image, in order to periodically backup a shared block store and remove
+files according to their modify time.
+
+The docker image is called `gcr.io/onec-co/datamon-datamover` and is tagged with
+versions just as the Kubernetes sidecar, `v<release_number>`, where `v0.7` is the first
+tag that will apply to the Datamover.
+
+The shell wrapper script is to be included in Kubernetes YAML with `command: ["datamover"]`
+and used with the following parameters
+
+* `-d` backup directory.  required.
+* `-l` bundle label.  defaults to `datamover-<timestamp>`
+* `-t` timestamp filter before.  a timestamp string in system local time among several formats, including
+  - `<Year>-<Month>-<Day>` as in `2006-Jan-02`
+  - `<Year><Month><Day><Hour><Minute>` as in `0601021504`
+  - `<Year><Month><Day><Hour><Minute><second>` as in `060102150405`
+  defaults to `090725000000`
+* `-f` filelist directory.  defaults to `/tmp` and is the location to write
+  - `upload.list`, the files that datamon will attempt to upload as part of the backup
+  - `uploaded.list`, the files that have been successfully uploaded as part of the backup
+  - `removable.list`, the files that have been successfully uploaded and that have a modify time before the specified timestamp filter
+* `-c` concurrency factor.  defaults to 200.  tune this down in case of the NFS being hammered by too many reads during backup.
+* `-u` unlink, a boolean toggle.  whether to unlink the files in `removeable.list` as part of the `datamover` script.  defaults to off/false/not present.
+
+
 # Feature requests and bugs
 
 Please file GitHub issues for features desired in addition to any bugs encountered.

--- a/cmd/backup2blobs/cmd/actOnFilelist.go
+++ b/cmd/backup2blobs/cmd/actOnFilelist.go
@@ -1,0 +1,356 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/spf13/cobra"
+)
+
+type filelistFile struct {
+	filename string
+	file     *os.File
+}
+
+func (f filelistFile) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("filename", f.filename)
+	return nil
+}
+
+type filelistFilter func(f filelistFile) (bool, error)
+
+func filterNone() filelistFilter {
+	return func(f filelistFile) (bool, error) {
+		return true, nil
+	}
+}
+
+func filterModify(time time.Time, after bool) filelistFilter {
+	return func(f filelistFile) (bool, error) {
+		fileInfo, err := f.file.Stat()
+		if err != nil {
+			return false, err
+		}
+		modTime := fileInfo.ModTime()
+		if after {
+			return modTime.After(time), nil
+		} else {
+			return modTime.Before(time), nil
+		}
+	}
+}
+
+type filelistAction func(f filelistFile) error
+
+func composeFilelistActions(actA filelistAction, actB filelistAction) filelistAction {
+	return func(f filelistFile) error {
+		if err := actA(f); err != nil {
+			return err
+		}
+		if err := actB(f); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func actLog() filelistAction {
+	return func(f filelistFile) error {
+		logger.Info("taking action on file",
+			zap.Object("filelistFile", f),
+		)
+		return nil
+	}
+}
+
+func actList(out io.StringWriter) filelistAction {
+	return func(f filelistFile) error {
+		_, err := out.WriteString(f.filename + "\n")
+		return err
+	}
+}
+
+func actUnlink() filelistAction {
+	return func(f filelistFile) error {
+		return os.Remove(f.filename)
+	}
+}
+
+type filelistActionRes struct {
+	err          error
+	filtered     bool
+	filelistFile filelistFile
+}
+
+func (res filelistActionRes) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if res.err != nil {
+		enc.AddString("err", res.err.Error())
+	}
+	enc.AddBool("filtered", res.filtered)
+	if err := enc.AddObject("filelistFile", res.filelistFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+type filelistActionChansT struct {
+	filename     chan string
+	allEnts      chan filelistFile
+	filteredEnts chan filelistFile
+	res          chan filelistActionRes
+}
+
+func buildFilelistEntrySync(filename string) (filelistFile, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return filelistFile{
+			filename: filename,
+		}, err
+	}
+	return filelistFile{
+		filename: filename,
+		file:     file,
+	}, nil
+}
+
+func buildFilelistEntries(filelistActionChans filelistActionChansT) {
+	var filename string
+	for {
+		filename = <-filelistActionChans.filename
+		ent, err := buildFilelistEntrySync(filename)
+		if err != nil {
+			filelistActionChans.res <- filelistActionRes{
+				err:          err,
+				filelistFile: ent,
+			}
+			continue
+		}
+		filelistActionChans.allEnts <- ent
+	}
+}
+
+func filterFilelistEntries(filelistActionChans filelistActionChansT, filter filelistFilter) {
+	var ent filelistFile
+	for {
+		ent = <-filelistActionChans.allEnts
+		ok, err := filter(ent)
+		if err != nil {
+			filelistActionChans.res <- filelistActionRes{
+				err:          err,
+				filelistFile: ent,
+			}
+			continue
+		}
+		if !ok {
+			filelistActionChans.res <- filelistActionRes{
+				filtered:     true,
+				filelistFile: ent,
+			}
+			continue
+		}
+		filelistActionChans.filteredEnts <- ent
+	}
+}
+
+func actOnFilelistEntries(filelistActionChans filelistActionChansT, action filelistAction) {
+	var ent filelistFile
+	for {
+		ent = <-filelistActionChans.filteredEnts
+		err := action(ent)
+		if err != nil {
+			filelistActionChans.res <- filelistActionRes{
+				err:          err,
+				filelistFile: ent,
+			}
+			continue
+		}
+		filelistActionChans.res <- filelistActionRes{
+			filelistFile: ent,
+		}
+	}
+}
+
+const (
+	parallelismPerBuildFilelistWorkers  = 20
+	parallelismPerFilterFilelistWorkers = 20
+	parallelismPerActOnWorkers          = 20
+)
+
+func actOnFilelist(inputFile *os.File, action filelistAction, filter filelistFilter) error {
+
+	var wgIndiv sync.WaitGroup
+	var wgAllInit sync.WaitGroup
+
+	scanner := bufio.NewScanner(inputFile)
+
+	filelistActionChans := filelistActionChansT{
+		filename:     make(chan string),
+		allEnts:      make(chan filelistFile),
+		filteredEnts: make(chan filelistFile),
+		res:          make(chan filelistActionRes),
+	}
+
+	buildFilelistWorkers := unlinkParams.parallelism / parallelismPerBuildFilelistWorkers
+	filterFilelistWorkers := unlinkParams.parallelism / parallelismPerFilterFilelistWorkers
+	actOnWorkers := unlinkParams.parallelism / parallelismPerActOnWorkers
+
+	for i := 0; i < buildFilelistWorkers; i++ {
+		go buildFilelistEntries(filelistActionChans)
+	}
+	for i := 0; i < filterFilelistWorkers; i++ {
+		go filterFilelistEntries(filelistActionChans, filter)
+	}
+	for i := 0; i < actOnWorkers; i++ {
+		go actOnFilelistEntries(filelistActionChans, action)
+	}
+
+	logger.Info("started worker threads",
+		zap.Int("buildFilelist", buildFilelistWorkers),
+		zap.Int("filterFilelist", filterFilelistWorkers),
+		zap.Int("actOn", actOnWorkers),
+	)
+
+	wgAllInit.Add(1)
+	go func() {
+		for scanner.Scan() {
+			filelistActionChans.filename <- scanner.Text()
+			wgIndiv.Add(1)
+		}
+		wgAllInit.Done()
+	}()
+
+	var err error
+	var errCnt int
+	var filteredCnt int
+	var actionCnt int
+
+	go func() {
+		var res filelistActionRes
+		for {
+			res = <-filelistActionChans.res
+			logger.Info("got result",
+				zap.Object("res", res),
+			)
+			switch {
+			case res.err != nil:
+				err = res.err
+				errCnt++
+			case res.filtered:
+				filteredCnt++
+			default:
+				actionCnt++
+			}
+			wgIndiv.Done()
+		}
+	}()
+
+	wgAllInit.Wait()
+	wgIndiv.Wait()
+
+	return err
+}
+
+func parseTime(timeStr string) (time.Time, error) {
+	var t time.Time
+	var err error
+
+	// parse based on reference time
+	// Mon Jan 2 15:04:05 -0700 MST 2006
+	validFormats := []string{
+		"2006-Jan-02",
+		"0601021504",
+		"060102150405",
+	}
+
+	for _, format := range validFormats {
+		t, err = time.Parse(format, timeStr)
+		if err == nil {
+			return time.Date(t.Year(), t.Month(), t.Day(),
+				t.Hour(), t.Minute(), t.Second(), t.Nanosecond(),
+				time.Local), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("time string didn't match any valid format")
+}
+
+var actOnFilelistCmd = &cobra.Command{
+	Use:   "filelist-actions",
+	Short: "perform various operations on a list of files",
+	Long:  "perform various operations on a list of files",
+	Run: func(cmd *cobra.Command, args []string) {
+		var action filelistAction
+		var filter filelistFilter
+		var inputFile *os.File
+
+		action = actLog()
+
+		if unlinkParams.unlink {
+			action = composeFilelistActions(action, actUnlink())
+		}
+
+		if unlinkParams.out != "" {
+			var outputFile *os.File
+			if unlinkParams.out == "-" {
+				outputFile = os.Stdout
+			} else {
+				var err error
+				outputFile, err = os.Create(unlinkParams.out)
+				if err != nil {
+					log.Fatalf("failed to open output file '%v': '%v'", unlinkParams.out, err)
+				}
+			}
+			action = composeFilelistActions(action, actList(outputFile))
+		}
+
+		if unlinkParams.timeBefore == "" {
+			filter = filterNone()
+		} else {
+			t, err := parseTime(unlinkParams.timeBefore)
+			if err != nil {
+				log.Fatalf("failed to parse --time-before: %v", err)
+			}
+			filter = filterModify(t, false)
+		}
+
+		if unlinkParams.filelist == "" || unlinkParams.filelist == "-" {
+			inputFile = os.Stdin
+		} else {
+			var err error
+			inputFile, err = os.Open(unlinkParams.filelist)
+			if err != nil {
+				log.Fatalf("failed to open input file '%v': '%v'", unlinkParams.filelist, err)
+			}
+		}
+
+		if err := actOnFilelist(inputFile, action, filter); err != nil {
+			log.Fatalf("failed to act on filelist: '%v'", err)
+		}
+	},
+}
+
+var unlinkParams struct {
+	filelist    string
+	out         string
+	timeBefore  string
+	unlink      bool
+	parallelism int
+}
+
+func init() {
+	flags := actOnFilelistCmd.Flags()
+	flags.StringVarP(&unlinkParams.filelist, "filelist", "", "", "List of input files")
+	flags.StringVarP(&unlinkParams.out, "out", "", "", "Output list of files")
+	flags.StringVarP(&unlinkParams.timeBefore, "time-before", "", "", "Filter modify times before.")
+	flags.BoolVarP(&unlinkParams.unlink, "unlink", "", false, "Whether to unlink files.")
+	flags.IntVarP(&unlinkParams.parallelism, "parallelism", "", 100, "Amount of parallelism.")
+
+	rootCmd.AddCommand(actOnFilelistCmd)
+}

--- a/cmd/backup2blobs/cmd/actOnFilelist.go
+++ b/cmd/backup2blobs/cmd/actOnFilelist.go
@@ -221,8 +221,8 @@ func actOnFilelist(inputFile *os.File, action filelistAction, filter filelistFil
 	wgAllInit.Add(1)
 	go func() {
 		for scanner.Scan() {
-			filelistActionChans.filename <- scanner.Text()
 			wgIndiv.Add(1)
+			filelistActionChans.filename <- scanner.Text()
 		}
 		wgAllInit.Done()
 	}()

--- a/cmd/datamon/cmd/bundle_mount.go
+++ b/cmd/datamon/cmd/bundle_mount.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 
 	daemonizer "github.com/jacobsa/daemonize"
@@ -116,7 +115,7 @@ var mountBundleCmd = &cobra.Command{
 		)
 		logger, err := dlogger.GetLogger(params.root.logLevel)
 		if err != nil {
-			log.Fatalln("Failed to set log level:" + err.Error())
+			logFatalln("Failed to set log level:" + err.Error())
 		}
 		fs, err := core.NewReadOnlyFS(bundle, logger)
 		if err != nil {

--- a/cmd/metrics/cmd/flags.go
+++ b/cmd/metrics/cmd/flags.go
@@ -18,6 +18,12 @@ type paramsT struct {
 		fileType  string
 		mockDest  bool
 	}
+	writeFiles struct {
+		fileSize       float64
+		numFiles       int
+		outDir         string
+		parallelWrites int
+	}
 }
 
 var params paramsT = paramsT{}
@@ -69,4 +75,28 @@ func addUploadMockDest(cmd *cobra.Command) string {
 	cmd.Flags().BoolVar(&params.upload.mockDest, flagName, true,
 		"whether to use GCS or a mock/stub/spy storage.Store")
 	return flagName
+}
+
+func addWriteFilesFilesize(cmd *cobra.Command) string {
+	const filesize = "filesize"
+	cmd.Flags().Float64Var(&params.writeFiles.fileSize, filesize, 16, "Per-file size (approx MiB) to write")
+	return filesize
+}
+
+func addWriteFilesNumFiles(cmd *cobra.Command) string {
+	const numFiles = "num-files"
+	cmd.Flags().IntVar(&params.writeFiles.numFiles, numFiles, 40, "Total number of files to write")
+	return numFiles
+}
+
+func addWriteFilesOutDir(cmd *cobra.Command) string {
+	const outDir = "out"
+	cmd.Flags().StringVar(&params.writeFiles.outDir, outDir, "", "Directory to write output files")
+	return outDir
+}
+
+func addWriteFilesParallelWrites(cmd *cobra.Command) string {
+	const parallelWrites = "parallel-writes"
+	cmd.Flags().IntVar(&params.writeFiles.parallelWrites, parallelWrites, 10, "Number of files to write in parallel")
+	return parallelWrites
 }

--- a/cmd/metrics/cmd/write_files.go
+++ b/cmd/metrics/cmd/write_files.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/oneconcern/datamon/pkg/cafs"
+	"github.com/oneconcern/datamon/pkg/storage"
+	"github.com/oneconcern/datamon/pkg/storage/localfs"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+// DieIfNotAccessible exits the process if the path is not accessible.
+func DieIfNotAccessible(path string) {
+	_, err := os.Stat(path)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func sanitizePath(path string) string {
+	sanitizedPath, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		log.Fatalln(err)
+	}
+	return sanitizedPath
+}
+
+func createPath(path string) {
+	// todo: determine proper permission bits.  previously 0700.
+	err := os.MkdirAll(path, 0777)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func DieIfNotDirectory(path string) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	if !fileInfo.IsDir() {
+		log.Fatalln("'" + path + "' is not a directory")
+	}
+}
+
+var writeFilesCmd = &cobra.Command{
+	Use:   "write-files",
+	Short: "Write test data files",
+	Long: `Write some files consisting of various byte patterns to disk.
+This command doesn't itself invoke datamon routines to collect metrics on them
+yet is generally part of the datamon metrics collection and benchmarking picture.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		sourceStore := func() storage.Store {
+			var s storage.Store
+			filenames := make([]string, 0)
+			numFiles := params.writeFiles.numFiles
+			for i := 0; i < numFiles; i++ {
+				nextFileName := fmt.Sprintf("testfile_%v", i)
+				filenames = append(filenames, nextFileName)
+			}
+			max := int64(1024 * 1024 * params.writeFiles.fileSize)
+			s = newGenStoreZeroOneChunks(filenames, max, cafs.DefaultLeafSize)
+			return s
+		}()
+
+		destStore := func() storage.Store {
+			var s storage.Store
+			destStorePath := sanitizePath(params.writeFiles.outDir)
+			logger.Info("setting destination store",
+				zap.String("path", destStorePath),
+			)
+			createPath(destStorePath)
+			DieIfNotAccessible(destStorePath)
+			DieIfNotDirectory(destStorePath)
+			s = localfs.New(afero.NewBasePathFs(afero.NewOsFs(), destStorePath))
+			return s
+		}()
+
+		ctx := context.Background()
+		srcKeys, err := sourceStore.Keys(ctx)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		logger.Info("preparing to write files",
+			zap.Int("num files", len(srcKeys)),
+		)
+		cc := make(chan struct{}, params.writeFiles.parallelWrites)
+		for idx, key := range srcKeys {
+			logger.Info("writing file",
+				zap.String("key", key),
+				zap.Int("idx", idx),
+			)
+			rdr, err := sourceStore.Get(ctx, key)
+			if err != nil {
+				log.Fatalln(err)
+			}
+			cc <- struct{}{}
+			go func(key string, rdr io.Reader, idx int) {
+				defer func() { <-cc }()
+				err := destStore.Put(ctx, key, rdr, storage.IfNotPresent)
+				if err != nil {
+					log.Fatalln(err)
+				}
+				logger.Info(" file written",
+					zap.String("key", key),
+					zap.Int("idx", idx),
+				)
+			}(key, rdr, idx)
+		}
+
+		logger.Info("waiting on all writes to finish")
+		for i := 0; i < cap(cc); i++ {
+			cc <- struct{}{}
+		}
+	},
+}
+
+func init() {
+	addWriteFilesOutDir(writeFilesCmd)
+	addWriteFilesFilesize(writeFilesCmd)
+	addWriteFilesNumFiles(writeFilesCmd)
+	addWriteFilesParallelWrites(writeFilesCmd)
+
+	rootCmd.AddCommand(writeFilesCmd)
+}

--- a/datamover.Dockerfile
+++ b/datamover.Dockerfile
@@ -1,0 +1,127 @@
+FROM golang:alpine as base
+
+ADD hack/create-netrc.sh /usr/bin/create-netrc
+
+RUN mkdir -p /stage/data /stage/etc/ssl/certs &&\
+  create-netrc &&\
+  apk add --no-cache musl-dev gcc ca-certificates mailcap upx tzdata zip git bash fuse &&\
+  update-ca-certificates &&\
+  cp /etc/ssl/certs/ca-certificates.crt /stage/etc/ssl/certs/ca-certificates.crt &&\
+  cp /etc/mime.types /stage/etc/mime.types
+
+# https://golang.org/src/time/zoneinfo.go Copy the zoneinfo installed by musl-dev
+WORKDIR /usr/share/zoneinfo
+RUN zip -r -0 /stage/zoneinfo.zip .
+
+ADD . /datamon
+WORKDIR /datamon
+
+
+ARG version_import_path
+ARG version
+ARG commit
+ARG dirty
+
+ENV VERSION_IMPORT_PATH ${version_import_path}
+ENV VERSION ${version}
+ENV GIT_COMMIT ${commit}
+ENV GIT_DIRTY ${dirty}
+
+RUN LDFLAGS='-s -w -linkmode external -extldflags "-static"' && \
+  LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}Version=${VERSION}'" && \
+  LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}BuildDate=$(date -u -R)'" && \
+  LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}GitCommit=${GIT_COMMIT}'" && \
+  LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}GitState=${GIT_DIRTY}'" && \
+  go build -o /stage/usr/bin/datamon --ldflags "$LDFLAGS" ./cmd/datamon
+RUN upx /stage/usr/bin/datamon
+RUN md5sum /stage/usr/bin/datamon
+
+RUN go build -o /stage/usr/bin/migrate --ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/backup2blobs
+RUN upx /stage/usr/bin/migrate
+RUN md5sum /stage/usr/bin/migrate
+
+RUN go build -o /stage/usr/bin/datamon_metrics --ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/metrics
+RUN upx /stage/usr/bin/datamon_metrics
+RUN md5sum /stage/usr/bin/datamon_metrics
+
+####
+# Build the dist image
+FROM ubuntu:latest
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+    git \
+    zsh \
+    less \
+    watch \
+    curl \
+    tmux \
+    bc \
+    vim \
+    htop &&\
+  apt-get autoremove -yqq &&\
+  apt-get clean -y &&\
+  apt-get autoclean -yqq &&\
+  rm -rf \
+    /tmp/* \
+    /var/tmp/* \
+    /var/lib/apt/lists/* \
+    /usr/share/doc/* \
+    /usr/share/locale/* \
+    /var/cache/debconf/*-old
+
+
+### BEGIN tini
+
+# omitting gpg verification during development/demo
+# RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64 /tmp/tini-static-amd64
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64.asc /tmp/tini-static-amd64.asc
+
+# omitting gpg verification during development/demo
+# RUN for key in \
+#       595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+#     ; do \
+#       gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+#       gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+#       gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
+#     done
+# RUN gpg --verify /tmp/tini-static-amd64.asc
+
+RUN install -m 0755 /tmp/tini-static-amd64 /bin/tini
+
+### END tini
+
+RUN mkdir /datamon
+COPY --from=base /datamon /datamon
+
+COPY --from=base /stage /
+ENV ZONEINFO /zoneinfo.zip
+
+ADD ./hack/fuse-demo/datamon.yaml /root/.datamon/datamon.yaml
+ADD ./hack/datamover/datamover.sh /usr/bin/datamover
+ADD ./hack/datamover/datamover_metrics.sh /usr/bin/datamover_metrics
+
+RUN chmod a+x /usr/bin/datamover
+RUN chmod a+x /usr/bin/datamover_metrics
+
+# USER root
+# USER developer
+
+RUN useradd -u 1020 -ms /bin/bash developer
+RUN groupadd -g 2000 developers
+RUN usermod -g developers developer
+RUN chown -R developer:developers /usr/bin/datamon
+
+USER developer
+RUN touch ~/.zshrc
+
+RUN cp /usr/bin/datamover /home/developer/datamover.sh && \
+  chmod +x /home/developer/datamover.sh
+RUN cp /usr/bin/datamover_metrics /home/developer/datamover_metrics.sh && \
+  chmod +x /home/developer/datamover_metrics.sh
+
+ENTRYPOINT [ "datamon" ]
+

--- a/datamover.Dockerfile
+++ b/datamover.Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update && \
     tmux \
     bc \
     vim \
+    mc \
     htop &&\
   apt-get autoremove -yqq &&\
   apt-get clean -y &&\

--- a/hack/datamover/access_nfs.sh
+++ b/hack/datamover/access_nfs.sh
@@ -1,0 +1,77 @@
+#! /bin/zsh
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+PROJ_ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+POD_START_POLL_INTERVAL=1
+
+typeset -A known_nfs_pvc_tags_to_names
+known_nfs_pvc_tags_to_names[argo]=pvc1
+known_nfs_pvc_tags_to_names[depmon]=depmon-pvc
+known_nfs_pvc_names=(${(v)known_nfs_pvc_tags_to_names})
+
+pvc_name_opt=argo
+create_pod=false
+
+while getopts cp: opt; do
+    case $opt in
+        (c)
+            create_pod=true
+            ;;
+        (p)
+            pvc_name_opt="$OPTARG"
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+
+pvc_name=
+if [[ ${known_nfs_pvc_names[(ie)$pvc_name_opt]} -le ${#known_nfs_pvc_names} ]]; then
+    pvc_name=$pvc_name_opt
+else
+    pvc_name=${known_nfs_pvc_tags_to_names[$pvc_name_opt]}
+fi
+if [[ -z $pvc_name ]]; then
+    print 'pvc name not set' 1>&2
+    exit 1
+fi
+
+deployment_name=datamon-datamover-nfs-access
+
+if $create_pod; then
+    k8s_yaml_name=datamover_nfs_access
+    res_def="${PROJ_ROOT_DIR}"/hack/k8s/gen/${k8s_yaml_name}.yaml
+    PVC_NAME=$pvc_name \
+    PVC_MNT_PATH=/filestore \
+            "${PROJ_ROOT_DIR}"/hack/envexpand \
+            "${PROJ_ROOT_DIR}"/hack/k8s/${k8s_yaml_name}.template.yaml \
+            > "$res_def"
+    if kubectl get deployment ${deployment_name} &> /dev/null; then
+	      kubectl delete -f "$res_def"
+    fi
+    kubectl create -f "$res_def"
+else
+    print 'skipping pod creation'
+fi
+
+if ! &>/dev/null kubectl get deployment $deployment_name; then
+    print "deployment_name $deployment_name not found" 1>&2
+    print 'try using the -c option to create a pod'
+    exit 1
+fi
+
+print 'waiting on pod start'
+pod_name=
+while [[ -z $pod_name ]]; do
+    sleep "$POD_START_POLL_INTERVAL"
+    pod_name=$(kubectl get pods -l app=datamon-datamover-nfs-access | grep Running | sed 's/ .*//')
+done
+
+kubectl exec -it "$pod_name" \
+        -c datamon-bin \
+        -- "/bin/zsh"

--- a/hack/datamover/create_demo_job.sh
+++ b/hack/datamover/create_demo_job.sh
@@ -1,0 +1,71 @@
+#! /bin/zsh
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+PROJ_ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+TIMESTAMP=$(date +%y%m%d%H%M%S)
+
+### be sure to run in dev env,
+# `kubens dev`,
+# in order to access NFS Share PVC
+
+pvc_mnt_path=/mnt/shared
+
+# used
+# '/mnt/shared/datamon/move_output/july26'
+# in test
+bkup_path_opt=
+
+timestamp_filter_before=090725000000
+
+filelist_dir=datamover-lists-${TIMESTAMP}
+
+while getopts p:t:f: opt; do
+    case $opt in
+        (p)
+            bkup_path_opt="$OPTARG"
+            ;;
+        (t)
+            timestamp_filter_before="$OPTARG"
+            ;;
+        (f)
+            filelist_dir="$OPTARG"
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+if [[ -z $bkup_path_opt ]]; then
+    print "backup path not specified.  specify with -p option." 1>&2
+    exit 1
+fi
+
+if ! print $bkup_path_opt | grep -q '^/'; then
+    bkup_path_opt=${pvc_mnt_path}/${bkup_path_opt}
+fi
+if ! print $filelist_dir | grep -q '^/'; then
+    filelist_dir=${pvc_mnt_path}/${filelist_dir}
+fi
+
+
+RES_DEF="${PROJ_ROOT_DIR}"/hack/k8s/gen/datamover_job.yaml
+
+# pvc1 is the NFS PVC name
+
+TIMESTAMP_FILTER_BEFORE=$timestamp_filter_before \
+PVC_MNT_PATH=$pvc_mnt_path \
+FILELIST_DIR=$filelist_dir \
+PVC_NAME=depmon-pvc \
+BKUP_PATH=$bkup_path_opt \
+         "${PROJ_ROOT_DIR}"/hack/envexpand \
+         "${PROJ_ROOT_DIR}"/hack/k8s/datamover_job.template.yaml \
+         > "$RES_DEF"
+
+
+kubectl delete job.batch/datamon-datamover-job
+
+kubectl create -f "$RES_DEF"

--- a/hack/datamover/create_demo_pod.sh
+++ b/hack/datamover/create_demo_pod.sh
@@ -1,0 +1,63 @@
+#! /bin/zsh
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+PROJ_ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+### be sure to run in dev env,
+# `kubens dev`,
+# in order to access NFS Share PVC
+
+# used
+# '/mnt/shared/datamon/move_output/july26'
+# in test
+BKUP_PATH_OPT=
+
+tot_size_tb=1
+num_files=100000
+
+write_files_only=false
+
+while getopts os:n:p: opt; do
+    case $opt in
+        (o)
+            write_files_only=true
+            ;;
+        (s)
+            tot_size_tb="$OPTARG"
+            ;;
+        (n)
+            num_files="$OPTARG"
+            ;;
+        (p)
+            BKUP_PATH_OPT="$OPTARG"
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+# if [[ -z $BKUP_PATH_OPT ]]; then
+#     print "backup path not specified.  specify with -p option." 1>&2
+#     exit 1
+# fi
+
+RES_DEF="${PROJ_ROOT_DIR}"/hack/k8s/gen/datamover.yaml
+
+WRITE_FILES_ONLY=$write_files_only \
+PVC_NAME=depmon-pvc \
+PVC_MNT_PATH=/mnt/shared \
+TOT_SIZE_TB=$tot_size_tb \
+NUM_FILES=$num_files \
+BKUP_PATH=$BKUP_PATH_OPT \
+  "${PROJ_ROOT_DIR}"/hack/envexpand \
+    "${PROJ_ROOT_DIR}"/hack/k8s/datamover.template.yaml \
+    > "$RES_DEF"
+
+if kubectl get deployment datamon-datamover-test &> /dev/null; then
+	kubectl delete -f "$RES_DEF"
+fi
+
+kubectl create -f "$RES_DEF"

--- a/hack/datamover/datamover.sh
+++ b/hack/datamover/datamover.sh
@@ -1,5 +1,8 @@
 #! /bin/zsh
 
+# use the ZERR trap to finalize (e.g. set different exit code, etc.)
+setopt ERR_EXIT
+
 typeset -a dirs
 
 TIMESTAMP=$(date +%y%m%d%H%M%S)

--- a/hack/datamover/datamover.sh
+++ b/hack/datamover/datamover.sh
@@ -1,0 +1,136 @@
+#! /bin/zsh
+
+typeset -a dirs
+
+TIMESTAMP=$(date +%y%m%d%H%M%S)
+
+BUNDLE_LABEL="datamover-${TIMESTAMP}"
+
+# todo: set to 'backup-filestore-output' before shipping
+REPO=ransom-datamon-test-repo
+
+typeset -i concurrency_factor
+concurrency_factor=200
+
+unlink=false
+# before last NFS bkup.. todo: verify whether this is accurate
+timestamp_filter_before=090725000000
+
+filelist_dir=/tmp
+
+while getopts d:c:l:ut:f: opt; do
+    case $opt in
+        (l)
+            BUNDLE_LABEL="$OPTARG"
+            ;;
+        (d)
+            dirs=("$OPTARG" $dirs)
+            ;;
+        (c)
+            concurrency_factor="$OPTARG"
+            ;;
+        (u)
+            unlink=true
+            ;;
+        (t)
+            timestamp_filter_before="$OPTARG"
+            ;;
+        (f)
+            filelist_dir="$OPTARG"
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+print "ensuring filelist directory $filelist_dir"
+if [[ ! -d $filelist_dir ]]; then
+    mkdir -p $filelist_dir
+fi
+
+UPLOAD_FILELIST=${filelist_dir}/upload.list
+UPLOADED_FILELIST=${filelist_dir}/uploaded.list
+REMOVABLE_FILELIST=${filelist_dir}/removable.list
+
+if [[ -e $UPLOAD_FILELIST ]]; then
+    print "$UPLOAD_FILELIST already exists" 1>&2
+    exit 1
+fi
+if [[ -e $UPLOADED_FILELIST ]]; then
+    print "$UPLOADED_FILELIST already exists" 1>&2
+    exit 1
+fi
+if [[ -e $REMOVABLE_FILELIST ]]; then
+    print "$REMOVABLE_FILELIST already exists" 1>&2
+    exit 1
+fi
+
+if [[ ! $#dirs -eq 1 ]]; then
+    print 'most provide precisely one backup dir' 1>&2
+    exit 1
+fi
+
+# based on fileUploadsByConcurrencyFactor in cmd/bundle_upload.go
+if [[ $concurrency_factor -lt 5 ]]; then
+    print "concurrency_factor $concurrency_factor must be set to at least 5" 1>&2
+    exit 1
+fi
+
+dir_path_param=$dirs[1]
+
+if [[ ! -d $dir_path_param ]]; then
+    print "$dir_path_param doesn't exist" 1>&2
+    exit 1
+fi
+
+cd $HOME
+
+if ! print . | migrate filelist-actions --time-before $timestamp_filter_before; then
+    print "$timestamp_filter_before isn't recognized by the filelist actions script" 1>&2
+    exit 1
+fi
+
+###
+
+dir_path_abs=$(cd $dir_path_param && pwd)
+
+if [[ ! -f $HOME/.datamon/datamon.yaml ]]; then
+    datamon config create \
+            --name 'ransom' \
+            --email 'rwilliams@oneconcern.com'
+fi
+
+sed_param='s@\(.*\)@'"${dir_path_abs}"'\/\1@'
+
+2>/dev/null migrate generate --out - --parallel --parent $dir_path_abs | \
+    sed $sed_param > ${UPLOAD_FILELIST}
+
+###
+
+datamon bundle upload \
+        --files ${UPLOAD_FILELIST} \
+        --message "upload from datamover script" \
+        --path / \
+        --repo $REPO \
+        --label $BUNDLE_LABEL \
+        --skip-on-error \
+        --concurrency-factor $concurrency_factor \
+        --loglevel debug
+
+###
+
+datamon bundle list files \
+        --repo $REPO \
+        --label $BUNDLE_LABEL | \
+    grep -v '^Using' | \
+    sed 's/name:\(.*\), size:.*, hash:.*/\1/' \
+        > ${UPLOADED_FILELIST}
+
+migrate filelist-actions \
+        --filelist ${UPLOADED_FILELIST} \
+        --unlink=${unlink} \
+        --time-before $timestamp_filter_before \
+        --out $REMOVABLE_FILELIST

--- a/hack/datamover/datamover_metrics.sh
+++ b/hack/datamover/datamover_metrics.sh
@@ -1,0 +1,156 @@
+#! /bin/zsh
+
+LOG_PATH=/tmp/datamover_metrics.log
+
+DM_BIN=datamover
+
+TEST_DIR=/mnt/shared/datamover-test
+
+tot_size_tb=1
+num_files=100000
+
+write_files=true
+write_files_only=false
+
+while getopts d:s:n:o:w opt; do
+    case $opt in
+        (o)
+            write_files_only="$OPTARG"
+            ;;
+        (w)
+            write_files=false
+            ;;
+        (d)
+            TEST_DIR="$OPTARG"
+            ;;
+        (s)
+            tot_size_tb="$OPTARG"
+            ;;
+        (n)
+            num_files="$OPTARG"
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+if [[ ! ($write_files_only = true || $write_files_only = false) ]]; then
+    print "write files only -o flag must be set to either 'true' or 'false'." \
+          "got '$write_files_only'" 1>&2
+    exit 1
+fi
+
+tot_size_mib=$(($tot_size_tb * 1000 * 1000))
+filesize_mib=$(print "scale=10; $tot_size_mib / $num_files" |bc)
+
+if [[ -d $TEST_DIR ]]; then
+    print "unlinking extant test directory $TEST_DIR"
+    rm -rf $TEST_DIR
+fi
+
+cd $HOME
+
+print "tot_size_tb: $tot_size_tb"
+print "filesize_mib: $filesize_mib"
+print "num_files: $num_files"
+print "tot_size_tb: $tot_size_tb" >> $LOG_PATH
+print "filesize_mib: $filesize_mib" >> $LOG_PATH
+print "num_files: $num_files" >> $LOG_PATH
+
+if $write_files; then
+    print 'writing files to share'
+    mkdir $TEST_DIR
+    WRITE_TIMESTAMP_A=$(date +%y%m%d%H%M%S)
+    sleep 2
+    datamon_metrics write-files \
+                    --filesize $filesize_mib \
+                    --num-files $(($num_files / 2)) \
+                    --out $TEST_DIR/sample_a-${WRITE_TIMESTAMP_A}
+    sleep 3
+    WRITE_TIMESTAMP_B=$(date +%y%m%d%H%M%S)
+    sleep 2
+    datamon_metrics write-files \
+                    --filesize $filesize_mib \
+                    --num-files $(($num_files / 2)) \
+                    --out $TEST_DIR/sample_b-${WRITE_TIMESTAMP_B}
+fi
+
+if $write_files_only; then
+    while true; do sleep 100; done
+fi
+
+typeset -A timer_state
+
+stop_timer() {
+    typeset timer_name=$timer_state[name]
+    typeset timer_start=$timer_state[start]
+    typeset timer_end=$(date +%y%m%d%H%M%S)
+    typeset log_msg="$timer_name end-time: $timer_end"
+    print $log_msg
+    print $log_msg >> $LOG_PATH
+    timer_state=()
+}
+
+start_timer() {
+    if [[ ! $#timer_state -eq 0 ]]; then
+        stop_timer
+    fi
+    typeset timer_name=$1
+    typeset timer_start=$(date +%y%m%d%H%M%S)
+    typeset log_msg="$timer_name start-time: $timer_start"
+    print $log_msg
+    print $log_msg >> $LOG_PATH
+    timer_state[name]=$timer_name
+    timer_state[start]=$timer_start
+}
+
+BUNDLE_LABEL="datamover-$(date +%y%m%d%H%M%S)"
+
+print 'running datamover'
+
+start_timer datamover
+
+$DM_BIN \
+    -d $TEST_DIR \
+    -t $WRITE_TIMESTAMP_B \
+    -l $BUNDLE_LABEL
+
+stop_timer
+
+## semi-fragile smoke test.  could remove or shore-up.
+tot_rm_lines=$(cat /tmp/removable.list \
+                   |wc -l |tr -s ' ' |cut -d' ' -f 2)
+sample_a_rm_lines=$(cat /tmp/removable.list | grep sample_a \
+                   |wc -l |tr -s ' ' |cut -d' ' -f 2)
+if [[ ! $tot_rm_lines -eq $sample_a_rm_lines ]]; then
+    print 'expected all removal list lines to be files in sample A' 1>&2
+    exit 1
+fi
+if [[ ! $tot_rm_lines -eq $(($num_files / 2)) ]]; then
+    print 'expected removal list lines to comprise half the number of files' 1>&2
+    exit 1
+fi
+
+####
+
+print 'unlinking test directory'
+rm -rf $TEST_DIR
+print 'creating download directory'
+mkdir $TEST_DIR
+
+start_timer download
+
+datamon bundle download \
+        --repo ransom-datamon-test-repo \
+        --label $BUNDLE_LABEL \
+        --concurrency-factor 400 \
+        --destination $TEST_DIR
+
+stop_timer
+
+
+# infinite sleep to debug, gather logs
+while true; do sleep 100; done

--- a/hack/datamover/datamover_metrics.sh
+++ b/hack/datamover/datamover_metrics.sh
@@ -1,5 +1,7 @@
 #! /bin/zsh
 
+setopt ERR_EXIT
+
 LOG_PATH=/tmp/datamover_metrics.log
 
 DM_BIN=datamover

--- a/hack/datamover/follow_job_logs.sh
+++ b/hack/datamover/follow_job_logs.sh
@@ -1,0 +1,19 @@
+#! /bin/zsh
+
+container_name=datamon-bin
+
+STARTUP_POLL_INTERVAL=1
+
+pod_name=
+
+echo "waiting on job start"
+
+while [[ -z $pod_name ]]; do
+    sleep "$STARTUP_POLL_INTERVAL"
+    pod_name=$(kubectl get pods -l app=datamon-datamover-job | grep Running | sed 's/ .*//')
+done
+
+
+echo "pod started, following logs of $pod_name"
+
+kubectl logs "$pod_name" -f -c datamon-bin |humanlog

--- a/hack/datamover/follow_logs.sh
+++ b/hack/datamover/follow_logs.sh
@@ -1,0 +1,19 @@
+#! /bin/zsh
+
+container_name=datamon-bin
+
+STARTUP_POLL_INTERVAL=1
+
+pod_name=
+
+echo "waiting on pod start"
+
+while [[ -z $pod_name ]]; do
+    sleep "$STARTUP_POLL_INTERVAL"
+    pod_name=$(kubectl get pods -l app=datamon-datamover-test | grep Running | sed 's/ .*//')
+done
+
+
+echo "pod started, following logs of $pod_name"
+
+kubectl logs "$pod_name" -f -c datamon-bin |humanlog

--- a/hack/datamover/nfs_lister.sh
+++ b/hack/datamover/nfs_lister.sh
@@ -1,0 +1,67 @@
+#! /bin/zsh
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+PROJ_ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+list_out=
+
+pvc_mnt_path=/mnt/shared
+pvc_name=depmon-pvc
+
+bkup_path_opt=
+
+while getopts n:p:o: opt; do
+    case $opt in
+        (o)
+            list_out="$OPTARG"
+            ;;
+        (p)
+            bkup_path_opt="$OPTARG"
+            ;;
+        (n)
+            pvc_name="$OPTARG"
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+if ! print $bkup_path_opt | grep -q '^/'; then
+    bkup_path_opt=${pvc_mnt_path}/${bkup_path_opt}
+fi
+
+
+template_name=datamover_nfs_lister
+RES_DEF="${PROJ_ROOT_DIR}"/hack/k8s/gen/${template_name}.yaml
+
+PVC_MNT_PATH=$pvc_mnt_path \
+PVC_NAME=$pvc_name \
+BKUP_PATH=$bkup_path_opt \
+         "${PROJ_ROOT_DIR}"/hack/envexpand \
+         "${PROJ_ROOT_DIR}"/hack/k8s/${template_name}.template.yaml \
+         > "$RES_DEF"
+
+kubectl delete job.batch/datamon-datamover-lister
+
+kubectl create -f "$RES_DEF"
+
+AWAIT_COMPLETION_POLL_INTERVAL=1
+
+num_completions=0
+while [[ $num_completions -eq 0 ]]; do
+    sleep $AWAIT_COMPLETION_POLL_INTERVAL
+    num_completions=$(kubectl get job datamon-datamover-lister | \
+                          tail -1 | \
+                          tr -s ' ' | \
+                          cut -d ' ' -f 2 | \
+                          cut -d'/' -f 1)
+done
+
+if [[ -z $list_out ]]; then
+    kubectl logs jobs.batch/datamon-datamover-lister | sed 's/\(.*\)/item:\1/'
+else
+    kubectl logs jobs.batch/datamon-datamover-lister &> $list_out
+fi

--- a/hack/datamover/retrieve_job_logs.sh
+++ b/hack/datamover/retrieve_job_logs.sh
@@ -1,0 +1,19 @@
+#! /bin/zsh
+
+container_name=datamon-bin
+
+STARTUP_POLL_INTERVAL=1
+
+pod_name=
+
+echo "waiting on job completion"
+
+while [[ -z $pod_name ]]; do
+    sleep "$STARTUP_POLL_INTERVAL"
+    pod_name=$(kubectl get pods -l app=datamon-datamover-job | grep Completed | sed 's/ .*//')
+done
+
+
+echo "pod started, following logs of $pod_name"
+
+kubectl logs "$pod_name" -c datamon-bin |humanlog

--- a/hack/datamover/run_job_shell.sh
+++ b/hack/datamover/run_job_shell.sh
@@ -1,0 +1,18 @@
+#! /bin/zsh
+
+container_name=datamon-bin
+
+STARTUP_POLL_INTERVAL=1
+
+pod_name=
+
+echo "waiting on pod start"
+
+while [[ -z $pod_name ]]; do
+    sleep "$STARTUP_POLL_INTERVAL"
+    pod_name=$(kubectl get pods -l app=datamon-datamover-job | grep Running | sed 's/ .*//')
+done
+
+kubectl exec -it "$pod_name" \
+        -c "$container_name" \
+        -- "/bin/zsh"

--- a/hack/datamover/run_shell.sh
+++ b/hack/datamover/run_shell.sh
@@ -1,0 +1,18 @@
+#! /bin/zsh
+
+container_name=datamon-bin
+
+STARTUP_POLL_INTERVAL=1
+
+pod_name=
+
+echo "waiting on pod start"
+
+while [[ -z $pod_name ]]; do
+    sleep "$STARTUP_POLL_INTERVAL"
+    pod_name=$(kubectl get pods -l app=datamon-datamover-test | grep Running | sed 's/ .*//')
+done
+
+kubectl exec -it "$pod_name" \
+        -c "$container_name" \
+        -- "/bin/zsh"

--- a/hack/k8s/datamover.template.yaml
+++ b/hack/k8s/datamover.template.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: datamon-datamover-test
+spec:
+  selector:
+    matchLabels:
+      app: datamon-datamover-test
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: datamon-datamover-test
+    spec:
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+      - name: set-pvc-vol-perms
+        image: ubuntu:latest
+        command:
+        - chown
+        - 1020:2000
+        - $PVC_MNT_PATH
+        volumeMounts:
+        - mountPath: $PVC_MNT_PATH
+          name: shared-vol
+
+      containers:
+      - name: datamon-bin
+        image: gcr.io/onec-co/datamon-datamover:latest
+        imagePullPolicy: "Always"
+
+        # command: ["/bin/tini"]
+        # args: ["--", "/bin/zsh"]
+
+        command: ["datamover_metrics"]
+        args: [
+        "-o", "$WRITE_FILES_ONLY",
+        "-s", "$TOT_SIZE_TB",
+        "-n", "$NUM_FILES"
+        ]
+
+        stdin: true
+        tty: true
+        volumeMounts:
+        - mountPath: $PVC_MNT_PATH
+          name: shared-vol
+
+        env:
+        - name: DATAMOVER_BKUP_PATH
+          value: $BKUP_PATH
+
+        # resources:
+        #   requests:
+        #     memory: "15G"
+
+      volumes:
+
+      - name: shared-vol
+        persistentVolumeClaim:
+          claimName: $PVC_NAME
+
+      # tolerations:
+      # - key: "oneconcern.com/flood"
+      #   operator: Equal
+      #   value: "inundation"
+      # nodeSelector:
+      #   kubernetes.io/role: "flood-pipeline"
+
+      # tolerations:
+      #   - key: "oneconcern.com/dedicated"
+      #     operator: Equal
+      #     value: "geodude"
+      # nodeSelector:
+      #     kubernetes.io/role: "geodude"
+
+

--- a/hack/k8s/datamover_job.template.yaml
+++ b/hack/k8s/datamover_job.template.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: datamon-datamover-job
+spec:
+  template:
+    metadata:
+      labels:
+        app: datamon-datamover-job
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: datamon-bin
+        image: gcr.io/onec-co/datamon-datamover:latest
+        imagePullPolicy: "Always"
+        command: ["datamover"]
+        args: [
+        "-t", "$TIMESTAMP_FILTER_BEFORE",
+        "-f", "$FILELIST_DIR",
+        "-d", "$BKUP_PATH"
+        ]
+
+        stdin: true
+        tty: true
+        volumeMounts:
+        - mountPath: $PVC_MNT_PATH
+          name: shared-vol
+
+        # resources:
+        #   requests:
+        #     memory: "15G"
+
+      volumes:
+
+      - name: shared-vol
+        persistentVolumeClaim:
+          claimName: $PVC_NAME
+          # readOnly: false
+
+      # tolerations:
+      # - key: "oneconcern.com/flood"
+      #   operator: Equal
+      #   value: "inundation"
+      # nodeSelector:
+      #   kubernetes.io/role: "flood-pipeline"
+
+      # tolerations:
+      #   - key: "oneconcern.com/dedicated"
+      #     operator: Equal
+      #     value: "geodude"
+      # nodeSelector:
+      #     kubernetes.io/role: "geodude"

--- a/hack/k8s/datamover_nfs_access.template.yaml
+++ b/hack/k8s/datamover_nfs_access.template.yaml
@@ -1,37 +1,43 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: datamon-datamover-job
+  name: datamon-datamover-nfs-access
 spec:
+  selector:
+    matchLabels:
+      app: datamon-datamover-nfs-access
+  replicas: 1
   template:
     metadata:
       labels:
-        app: datamon-datamover-job
+        app: datamon-datamover-nfs-access
     spec:
-      restartPolicy: Never
-      containers:
-      - name: datamon-bin
-        image: gcr.io/onec-co/datamon-datamover:latest
-        imagePullPolicy: "Always"
-        command: ["datamover"]
-        args: [
-        "-t", "$TIMESTAMP_FILTER_BEFORE",
-        "-f", "$FILELIST_DIR",
-        "-d", "$BKUP_PATH"
-        ]
-
-        stdin: true
-        tty: true
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+      - name: set-pvc-vol-perms
+        image: ubuntu:latest
+        command:
+        - chown
+        - 1020:2000
+        - $PVC_MNT_PATH
         volumeMounts:
         - mountPath: $PVC_MNT_PATH
           name: shared-vol
 
-        - mountPath: /tmp/gac
-          name: google-application-credentials
+      containers:
+      - name: datamon-bin
+        image: gcr.io/onec-co/datamon-datamover:latest
+        imagePullPolicy: "Always"
+        stdin: true
+        tty: true
 
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /tmp/gac/google-application-credentials.json
+        command: ["/bin/tini"]
+        args: ["--", "/bin/zsh"]
+
+        volumeMounts:
+        - mountPath: $PVC_MNT_PATH
+          name: shared-vol
 
         # resources:
         #   requests:
@@ -39,14 +45,9 @@ spec:
 
       volumes:
 
-      - name: google-application-credentials
-        secret:
-          secretName: google-application-credentials
-
       - name: shared-vol
         persistentVolumeClaim:
           claimName: $PVC_NAME
-          # readOnly: false
 
       # tolerations:
       # - key: "oneconcern.com/flood"

--- a/hack/k8s/datamover_nfs_lister.template.yaml
+++ b/hack/k8s/datamover_nfs_lister.template.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: datamon-datamover-lister
+spec:
+  template:
+    metadata:
+      labels:
+        app: datamon-datamover-lister
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: lister
+        image: ubuntu:latest
+        imagePullPolicy: "Always"
+        command: ["find"]
+        args: ["$BKUP_PATH", "-type", "d", "-maxdepth", "1"]
+        stdin: true
+        tty: true
+        volumeMounts:
+        - mountPath: $PVC_MNT_PATH
+          name: shared-vol
+      volumes:
+      - name: shared-vol
+        persistentVolumeClaim:
+          claimName: $PVC_NAME
+          readOnly: true

--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -115,6 +115,9 @@ func uploadBundleFile(
 	defer func() {
 		<-chans.concurrencyControl
 	}()
+	logger.Debug("putting file in cafs",
+		zap.String("filename", file),
+	)
 	putRes, e := cafsArchive.Put(ctx, fileReader)
 	if e != nil {
 		chans.error <- errorHit{


### PR DESCRIPTION
as with the [sidecar](pod/datamon-datamover-test-5b87d6d949-8svcr) used in Argo workflows, this is an operationalization of datamon in the sense that it's a use of datamon in order to accomplish a specific task.  in addition to the datamon program itself, an operationalization consists of any necessary auxiliary programs (for example, the `migrate` program used to create and act on lists of files in this case) and a wrapper script (shell scripts here and in the sidecar, although Python or similar could be used as well), all packaged as a Docker image along with sample Kubernetes YAML, and documented such that datamon users get an interface specific to their needs.

the particular use-case here at One Concern that we're currently operationalizing is backing up and cleaning an NFS filestore shared among various data-science pipelines and ad-hoc experiments.  while datamon is increasingly useful as the primary storage mechanism for some data-science pipelines, it's not feasible to replace the NFS store wholesale.  additionally, for ad-hoc data-science scripts (those that aren't part of pipelines), `datamon`s archiving and tracking mechanisms can be more of a hindrance than an asset.  so we wind up with a large (approx 10^7 files totaling in 32-64TB) NFS store that slowly fills up with data.

the operation here is to backup all data in the NFS store to datamon as well as to remove (unlink) all files with a modify time before some specified time.

the current scope of the request is a PoC of the operationalization.  scalability appears (`./hack/datamover/create_demo_pod.sh -s <size_tb> -n <num_files>` in order for statistics of up to at least around 1 TB and 10^5 files.  additional debugging and optimization might be required to bring the operation up to the requirements NFS store backup.