### PR TITLE
Docker Desktop sidecar usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,11 @@ build-datamon-mac:
 	go build -o out/datamon.mac --ldflags "${LDFLAGS}" ./cmd/datamon
 	(cd pkg/web && packr2 clean)
 
+.PHONY: build-datamon-local
+## Build datamon executable in-place for local os.  Goes with internal operationalization demos.
+build-datamon-local:
+	@go build -o cmd/datamon/datamon ./cmd/datamon/
+
 .PHONY: build-all
 ## Build all the containers
 build-all: clean build-datamon build-migrate
@@ -262,14 +267,6 @@ fuse-demo-coord-build-datamon:
 		-f ./hack/fuse-demo/coord-datamon.Dockerfile \
 		.
 	docker push gcr.io/onec-co/datamon-fuse-demo-coord-datamon
-
-## demonstrate a fuse read-only filesystem
-fuse-demo-coord: fuse-demo-coord-build-app fuse-demo-coord-build-datamon
-	@go build -o cmd/datamon/datamon ./cmd/datamon/
-	@date '+%s' > /tmp/datamon_fuse_demo_coord_start_timestamp
-	@./hack/fuse-demo/create_coord_pod.sh
-	@./hack/fuse-demo/follow_coord_logs.sh
-	@./hack/fuse-demo/verify_coord_bundle.sh
 
 .PHONY: profile-metrics
 ## Build the metrics collection binary and write output

--- a/hack/fuse-demo/create_coord_pod.sh
+++ b/hack/fuse-demo/create_coord_pod.sh
@@ -4,6 +4,22 @@ SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 proj_root_dir="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
+pull_policy=Always
+
+while getopts o opt; do
+    case $opt in
+        (o)
+            # local deploy
+            pull_policy=IfNotPresent
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
 if [[ -z $GOOGLE_APPLICATION_CREDENTIALS ]]; then
 	echo 'GOOGLE_APPLICATION_CREDENTIALS env variable not set' 1>&2
 	exit 1
@@ -20,6 +36,7 @@ kubectl create secret generic \
 
 RES_DEF="$proj_root_dir"/hack/k8s/gen/example-coord.yaml
 
+PULL_POLICY=$pull_policy \
 SHELL_NAME="$(basename "$SHELL")" \
 	PROJROOT="$(git rev-parse --show-toplevel)" \
 	GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD |sed 's@/@_@g')" \

--- a/hack/fuse-demo/demo_coord.sh
+++ b/hack/fuse-demo/demo_coord.sh
@@ -1,0 +1,77 @@
+#! /bin/zsh
+
+## demonstrate a fuse read-only filesystem
+
+# on the utility shell scripts v. makefile targets by use-case
+# https://stackoverflow.com/a/45003119
+
+setopt ERR_EXIT
+
+typeset -A known_k8s_tags_to_ctxs
+known_k8s_tags_to_ctxs[local]=docker-desktop
+known_k8s_tags_to_ctxs[remote]=gke_onec-co_us-west2-c_onec-dev
+known_k8s_ctxs=(${(v)known_k8s_tags_to_ctxs})
+
+k8s_ctx_opt=remote
+build_sidecar_base=true
+build_demo_sidecar=true
+build_demo_app=true
+build_local=true
+
+while getopts os opt; do
+    case $opt in
+        (o)
+            # local deploy
+            k8s_ctx_opt=local
+            ;;
+        (s)
+            build_sidecar_base=false
+            build_demo_sidecar=false
+            build_demo_app=false
+            build_local=false
+            ;;
+        (\?)
+            print Bad option, aborting.
+            exit 1
+            ;;
+    esac
+done
+(( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
+
+k8s_ctx=
+if [[ ${known_k8s_ctxs[(ie)$k8s_ctx_opt]} -le ${#known_k8s_ctxs} ]]; then
+    k8s_ctx=$k8s_ctx_opt
+else
+    k8s_ctx=${known_k8s_tags_to_ctxs[$k8s_ctx_opt]}
+fi
+if [[ -z $k8s_ctx ]]; then
+    print 'kubernetes context not set' 1>&2
+    exit 1
+fi
+kubectx $k8s_ctx
+
+##
+
+if $build_sidecar_base; then
+    make build-and-push-fuse-sidecar
+fi
+if $build_demo_app; then
+    make fuse-demo-coord-build-app
+fi
+if $build_demo_sidecar; then
+    make fuse-demo-coord-build-datamon
+fi
+if $build_local; then
+    make build-datamon-local
+fi
+
+date '+%s' > /tmp/datamon_fuse_demo_coord_start_timestamp
+
+
+if [[ $k8s_ctx_opt = 'local' ]]; then
+    ./hack/fuse-demo/create_coord_pod.sh -o
+    else
+        ./hack/fuse-demo/create_coord_pod.sh
+fi
+./hack/fuse-demo/follow_coord_logs.sh
+./hack/fuse-demo/verify_coord_bundle.sh

--- a/hack/fuse-demo/wrap_datamon.sh
+++ b/hack/fuse-demo/wrap_datamon.sh
@@ -185,6 +185,10 @@ fi
 ## COORDINATION BEGINS by starting a datamon FUSE mount
 echo "starting mounts '$MOUNT_CMDS'"
 
+# in some kubernetes distros like docker-desktop, /dev/fuse has perms 660 rather than 666
+echo "setting privs on fuse device"
+sudo chgrp developers /dev/fuse
+
 mount_points=
 mount_idx=0
 datamon_pids=

--- a/hack/k8s/example-coord.template.yaml
+++ b/hack/k8s/example-coord.template.yaml
@@ -15,7 +15,7 @@ spec:
       initContainers:
       - name: init-application-wrap
         image: gcr.io/onec-co/datamon-fuse-demo-coord-datamon:latest
-        imagePullPolicy: "Always"
+        imagePullPolicy: "$PULL_POLICY"
         command: ["sh", "-c", "mkdir /tmp/coord/.scripts; cp wrap_application.sh /tmp/coord/.scripts/wrap_application.sh; chmod a+x /tmp/coord/.scripts/wrap_application.sh; echo 'placed application wrapper'"]
         stdin: true
         tty: true
@@ -25,7 +25,7 @@ spec:
       containers:
       - name: demo-app
         image: gcr.io/onec-co/datamon-fuse-demo-coord-app:latest
-        imagePullPolicy: "Always"
+        imagePullPolicy: "$PULL_POLICY"
         command: ["/tmp/coord/.scripts/wrap_application.sh"]
         # use the wrong number of params in order to simulate error out of mock app
         # args: ["-c", "/tmp/coord", "--", "./mock_application.sh", "/tmp/mount"]
@@ -43,7 +43,7 @@ spec:
           mountPropagation: "HostToContainer"
       - name: datamon-sidecar
         image: gcr.io/onec-co/datamon-fuse-demo-coord-datamon:latest
-        imagePullPolicy: "Always"
+        imagePullPolicy: "$PULL_POLICY"
         command: ["./wrap_datamon.sh"]
         args: ["-s", "-c", "/tmp/coord",
         "-i", "/tmp/bundleid.txt",

--- a/sidecar.Dockerfile
+++ b/sidecar.Dockerfile
@@ -28,7 +28,10 @@ ADD ./hack/fuse-demo/datamon.yaml /root/.datamon/datamon.yaml
 
 # Build the dist image
 FROM ubuntu:latest
-RUN apt-get update && apt-get install -y --no-install-recommends fuse &&\
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fuse \
+    sudo \
+    &&\
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN echo "allow_root" >> /etc/fuse.conf
 
@@ -48,5 +51,10 @@ RUN useradd -u 1020 -ms /bin/bash developer
 RUN groupadd -g 2000 developers
 RUN usermod -g developers developer
 RUN chown -R developer:developers /usr/bin/datamon
+
+RUN mkdir -p /etc/sudoers.d &&\
+  echo "developer ALL = (ALL) NOPASSWD: ALL" > /etc/sudoers.d/developer &&\
+  chmod 0400 /etc/sudoers.d/developer
+
 USER developer
 ENTRYPOINT [ "datamon" ]


### PR DESCRIPTION
adding `sudo` to the sidecar docker image in order to `chgrp` `/dev/fuse` such that `fusermount` via `jacobsa/go-fuse` can open this kernel device file.

see #247 for attempts at kubernetes-specific approaches that avoid `sudo`.