### PR TITLE
base docker img, wrap_datamon.sh to zsh, dbg dest store parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - run:
           name: Lint shell scripts
           command: |
-            shellcheck hack/fuse-demo/wrap_*.sh
+            shellcheck hack/fuse-demo/wrap_application.sh
             shellcheck deploy/datamon.sh
       - run:
           name: Ensure metrics

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:
 
 .PHONY: build-and-push-fuse-sidecar
 ## build sidecar container used in Argo workflows
-build-and-push-fuse-sidecar:
+build-and-push-fuse-sidecar: build-datamon-binaries
 	@echo 'building fuse sidecar container'
 	docker build \
 		--progress plain \
@@ -63,7 +63,7 @@ build-and-push-fuse-sidecar:
 
 .PHONY: build-and-push-datamover
 ## build sidecar container used in Argo workflows
-build-and-push-datamover:
+build-and-push-datamover: build-datamon-binaries
 	@echo 'building fuse sidecar container'
 	docker build \
 		--progress plain \
@@ -211,12 +211,12 @@ check: gofmt goimports
 .PHONY: lint-init-scripts
 ## build shell container used in fuse demo
 fuse-demo-lint-init-scripts:
-	shellcheck hack/fuse-demo/wrap_*.sh
+	shellcheck hack/fuse-demo/wrap_application.sh
 
 .PHONY: fuse-demo-build-shell
 ## build shell container used in fuse demo
 fuse-demo-build-shell:
-	@echo 'building fuse demo container'
+	@echo 'building fuse demo application container'
 	docker build \
 		--progress plain \
 		-t gcr.io/onec-co/datamon-fuse-demo-shell \
@@ -227,8 +227,8 @@ fuse-demo-build-shell:
 
 .PHONY: fuse-demo-build-sidecar
 ## build sidecar container used in fuse demo
-fuse-demo-build-sidecar:
-	@echo 'building fuse demo container'
+fuse-demo-build-sidecar: build-and-push-fuse-sidecar
+	@echo 'building fuse demo sidecar container'
 	docker build \
 		--progress plain \
 		-t gcr.io/onec-co/datamon-fuse-demo-sidecar \
@@ -239,9 +239,7 @@ fuse-demo-build-sidecar:
 
 ## demonstrate a fuse read-only filesystem
 fuse-demo-ro: fuse-demo-build-shell fuse-demo-build-sidecar
-	@docker image push gcr.io/onec-co/datamon-fuse-demo-shell
 	@./hack/fuse-demo/create_ro_pod.sh
-	@sleep 8 # dumb timeout on container startup
 	@./hack/fuse-demo/run_shell.sh
 
 .PHONY: fuse-demo-coord-build-app

--- a/binaries.Dockerfile
+++ b/binaries.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as base
+FROM golang:1.13-alpine3.10 as base
 
 RUN mkdir -p /stage/data /stage/etc/ssl/certs &&\
   apk add --no-cache musl-dev gcc ca-certificates mailcap upx tzdata zip git &&\
@@ -29,6 +29,7 @@ RUN go mod download -json
 
 RUN cd ./pkg/web && packr2
 
+# .{os} extension binaries are those distributed via github releases
 RUN LDFLAGS='-s -w -linkmode external -extldflags "-static"' && \
   LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}Version=${VERSION}'" && \
   LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}BuildDate=$(date -u -R)'" && \
@@ -42,3 +43,16 @@ RUN LDFLAGS='-s -w -linkmode internal' && \
   LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}GitCommit=${GIT_COMMIT}'" && \
   LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}GitState=${GIT_DIRTY}'" && \
   CGO_ENABLED=0 GOOS=darwin GOHOSTOS=linux go build -o /stage/usr/bin/datamon.mac --ldflags "$LDFLAGS" ./cmd/datamon
+
+# additional binaries are provided for building distributable docker images
+RUN cp /stage/usr/bin/datamon.linux /stage/usr/bin/datamon && \
+  upx /stage/usr/bin/datamon
+RUN md5sum /stage/usr/bin/datamon
+
+RUN go build -o /stage/usr/bin/migrate --ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/backup2blobs
+RUN upx /stage/usr/bin/migrate
+RUN md5sum /stage/usr/bin/migrate
+
+RUN go build -o /stage/usr/bin/datamon_metrics --ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/metrics
+RUN upx /stage/usr/bin/datamon_metrics
+RUN md5sum /stage/usr/bin/datamon_metrics

--- a/cmd/datamon/cmd/cli_test.go
+++ b/cmd/datamon/cmd/cli_test.go
@@ -278,7 +278,7 @@ func listRepos(t *testing.T) ([]repoListEntry, error) {
 	require.NoError(t, err, "i/o error reading patched log from pipe")
 	//
 	rles := make([]repoListEntry, 0)
-	for _, line := range getDataLogLines(t, string(lb), []string{`Using config file`}) {
+	for _, line := range getDataLogLines(t, string(lb), []string{}) {
 		sl := strings.Split(line, ",")
 		t, err := time.Parse(timeForm, strings.TrimSpace(sl[4]))
 		if err != nil {
@@ -469,7 +469,7 @@ func listBundles(t *testing.T, repoName string) ([]bundleListEntry, error) {
 	lb, err := ioutil.ReadAll(r)
 	require.NoError(t, err, "i/o error reading patched log from pipe")
 	bles := make([]bundleListEntry, 0)
-	for _, line := range getDataLogLines(t, string(lb), []string{`Using config file`}) {
+	for _, line := range getDataLogLines(t, string(lb), []string{}) {
 		sl := strings.Split(line, ",")
 		t, err := time.Parse(timeForm, strings.TrimSpace(sl[1]))
 		if err != nil {
@@ -592,7 +592,7 @@ func listLabels(t *testing.T, repoName string) []labelListEntry {
 	lb, err := ioutil.ReadAll(r)
 	require.NoError(t, err, "i/o error reading patched log from pipe")
 	lles := make([]labelListEntry, 0)
-	for _, line := range getDataLogLines(t, string(lb), []string{`Using config file`}) {
+	for _, line := range getDataLogLines(t, string(lb), []string{}) {
 		sl := strings.Split(line, ",")
 		time, err := time.Parse(timeForm, strings.TrimSpace(sl[2]))
 		require.NoError(t, err, "couldn't parse label list time")
@@ -848,7 +848,7 @@ func TestDiffBundle(t *testing.T) {
 	lb, err := ioutil.ReadAll(r)
 	require.NoError(t, err, "i/o error reading patched log from pipe")
 	des := make([]diffEntry, 0)
-	for _, line := range getDataLogLines(t, string(lb), []string{`Using config file`}) {
+	for _, line := range getDataLogLines(t, string(lb), []string{}) {
 		sl := strings.Split(line, ",")
 		de := diffEntry{
 			rawLine:    line,

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -279,16 +279,14 @@ func paramsToDestStore(params paramsT,
 	var consumableStorePath string
 	var destStore storage.Store
 
-	if tmpdirPrefix != "" {
-		if params.bundle.DataPath != "" {
-			return nil, fmt.Errorf("bundle data path isn't compatible with temp dir usage")
-		}
-		if destT == destTNonEmpty {
-			return nil, fmt.Errorf("can't specify temp dest path and non-empty dir mutually exclusive")
-		}
+	if tmpdirPrefix != "" && params.bundle.DataPath != "" {
+		tmpdirPrefix = ""
 	}
 
 	if tmpdirPrefix != "" {
+		if destT == destTNonEmpty {
+			return nil, fmt.Errorf("can't specify temp dest path and non-empty dir mutually exclusive")
+		}
 		consumableStorePath, err = ioutil.TempDir("", tmpdirPrefix)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create temporary directory: %v", err)

--- a/cmd/datamon/cmd/root.go
+++ b/cmd/datamon/cmd/root.go
@@ -81,9 +81,8 @@ func initConfig() {
 
 	viper.AutomaticEnv() // read in environment variables that match
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		log.Println("Using config file:", viper.ConfigFileUsed())
-	}
+	viper.ReadInConfig() // nolint:errcheck
+	// `viper.ConfigFileUsed()` returns path to config file if error is nil
 	var err error
 	config, err = newConfig()
 	if err != nil {

--- a/datamover.Dockerfile
+++ b/datamover.Dockerfile
@@ -1,48 +1,4 @@
-FROM golang:alpine as base
-
-ADD hack/create-netrc.sh /usr/bin/create-netrc
-
-RUN mkdir -p /stage/data /stage/etc/ssl/certs &&\
-  create-netrc &&\
-  apk add --no-cache musl-dev gcc ca-certificates mailcap upx tzdata zip git bash fuse &&\
-  update-ca-certificates &&\
-  cp /etc/ssl/certs/ca-certificates.crt /stage/etc/ssl/certs/ca-certificates.crt &&\
-  cp /etc/mime.types /stage/etc/mime.types
-
-# https://golang.org/src/time/zoneinfo.go Copy the zoneinfo installed by musl-dev
-WORKDIR /usr/share/zoneinfo
-RUN zip -r -0 /stage/zoneinfo.zip .
-
-ADD . /datamon
-WORKDIR /datamon
-
-
-ARG version_import_path
-ARG version
-ARG commit
-ARG dirty
-
-ENV VERSION_IMPORT_PATH ${version_import_path}
-ENV VERSION ${version}
-ENV GIT_COMMIT ${commit}
-ENV GIT_DIRTY ${dirty}
-
-RUN LDFLAGS='-s -w -linkmode external -extldflags "-static"' && \
-  LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}Version=${VERSION}'" && \
-  LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}BuildDate=$(date -u -R)'" && \
-  LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}GitCommit=${GIT_COMMIT}'" && \
-  LDFLAGS="$LDFLAGS -X '${VERSION_IMPORT_PATH}GitState=${GIT_DIRTY}'" && \
-  go build -o /stage/usr/bin/datamon --ldflags "$LDFLAGS" ./cmd/datamon
-RUN upx /stage/usr/bin/datamon
-RUN md5sum /stage/usr/bin/datamon
-
-RUN go build -o /stage/usr/bin/migrate --ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/backup2blobs
-RUN upx /stage/usr/bin/migrate
-RUN md5sum /stage/usr/bin/migrate
-
-RUN go build -o /stage/usr/bin/datamon_metrics --ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/metrics
-RUN upx /stage/usr/bin/datamon_metrics
-RUN md5sum /stage/usr/bin/datamon_metrics
+FROM datamon-binaries as base
 
 ####
 # Build the dist image

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/timakin/bodyclose v0.0.0-20190721030226-87058b9bfcec h1:AmoEvWAO3nDx1MEcMzPh+GzOOIA5Znpv6++c7bePPY0=

--- a/hack/fuse-demo/coord-datamon.Dockerfile
+++ b/hack/fuse-demo/coord-datamon.Dockerfile
@@ -11,4 +11,4 @@ USER developer
 # ADD hack/fuse-demo/datamon.yaml /home/developer/.datamon/datamon.yaml
 
 ENTRYPOINT ["./wrap_datamon.sh"]
-CMD ["-c", "/tmp/coord", "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo", "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --destination /tmp --mount /tmp/mount --stream"]
+CMD ["-c", "/tmp/coord", "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo", "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream"]

--- a/hack/fuse-demo/create_ro_pod.sh
+++ b/hack/fuse-demo/create_ro_pod.sh
@@ -68,9 +68,8 @@ else
         echo 'bundle id and label are mutually exclusive' 1>&2
         exit 1
     fi
-    bundle_id=$("$DATAMON_EXEC" label list --repo "$repo_name" 2>&1 | \
-                    grep '^'"$label" | \
-                    cut -d',' -f2 | sed 's/ //g')
+    bundle_id=$(2>&1 "$DATAMON_EXEC" label get --repo "$repo_name" --label "$label" | \
+                    cut -d ',' -f 2 | tr -d ' ')
     if [ "$bundle_id" = '' ]; then
         echo "couldn't find bundle if for label $label" 1>&2
         exit 1

--- a/hack/fuse-demo/run_shell.sh
+++ b/hack/fuse-demo/run_shell.sh
@@ -15,12 +15,15 @@ while getopts s opt; do
 done
 (( OPTIND > 1 )) && shift $(( OPTIND - 1 ))
 
-pod_name=$(kubectl get pods -l app=datamon-ro-demo | grep Running | sed 's/ .*//')
+STARTUP_POLL_INTERVAL=1
+typeset pod_name
 
-if [[ -z $pod_name ]]; then
-	echo 'fuse demo pod not found' 1>&2
-	exit 1
-fi
+print -- "waiting on pod start"
+
+while [[ -z $pod_name ]]; do
+    sleep "$STARTUP_POLL_INTERVAL"
+    pod_name=$(kubectl get pods -l app=datamon-ro-demo | grep Running | sed 's/ .*//')
+done
 
 kubectl exec -it "$pod_name" \
         -c "$container_name" \

--- a/hack/fuse-demo/wrap_datamon.sh
+++ b/hack/fuse-demo/wrap_datamon.sh
@@ -1,17 +1,20 @@
-#! /bin/sh
+#! /bin/zsh
 
 ### datamon wrapper (demo)
 # half of the container coordination sketch, a script like this one
 # is meant to wrap datamon in the sidecar container of an Argo DAG node
 # and communciate with a script like wrap_application.sh.
 
+setopt ERR_EXIT
+setopt PIPE_FAIL
+
 POLL_INTERVAL=1 # sec
 
 #####
 
-COORD_POINT=
-DATAMON_CMDS=
-BUNDLE_ID_FILE=
+typeset COORD_POINT
+typeset -a DATAMON_CMDS
+typeset BUNDLE_ID_FILE
 
 SLEEP_INSTEAD_OF_EXIT=
 
@@ -26,7 +29,7 @@ while getopts sc:d:i: opt; do
         (d)
             datamon_cmd=$(echo "$OPTARG" |tr '\t' ' ' |tr -s ' ' | \
                               sed 's/^ //' |sed 's/ $//')
-            DATAMON_CMDS="${DATAMON_CMDS}:${datamon_cmd}"
+            DATAMON_CMDS=($datamon_cmd $DATAMON_CMDS)
             ;;
         (i)
             BUNDLE_ID_FILE="$OPTARG"
@@ -37,79 +40,68 @@ while getopts sc:d:i: opt; do
             ;;
     esac
 done
-if [ "$OPTIND" -gt 1 ]; then
+if [[ "$OPTIND" -gt 1 ]]; then
     shift $(( OPTIND - 1 ))
 fi
 
-DATAMON_CMDS=$(echo "$DATAMON_CMDS" |sed 's/^://')
-
-if [ -z "$DATAMON_CMDS" ]; then
+if [[ $#DATAMON_CMDS -eq 0 ]]; then
     echo "no datamon cmds to run" 1>&2
     exit 1
 fi
-if [ -z "$COORD_POINT" ]; then
+if [[ -z $COORD_POINT ]]; then
     echo "coordination point not set" 1>&2
     exit 1
 fi
 
 echo "getopts checks ok"
 
-num_upload_cmds=0
-UPLOAD_CMDS=
-MOUNT_CMDS=
-CONFIG_CMD=
+typeset -a UPLOAD_CMDS
+typeset -a MOUNT_CMDS
+typeset CONFIG_CMD
 
-ifs_orig="$IFS"
-IFS=':'
 for datamon_cmd in $DATAMON_CMDS; do
-    if ! echo "$datamon_cmd" | grep -q '^bundle'; then
-        if ! echo "$datamon_cmd" | grep -q '^config'; then
-            echo "only bundle and config commands supported.  got '$datamon_cmd'." 1>&2
-            exit 1
-        else
-            if [ -n "$CONFIG_CMD" ]; then
-                echo "expected at most one 'config' command" 1>&2
+    if print $datamon_cmd | grep -q '^bundle'; then
+        bundle_cmd_name=$(echo "$datamon_cmd" |sed 's/[^ ]* \([^ ]*\).*/\1/')
+        case $bundle_cmd_name in
+            (upload)
+                UPLOAD_CMDS=($datamon_cmd $UPLOAD_CMDS)
+                ;;
+            (mount)
+                MOUNT_CMDS=($datamon_cmd $MOUNT_CMDS)
+                ;;
+            (\?)
+                echo "unsupported datamon bundle command '$bundle_cmd_name' " \
+                     "in '$datamon_cmd'" 1>&2
                 exit 1
-            fi
-            CONFIG_CMD="$datamon_cmd"
-        fi
-        else
-            bundle_cmd_name=$(echo "$datamon_cmd" |sed 's/[^ ]* \([^ ]*\).*/\1/')
-            case $bundle_cmd_name in
-                (upload)
-                    num_upload_cmds="$((num_upload_cmds + 1))"
-                    UPLOAD_CMDS="$UPLOAD_CMDS:$datamon_cmd"
-                    ;;
-                (mount)
-                    MOUNT_CMDS="$MOUNT_CMDS:$datamon_cmd"
-                    ;;
-                (\?)
-                    echo "unsupported datamon bundle command '$bundle_cmd_name' " \
-                         "in '$datamon_cmd'" 1>&2
-                    exit 1
-                    ;;
-            esac
+                ;;
+        esac
+        continue
     fi
+    if ! print $datamon_cmd | grep -q '^config'; then
+        echo "only bundle and config commands supported.  got '$datamon_cmd'." 1>&2
+        exit 1
+    fi
+    if [[ -n $CONFIG_CMD ]]; then
+        echo "expected at most one 'config' command" 1>&2
+        exit 1
+    fi
+    CONFIG_CMD="$datamon_cmd"
 done
-IFS="$ifs_orig"
 
-if [ -n "$BUNDLE_ID_FILE" ]; then
-    bundle_id_file_dir="$(dirname "$BUNDLE_ID_FILE")"
-    if [ ! -d "$bundle_id_file_dir" ]; then
+if [[ -n "$BUNDLE_ID_FILE" ]]; then
+    bundle_id_file_dir=$(dirname "$BUNDLE_ID_FILE")
+    if [[ ! -d "$bundle_id_file_dir" ]]; then
         mkdir -p "$bundle_id_file_dir"
     fi
-    if [ -f "$BUNDLE_ID_FILE" ]; then
+    if [[ -f "$BUNDLE_ID_FILE" ]]; then
         echo "$BUNDLE_ID_FILE already exists" 1>&2
         exit 1
     fi
-    if [ ! "$num_upload_cmds" -eq 1 ]; then
+    if [[ ! $#UPLOAD_CMDS -eq 1 ]]; then
         echo "expected precisley one upload command when bundle id file specified" 1>&2
         exit 1
     fi
 fi
-
-UPLOAD_CMDS=$(echo "$UPLOAD_CMDS" |sed 's/^://')
-MOUNT_CMDS=$(echo "$MOUNT_CMDS" |sed 's/^://')
 
 #####
 
@@ -121,14 +113,14 @@ await_event() {
     EVENT_NAME="$1"
     DBG_MSG="$2"
     DBG_POLLS="$3"
-    if [ -n "$DBG_MSG" ]; then
+    if [[ -n $DBG_MSG ]]; then
         echo "$DBG_MSG"
     fi
-    while [ -z "$COORD_DONE" ]; do
-        if [ -f "${COORD_POINT}/${EVENT_NAME}" ]; then
+    while [[ -z $COORD_DONE ]]; do
+        if [[ -f "${COORD_POINT}/${EVENT_NAME}" ]]; then
             COORD_DONE=1
         fi
-        if [ -n "$DBG_POLLS" ]; then
+        if [[ -n $DBG_POLLS ]]; then
             echo "... $DBG_MSG ..."
         fi
         sleep "$POLL_INTERVAL"
@@ -144,107 +136,101 @@ emit_event() {
 }
 
 run_datamon_cmd() {
+    typeset params_param
+    typeset -a params
+    typeset stat
     params_param="$1"
-    set --
-    params_param_rem=$(echo "$params_param" |tr '\t' ' ' |tr -s ' ')
-    while [ -n "$params_param_rem" ]; do
-        params_param_rem=$(echo "$params_param_rem" |sed 's/^ //')
-        if echo "$params_param_rem" |grep -q "^'"; then
-            next_param=$(echo "$params_param_rem" |sed "s/^'\\([^']*\\)'.*/\\1/")
-            if [ -z "$next_param" ]; then
-                echo "unterminated quote in params string" 1>&2
-                exit 1
-            fi
-            params_param_rem=$(echo "$params_param_rem" |sed "s/^'[^']*'//")
-        else
-            if echo "$params_param_rem" |grep -q '^"'; then
-                next_param=$(echo "$params_param_rem" |sed 's/^"\([^"]*\)".*/\1/')
-                if [ -z "$next_param" ]; then
-                    echo "unterminated quote in params string" 1>&2
-                    exit 1
-                fi
-                params_param_rem=$(echo "$params_param_rem" |sed 's/^"[^"]*"//')
-            else
-                next_param=$(echo "$params_param_rem" |sed 's/^\([^ ]*\).*/\1/')
-                params_param_rem=$(echo "$params_param_rem" |sed 's/^[^ ]*//')
-            fi
-        fi
-        set -- "$@" "$next_param"
-    done
-    datamon "$@"
-    stat="$?"
-    if [ "$stat" != '0' ]; then
-        return "$stat"
+    # split string according to shell parsing, remove quotes
+    # http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion-Flags
+    params=(${(Q)${(z)params_param}})
+    datamon $params
+    return $?
+}
+
+dbg_print() {
+    typeset dbg=true
+    if $dbg; then
+        print -- $*
     fi
 }
 
-if [ -n "$CONFIG_CMD" ]; then
+dbg_print "have zsh version $ZSH_VERSION"
+
+if [[ -n $CONFIG_CMD ]]; then
     run_datamon_cmd "$CONFIG_CMD"
 fi
 
 ## COORDINATION BEGINS by starting a datamon FUSE mount
-echo "starting mounts '$MOUNT_CMDS'"
+echo "starting ${#MOUNT_CMDS} mounts '$MOUNT_CMDS'"
 
 # in some kubernetes distros like docker-desktop, /dev/fuse has perms 660 rather than 666
 echo "setting privs on fuse device"
 sudo chgrp developers /dev/fuse
 
-mount_points=
-mount_idx=0
-datamon_pids=
-ifs_orig="$IFS"
-IFS=':'
+typeset -a mount_points
+typeset -i mount_idx
+typeset -a datamon_pids
 for mount_cmd in $MOUNT_CMDS; do
-    mount_point=$(echo "$mount_cmd" |sed 's/^.*--mount//' |sed 's/^ *//' |sed 's/ .*//')
-    if [ -z "$mount_point" ]; then
+    dbg_print "running mount command '${mount_cmd}' (${mount_idx})"
+    mount_cmd_params=(${(Q)${(z)mount_cmd}})
+    mount_flag_idx=${mount_cmd_params[(ie)--mount]}
+    if [[ $mount_flag_idx -ge ${#mount_cmd_params} ]]; then
+        print -- "didn't find --mount flag parameter in '$mount_cmd'" 1>&2
+        exit 1
+    fi
+    mount_point=${mount_cmd_params[$((mount_flag_idx + 1))]}
+    if [[ -z $mount_point ]]; then
         echo "didn't find mount point in '$mount_cmd'" 1>&2
-        exit
+        exit 1
     fi
-    if [ ! -d "$mount_point" ]; then
+    if [[ ! -d "$mount_point" ]]; then
         echo "'$mount_point' doesn't exist" 1>&2
-        exit
+        exit 1
     fi
-    IFS="$ifs_orig"
     log_file_mount="/tmp/datamon_mount.${mount_idx}.log"
-    run_datamon_cmd "$mount_cmd" > "$log_file_mount" 2>&1 &
-    IFS=':'
-    datamon_status="$?"
-    datamon_pid="$!"
+    unsetopt ERR_EXIT
+    run_datamon_cmd $mount_cmd > "$log_file_mount" 2>&1 &
+    datamon_status=$?
+    datamon_pid=$!
+    setopt ERR_EXIT
     echo "started datamon '$mount_cmd' with pid $datamon_pid"
 
-    if [ "$datamon_status" != "0" ]; then
+    if [[ ! $datamon_status -eq 0 ]]; then
         echo "error starting datamon $mount_cmd, try shell" 2>&1
         cat "$log_file_mount"
         sleep 3600
         exit 1
     fi
-    mount_idx=$((mount_idx + 1))
-    datamon_pids="$datamon_pids $datamon_pid"
-    mount_points="$mount_points:$mount_point"
+    dbg_print "datamon status checks out okay"
+    ((mount_idx++)) || true
+    dbg_print "mount idx incremented"
+    datamon_pids=($datamon_pid $datamon_pids)
+    dbg_print "updated datamon pids"
+    mount_points=($mount_point $mount_points)
+    dbg_print "updated datamon mount points"
 done
-IFS="$ifs_orig"
 
-datamon_pids=$(echo "$datamon_pids" |sed 's/^ //')
-mount_points=$(echo "$mount_points" |sed 's/^://')
+dbg_print "out of mount for loop"
 
-echo "started datamon mounts with pids '$datamon_pids,' mount_points '$mount_points'"
+echo "started datamon mounts with pids '${datamon_pids},' mount_points '${mount_points}'"
 
 echo "waiting on datamon mount (datamon wrap)"
 
+typeset -a found_mount_points
 MOUNT_COORD_DONE=
-while [ -z "$MOUNT_COORD_DONE" ]; do
-    found_mount_idx=0
+while [[ -z $MOUNT_COORD_DONE ]]; do
     mount_data=$(mount | cut -d" " -f 3,5)
-    ifs_orig="$IFS"
-    IFS=':'
     for mount_point in $mount_points; do
+        if ((${found_mount_points[(Ie)$mount_point]})); then
+            # mount point already found
+            continue
+        fi
         if echo "$mount_data" | grep -q "^$mount_point fuse$"; then
-            found_mount_idx=$((found_mount_idx + 1))
+            found_mount_points=($mount_point $found_mount_points)
         fi
     done
-    IFS="$ifs_orig"
-    echo "$found_mount_idx / $mount_idx fuse mounts found"
-    if [ "$mount_idx" = "$found_mount_idx" ]; then
+    echo "${#found_mount_points} / ${#mount_points} fuse mounts found"
+    if [[ ${#found_mount_points} -eq ${#mount_points} ]]; then
         MOUNT_COORD_DONE=1
     fi
     sleep "$POLL_INTERVAL"
@@ -272,41 +258,59 @@ echo "starting datamon upload"
 
 ## notify the the application if the upload was successful, and exit this container in any case
 
-upload_idx=0
-ifs_orig="$IFS"
-IFS=':'
+typeset -i upload_idx
 for upload_cmd in $UPLOAD_CMDS; do
-    IFS="$ifs_orig"
+    dbg_print "running upload command '${upload_cmd}' (${upload_idx})"
     log_file_upload="/tmp/datamon_upload.${upload_idx}.log"
-    bundle_id=$(2>&1 run_datamon_cmd "$upload_cmd" | \
-                    tee "$log_file_upload" | \
-                    grep 'Uploaded bundle id' | \
-                    tail -1 | \
-                    sed 's/Uploaded bundle id:\(.*\)/\1/')
-    datamon_status="$?"
-    if [ "$datamon_status" != 0 ]; then
+    unsetopt ERR_EXIT
+    run_datamon_cmd "$upload_cmd" > "$log_file_upload" 2>&1
+    datamon_status=$?
+    setopt ERR_EXIT
+    if [[ ! $datamon_status -eq 0 ]]; then
+        dbg_print "upload command failed"
         echo "error starting datamon $upload_cmd, try shell" 2>&1
         cat "$log_file_upload"
         sleep 3600
         exit 1
     fi
-    if [ -n "$BUNDLE_ID_FILE" ]; then
-        if [ -f "$BUNDLE_ID_FILE" ]; then
+    dbg_print "upload command had nominal status"
+    if [[ -n $BUNDLE_ID_FILE ]]; then
+        if [[ -f "$BUNDLE_ID_FILE" ]]; then
             echo "$BUNDLE_ID_FILE already exists" 1>&2
+            exit 1
+        fi
+        dbg_print "getting bundle id lines"
+        unsetopt ERR_EXIT
+        bundle_id_lines=$(cat "$log_file_upload" | grep 'Uploaded bundle id')
+        bundle_id_lines_status=$?
+        setopt ERR_EXIT
+        if [[ ! $bundle_id_lines_status -eq 0 ]]; then
+            print "didn't find any bundle id lines" 1>&2
+            sleep 3600
+            exit 1
+        fi
+        dbg_print "have bundle id lines ${bundle_id_lines}"
+        unsetopt ERR_EXIT
+        bundle_id=$(print -- ${bundle_id_lines} | \
+                        tail -1 | \
+                        sed 's/Uploaded bundle id:\(.*\)/\1/')
+        bundle_id_status=$?
+        setopt ERR_EXIT
+        if [[ ! $bundle_id_status -eq 0 ]]; then
+            print "didn't parse bundle id out of ${bundle_id_lines}" 1>&2
+            sleep 3600
             exit 1
         fi
         echo "$bundle_id" > "$BUNDLE_ID_FILE"
     fi
-    IFS=':'
-    upload_idx=$((upload_idx + 1))
+    ((upload_idx++)) || true
 done
-IFS="$ifs_orig"
 
 emit_event \
     'uploaddone' \
     'dispatching upload done event'
 
-if [ -z "$SLEEP_INSTEAD_OF_EXIT" ]; then
+if [[ -z $SLEEP_INSTEAD_OF_EXIT ]]; then
     exit 0
 fi
 

--- a/hack/k8s/example-coord.template.yaml
+++ b/hack/k8s/example-coord.template.yaml
@@ -49,7 +49,7 @@ spec:
         "-i", "/tmp/bundleid.txt",
         "-d", "config create --name \"Coord\" --email coord-bot@oneconcern.com",
         "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo",
-        "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --destination /tmp --mount /tmp/mount --stream"]
+        "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream"]
         securityContext:
           privileged: true
         stdin: true

--- a/hack/k8s/example-ro.template.yaml
+++ b/hack/k8s/example-ro.template.yaml
@@ -31,7 +31,6 @@ spec:
         args: ["bundle", "mount",
         "--repo", "$REPO_NAME",
         "--bundle", "$BUNDLE_ID",
-        "--destination", "/tmp",
         "--mount", "/tmp/mount",
         "--stream"]
         securityContext:

--- a/sidecar.Dockerfile
+++ b/sidecar.Dockerfile
@@ -1,36 +1,16 @@
-FROM golang:alpine as base
-
-ADD hack/create-netrc.sh /usr/bin/create-netrc
-
-RUN mkdir -p /stage/data /stage/etc/ssl/certs &&\
-  create-netrc &&\
-  apk add --no-cache musl-dev gcc ca-certificates mailcap upx tzdata zip git bash fuse &&\
-  update-ca-certificates &&\
-  cp /etc/ssl/certs/ca-certificates.crt /stage/etc/ssl/certs/ca-certificates.crt &&\
-  cp /etc/mime.types /stage/etc/mime.types
-
-# https://golang.org/src/time/zoneinfo.go Copy the zoneinfo installed by musl-dev
-WORKDIR /usr/share/zoneinfo
-RUN zip -r -0 /stage/zoneinfo.zip .
-
-ADD . /datamon
-WORKDIR /datamon
-
-RUN go build -o /stage/usr/bin/datamon --ldflags '-s -w -linkmode external -extldflags "-static"' ./cmd/datamon
-RUN upx /stage/usr/bin/datamon
-RUN md5sum /stage/usr/bin/datamon
-
+FROM datamon-binaries as base
 
 # dist-alike during development/debug
 RUN cp /stage/usr/bin/datamon /usr/bin/datamon
-
 ADD ./hack/fuse-demo/datamon.yaml /root/.datamon/datamon.yaml
 
 # Build the dist image
-FROM ubuntu:latest
+FROM ubuntu:18.10
 RUN apt-get update && apt-get install -y --no-install-recommends \
     fuse \
     sudo \
+    vim \
+    zsh \
     &&\
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN echo "allow_root" >> /etc/fuse.conf


### PR DESCRIPTION
this patch clears the ground a bit for #256 and other datamon kubernetes "batteries":

* all docker images that require building binaries from golang source are based on `binaries.Dockerfile`, and this is the only docker image that includes `go build` steps
* `wrap_datamon.sh` is converted to zsh.  `wrap_application.sh` is still POSIX sh so that it can be run within any application container from a shared volume.  the battery-specific scripts, on the other hand, run within their respective images and can use any interpreter made available within those docker images
* 3dbeae5d introduced a bug wherein it wasn't possible to specify `--destination` on the `bundle mount` command.  this commit both fixes that bug as well as changes the demo to omit the `--destination` flag such that a temporary directory is used, probably a saner default to recommend to users.