### PR TITLE
[wip] [const] sidecar bundle id param

### DIFF
--- a/hack/fuse-demo/wrap_application.sh
+++ b/hack/fuse-demo/wrap_application.sh
@@ -13,8 +13,13 @@ COORD_POINT=
 
 POLL_INTERVAL=1 # sec
 
-while getopts c: opt; do
+SLEEP_INSTEAD_OF_EXIT=
+
+while getopts sc: opt; do
     case $opt in
+        (s)
+            SLEEP_INSTEAD_OF_EXIT=true
+            ;;
         (c)
             COORD_POINT="$OPTARG"
             ;;
@@ -95,3 +100,10 @@ await_event \
 
 ## COORDINATION ENDS with this container exiting
 echo "recved upload done event, exiting"
+
+if [ -z "$SLEEP_INSTEAD_OF_EXIT" ]; then
+    exit 0
+fi
+
+echo "sleeping indefinitely (for debug)"
+while true; do sleep 100; done

--- a/hack/fuse-demo/wrap_datamon.sh
+++ b/hack/fuse-demo/wrap_datamon.sh
@@ -268,7 +268,7 @@ for upload_cmd in $UPLOAD_CMDS; do
     IFS="$ifs_orig"
     bundle_id=$(2>&1 run_datamon_cmd "$upload_cmd" | \
                     grep 'Uploaded bundle id' | \
-                    head -1 | \
+                    tail -1 | \
                     sed 's/Uploaded bundle id:\(.*\)/\1/')
     upload_status="$?"
     if [ "$upload_status" != 0 ]; then

--- a/hack/k8s/example-coord.template.yaml
+++ b/hack/k8s/example-coord.template.yaml
@@ -29,7 +29,8 @@ spec:
         command: ["/tmp/coord/.scripts/wrap_application.sh"]
         # use the wrong number of params in order to simulate error out of mock app
         # args: ["-c", "/tmp/coord", "--", "./mock_application.sh", "/tmp/mount"]
-        args: ["-c", "/tmp/coord", "--", "./mock_application.sh", "/tmp/mount", "/tmp/upload"]
+        args: ["-s", "-c", "/tmp/coord", "--",
+        "./mock_application.sh", "/tmp/mount", "/tmp/upload"]
         stdin: true
         tty: true
         volumeMounts:
@@ -44,7 +45,11 @@ spec:
         image: gcr.io/onec-co/datamon-fuse-demo-coord-datamon:latest
         imagePullPolicy: "Always"
         command: ["./wrap_datamon.sh"]
-        args: ["-c", "/tmp/coord", "-d", "config create --name \"Coord\" --email coord-bot@oneconcern.com", "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo", "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --destination /tmp --mount /tmp/mount --stream"]
+        args: ["-c", "/tmp/coord",
+        "-i", "/tmp/bundleid.txt",
+        "-d", "config create --name \"Coord\" --email coord-bot@oneconcern.com",
+        "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo",
+        "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --destination /tmp --mount /tmp/mount --stream"]
         securityContext:
           privileged: true
         stdin: true


### PR DESCRIPTION
this adds an `-i` for bundleID parameter to the `wrap_datamon.sh` script used by the FUSE RO FS sidecar by request for the seismic Argo pipeline.

use of this parameter supposes precisely one `bundle upload` command is passed to `wrap_datamon.sh` via the `-d` flag and writes the bundle id of the uploaded file to the file specified as the `-i` parameter.  this file can then be used as the [output parameter](https://github.com/argoproj/argo/tree/master/examples#output-parameters) of the Argo DAG node using the sidecar setup.
