### PR TITLE
init build-and-push-release-docker-images Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ TARGET_MAX_CHAR_NUM=25
 # Version and repo
 VERSION=$(shell git describe --tags)
 COMMIT=$(shell git rev-parse HEAD)
+RELEASE_TAG=$(shell ./hack/release_tag.sh)
+RELEASE_TAG_LATEST=$(shell ./hack/release_tag.sh -l)
 GITDIRTY=$(shell git diff --quiet || echo 'dirty')
 REPOSITORY ?= "gcr.io/onec-co"
 
@@ -55,6 +57,8 @@ build-and-push-fuse-sidecar: build-datamon-binaries
 		-t gcr.io/onec-co/datamon-fuse-sidecar \
 		-t gcr.io/onec-co/datamon-fuse-sidecar:${GITHUB_USER}-$$(date '+%Y%m%d') \
 		-t gcr.io/onec-co/datamon-fuse-sidecar:$(subst /,_,$(GIT_BRANCH)) \
+		-t gcr.io/onec-co/datamon-fuse-sidecar:$(RELEASE_TAG) \
+		-t gcr.io/onec-co/datamon-fuse-sidecar:$(RELEASE_TAG_LATEST) \
 		--ssh default \
 		-f sidecar.Dockerfile \
 		.
@@ -74,10 +78,16 @@ build-and-push-datamover: build-datamon-binaries
 		-t gcr.io/onec-co/datamon-datamover \
 		-t gcr.io/onec-co/datamon-datamover:${GITHUB_USER}-$$(date '+%Y%m%d') \
 		-t gcr.io/onec-co/datamon-datamover:$(subst /,_,$(GIT_BRANCH)) \
+		-t gcr.io/onec-co/datamon-datamover:$(RELEASE_TAG) \
+		-t gcr.io/onec-co/datamon-datamover:$(RELEASE_TAG_LATEST) \
 		--ssh default \
 		-f datamover.Dockerfile \
 		.
 	docker push gcr.io/onec-co/datamon-datamover
+
+.PHONY: build-and-push-release-docker-images
+## build all docker images associated with a release
+build-and-push-release-docker-images: build-and-push-fuse-sidecar build-and-push-datamover
 
 .PHONY: build-datamon
 ## Build datamon docker container (datamon)

--- a/hack/release_tag.sh
+++ b/hack/release_tag.sh
@@ -1,0 +1,49 @@
+#! /bin/zsh
+
+setopt ERR_EXIT
+
+is_latest=false
+
+while getopts l opt; do
+    case $opt in
+        (l)
+            is_latest=true
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+typeset -a version_tags
+version_tags=($(git tag --points-at HEAD |grep '^v' || true))
+
+if [[ ${#version_tags} -gt 1 ]]; then
+    print 'ambiguous tags at HEAD: multiple tags begin with v' 1>&2
+    print -- "$version_tags" 1>&2
+    exit 1
+fi
+
+if [[ ${#version_tags} -eq 1 ]]; then
+    if $is_latest; then
+        if &> /dev/null docker pull \
+              gcr.io/onec-co/datamon-fuse-sidecar:${version_tags[1]}; then
+            release_tag='latest-official-rebuild'
+        else
+            release_tag='latest-official-init'
+        fi
+    else
+        release_tag=${version_tags[1]}
+    fi
+else
+    if $is_latest; then
+        release_tag='latest-unofficial'
+    else
+        hash=$(git show --abbrev-commit |grep '^commit' | cut -d' ' -f 2)
+        release_tag="hash-${hash}"
+    fi
+fi
+
+print -- ${release_tag}


### PR DESCRIPTION
slight automation increment while setting [v0.7](https://github.com/oneconcern/datamon/releases/tag/v0.7)

the additional Makefile target included builds both [the Argo sidecar](https://github.com/oneconcern/datamon#kubernetes-sidecar-guide) and [the NFS datamover](https://github.com/oneconcern/datamon#datamover-container-guide) and deploys to the repo with a release tag.

the release tag is the same as that used by git when `HEAD` is on such a tag.  otherwise, it's `hash-<hash>`, where `<hash>` is the abbreviated hash out of git.