### PR TITLE
release_from_docker_build.sh consistency

### DIFF
--- a/hack/release_from_docker_build.sh
+++ b/hack/release_from_docker_build.sh
@@ -1,18 +1,18 @@
-#! /bin/sh
+#! /bin/zsh
 
 STAGE_DIR=/tmp/datamon-release
 REL_DIR=out/release
 
-if [ -d "$STAGE_DIR" ]; then
-    rm -rf "$STAGE_DIR"
+if [[ -d $STAGE_DIR ]]; then
+    rm -rf $STAGE_DIR
 fi
 
-if [ -d "$REL_DIR" ]; then
-    rm -rf "$REL_DIR"
+if [[ -d $REL_DIR ]]; then
+    rm -rf $REL_DIR
 fi
 
-mkdir -p "$STAGE_DIR"
-mkdir -p "$REL_DIR"
+mkdir -p $STAGE_DIR
+mkdir -p $REL_DIR
 
 docker_container=$(docker create datamon-binaries)
 
@@ -24,7 +24,18 @@ for plat in linux mac; do
     mv "${STAGE_DIR}/${plat}/datamon.${plat}.tgz" "$REL_DIR"
 done
 
+md5exec=
+if command -v md5sum &> /dev/null; then
+    md5exec='md5sum'
+else
+    md5exec=('md5' '-r')
+fi
+
+if [[ -e "${REL_DIR}/datamon.dsc" ]]; then
+    rm "${REL_DIR}/datamon.dsc"
+fi
+
 (cd "$REL_DIR" && \
      for archive in $(ls -1 datamon.*.tgz); do
-         md5sum $archive >> datamon.dsc
+         $md5exec $archive >> datamon.dsc
      done)


### PR DESCRIPTION
this diff contains a couple of changes to make `release_from_docker_build.sh` consistent with internal standards from other scripts:

* `md5`, the OS X builtin is used instead of `md5sum`, the homebrew install
* zsh is used instead of POSIX or bash for those scripts that are part of the datamon internal environment
