### PR TITLE
feat(bundle): Channel simplified func

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ mocks:
 
 .PHONY: runtests
 runtests: mocks
-	@go test ./...
+	@go test -v ./cmd/datamon//cmd
 
 .PHONY: gofmt
 ## Run gofmt on the cmd and pkg packages

--- a/cmd/datamon/cmd/cli_test.go
+++ b/cmd/datamon/cmd/cli_test.go
@@ -463,7 +463,7 @@ func (b bundleListEntries) Len() int {
 	return len(b)
 }
 func (b bundleListEntries) Less(i, j int) bool {
-	return b[i].time.Before(b[j].time)
+	return b[i].hash < b[j].hash
 }
 func (b bundleListEntries) Last() bundleListEntry {
 	return b[len(b)-1]
@@ -493,12 +493,15 @@ func listBundles(t *testing.T, repoName string) (bundleListEntries, error) {
 		}
 		rle := bundleListEntry{
 			rawLine: line,
-			hash:    strings.TrimSpace(sl[0]),
+			hash:    strings.TrimSpace(sl[0]), // bundle key ID
 			message: strings.TrimSpace(sl[2]),
 			time:    t,
 		}
 		bles = append(bles, rle)
 	}
+	// bundles are ordered by lexicographic order of keys (ksuids).
+	require.True(t, sort.IsSorted(bles))
+
 	sort.Sort(bles) // sort test result by timestamp
 	return bles, nil
 }
@@ -521,7 +524,6 @@ func testListBundle(t *testing.T, file uploadTree, bcnt int) {
 	require.NoError(t, err, "error out of listBundles() test helper")
 	require.Equal(t, bcnt, bundles.Len(), "bundle count in test repo")
 
-	// ordering of bundles is not strictly required
 	found := false
 	for _, b := range bundles {
 		if msg == b.message {

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -52,6 +52,7 @@ type paramsT struct {
 	}
 	core struct {
 		ConcurrencyFactor int
+		BatchSize         int
 	}
 }
 
@@ -143,9 +144,17 @@ func addCoreConcurrencyFactorFlag(cmd *cobra.Command) string {
 	// this takes the usual "concurrency-factor" flag, but sets non-object specific settings
 	concurrencyFactor := concurrencyFactorFlag
 	cmd.Flags().IntVar(&params.core.ConcurrencyFactor, concurrencyFactor, 100,
-		"Heuristic on the amount of concurrency used by core operations (e.g. bundle list).  "+
+		"Heuristic on the amount of concurrency used by core operations (e.g. bundle list). "+
+			"Concurrent retrieval of bundle metadata is capped by the 'batch-size' parameter. "+
 			"Turn this value down to use less memory, increase for faster operations.")
 	return concurrencyFactor
+}
+
+func addBatchSizeFlag(cmd *cobra.Command) string {
+	batchSize := "batch-size"
+	cmd.Flags().IntVar(&params.core.BatchSize, batchSize, 1024,
+		"Number of bundle keys fetched per rountrip to storage -- keys are 20B long, defaults corresponds to 20kB pages")
+	return batchSize
 }
 
 func addWebPortFlag(cmd *cobra.Command) string {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ replace github.com/spf13/cobra => github.com/babysnakes/cobra v0.0.2-0.201806031
 
 replace github.com/spf13/pflag => github.com/spf13/pflag v1.0.3
 
+replace go.uber.org/goleak => go.uber.org/goleak v0.10.1-0.20190823232112-227bd74c3482
+
 require (
 	cloud.google.com/go v0.37.1
 	github.com/aws/aws-sdk-go v1.18.6
@@ -39,6 +41,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
+	go.uber.org/goleak v0.0.0-00010101000000-000000000000
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,8 @@ go.opencensus.io v0.19.1 h1:gPYKQ/GAQYR2ksU+qXNmq3CrOZWT1kkryvW6O0v1acY=
 go.opencensus.io v0.19.1/go.mod h1:gug0GbSHa8Pafr0d2urOSgoXHZ6x/RUlaiT0d9pqb4A=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/goleak v0.10.1-0.20190823232112-227bd74c3482 h1:XWhmT83tvdC3rYK6oelyqcEgLqbL/g5XjE/QOAf+1js=
+go.uber.org/goleak v0.10.1-0.20190823232112-227bd74c3482/go.mod h1:VCZuO8V8mFPlL0F5J5GK1rtHV3DrFcQ1R8ryq7FK0aI=
 go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
@@ -365,7 +367,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/pkg/core/bundle_list.go
+++ b/pkg/core/bundle_list.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"strings"
+	"sort"
 	"sync"
+
+	"errors"
 
 	"gopkg.in/yaml.v2"
 
 	"github.com/oneconcern/datamon/pkg/model"
 	"github.com/oneconcern/datamon/pkg/storage"
+	"github.com/oneconcern/datamon/pkg/storage/status"
 )
 
 const (
 	maxMetaFilesToProcess = 1000000
-	typicalBundlesNum     = 1000
+	typicalBundlesNum     = 1000 // default number of allocated slots for bundles in a repo
 )
 
 func minInt(a, b int) int {
@@ -25,29 +28,339 @@ func minInt(a, b int) int {
 	return b
 }
 
-// ListBundles returns the list of bundle descriptors from a repo.
+// ErrInterrupted signals that the current background processing is interrupted
+var ErrInterrupted = errors.New("background processing interrupted")
+
+// DoSelectBundles is a helper function to listen on a channel of batches of bundle descriptors and an error channel.
 //
-// NOTE: resulting bundles are returned in no particular order.
+// It applies some function on the received batches and returns an error if one appears on the error channel.
 //
-// TODO: return a paginated list of id<->bd (separate function in repo_list.go)
-func ListBundles(repo string, store storage.Store, opts ...BundleListOption) ([]model.BundleDescriptor, error) {
-	settings := CoreSettings{concurrentBundleList: defaultBundleListConcurrency}
+// Example usage:
+//
+//		err := DoSelectBundles(bundlesChan, errChan, func(bundleBatch model.BundleDescriptors) {
+//			bundles = append(bundles, bundleBatch...)
+//		})
+func DoSelectBundles(bundlesChan <-chan model.BundleDescriptors, errorChan <-chan error, do func(model.BundleDescriptors)) error {
+	var err error
+
+LOOP:
+	// consume batches of ordered bundle metadata
+	for {
+		select {
+		case bundleBatch, ok := <-bundlesChan:
+			if !ok {
+				// last attempt to catch an error
+				// (i.e. bundlesChan has closed, but an error was also present on errorChan and hasn't been selected)
+				if err == nil {
+					if e, ok := <-errorChan; ok {
+						err = e
+					}
+				}
+				break LOOP
+			}
+			do(bundleBatch)
+		case e, ok := <-errorChan: // do not exit here: the only natural exit occurs when bundlesChan is closed
+			if ok && err == nil { // retain first error
+				err = e
+			}
+		}
+	}
+
+	return err
+}
+
+// ApplyBundleFunc is a function to be applied on a bundle
+type ApplyBundleFunc func(model.BundleDescriptor) error
+
+// ListBundlesApply applies some function to the retrieved bundles, in lexicographic order of keys.
+//
+// The execution of the applied function does not block background retrieval of more keys and bundle descriptors.
+//
+// Example usage: printing bundle descriptors as they come
+//
+//   err := core.ListBundlesApply(repo, store, func(bundle model.BundleDescriptorOption) error {
+//				fmt.Fprintf(os.Stderr, "%v\n", bundle)
+//				return nil
+//			})
+func ListBundlesApply(repo string, store storage.Store, apply ApplyBundleFunc, opts ...BundleListOption) error {
+	var (
+		err, applyErr error
+		wg            sync.WaitGroup
+		workDone      bool
+		mutex         sync.Mutex
+	)
+
+	bundleChan := make(chan model.BundleDescriptor)
+	doneChan := make(chan struct{}, 1)
+
+	// collect bundle metadata asynchronously
+	wg.Add(1)
+	go func(bundleChan chan<- model.BundleDescriptor, doneChan chan struct{}, wg *sync.WaitGroup) {
+		defer func() {
+			close(bundleChan)
+			wg.Done()
+		}()
+
+		bundlesChan, errChan, workers := ListBundlesChan(repo, store, append(opts, WithBundleDoneChan(doneChan))...)
+
+		err = DoSelectBundles(bundlesChan, errChan, func(bundleBatch model.BundleDescriptors) {
+			for _, bundle := range bundleBatch {
+				bundleChan <- bundle // transfer a batch of metadata to the applied func
+			}
+		})
+
+		mutex.Lock()
+		workDone = true // nothing left to interrupt
+		close(doneChan)
+		mutex.Unlock()
+
+		workers.Wait()
+	}(bundleChan, doneChan, &wg)
+
+	// apply function on collected metadata
+	for bundle := range bundleChan {
+		if applyErr = apply(bundle); applyErr != nil {
+			// wind down goroutines, but if interrupt channel is already closed (i.e nothing left to be interrupted)
+			mutex.Lock()
+			if !workDone {
+				doneChan <- struct{}{}
+			}
+			mutex.Unlock()
+			for range bundleChan {
+			} // wait for close
+			break
+		}
+	}
+	wg.Wait()
+	// collect errors
+	switch {
+	case err == ErrInterrupted && applyErr != nil:
+		return applyErr
+	case err != nil:
+		return err
+	case applyErr != nil:
+		return applyErr
+	default:
+		return nil
+	}
+}
+
+// ListBundles returns a list of bundle descriptors from a repo. It collects all bundles until completion.
+func ListBundles(repo string, store storage.Store, opts ...BundleListOption) (model.BundleDescriptors, error) {
+	bundles := make(model.BundleDescriptors, 0, typicalBundlesNum)
+
+	bundlesChan, errChan, workers := ListBundlesChan(repo, store, opts...)
+
+	// consume batches of ordered bundles
+	err := DoSelectBundles(bundlesChan, errChan, func(bundleBatch model.BundleDescriptors) {
+		bundles = append(bundles, bundleBatch...)
+	})
+
+	workers.Wait()
+
+	return bundles, err // we may have some batches resolved before the error occurred
+}
+
+// ListBundlesChan returns a list of bundle descriptors from a repo. Each batch of returned descriptors
+// is sent on the output channel, following key lexicographic order.
+//
+// Simple use cases of this helper are wrapped in ListBundles (block until completion) and ListBundlesApply
+// (apply function while retrieving metadata).
+//
+// An optional signaling channel may be given as option to interrupt background processing (e.g. on error).
+//
+// The sync.WaitGroup for internal goroutines is returned if caller wants to wait and avoid any leaked goroutines.
+func ListBundlesChan(repo string, store storage.Store, opts ...BundleListOption) (chan model.BundleDescriptors, chan error, *sync.WaitGroup) {
+	var (
+		wg, wg2 sync.WaitGroup
+	)
+
+	settings := defaultCoreSettings()
 	for _, bApply := range opts {
 		bApply(&settings)
 	}
 
-	// Get a list
-	e := RepoExists(repo, store)
-	if e != nil {
-		return nil, e
+	batchChan := make(chan model.BundleDescriptors)
+	errorChan := make(chan error, 1) // buffering early errors avoids blocking without dropping the message
+
+	if err := RepoExists(repo, store); err != nil {
+		errorChan <- err
+		close(batchChan)
+		close(errorChan)
+		return batchChan, errorChan, &wg
 	}
 
-	// this call is not made async yet
-	ks, _, err := store.KeysPrefix(context.Background(), "", model.GetArchivePathPrefixToBundles(repo), "/", maxMetaFilesToProcess)
-	if err != nil {
-		return nil, err
+	// signaling channels
+	doneWithKeysChan := make(chan struct{}, 1)
+	doneWithBundlesChan := make(chan struct{}, 1)
+
+	if settings.doneChannel != nil {
+		// watch for an interruption signal requested by caller
+		wg.Add(1)
+		go watchForInterrupts(settings.doneChannel, &wg, doneWithKeysChan, doneWithBundlesChan)
 	}
 
+	keysChan := make(chan []string)
+	keyErrorChan := make(chan error)
+	bundleErrorChan := make(chan error)
+
+	// listening to errors from slave goroutines
+	wg.Add(1)
+	go watchForErrors(keyErrorChan, bundleErrorChan, errorChan, doneWithKeysChan, doneWithBundlesChan, &wg)
+
+	// starting keys retrieval
+	wg.Add(1)
+	go fetchKeys(repo, store, settings, keysChan, keyErrorChan, doneWithKeysChan, &wg) // scan for key batches
+
+	// start bundle metadata retrieval
+	wg.Add(1)
+	go fetchBundles(repo, store, settings, keysChan, batchChan, bundleErrorChan, doneWithBundlesChan, &wg)
+
+	// cleanup internal signaling channels
+	wg2.Add(1)
+	go func(wg, wg2 *sync.WaitGroup, inputChans ...chan<- struct{}) {
+		defer wg2.Done()
+		wg.Wait()
+		for _, ch := range inputChans {
+			close(ch)
+		}
+	}(&wg, &wg2, doneWithKeysChan, doneWithBundlesChan)
+
+	// return at once. Caller may chose to wait on returned WaitGroup
+	return batchChan, errorChan, &wg2
+}
+
+// watchForInterrupts broadcasts a done signal to several output channels
+func watchForInterrupts(doneChan <-chan struct{}, wg *sync.WaitGroup, outputChans ...chan<- struct{}) {
+	defer func() {
+		wg.Done()
+	}()
+
+	if _, interrupt := <-doneChan; interrupt {
+		for _, outputChan := range outputChans {
+			outputChan <- struct{}{}
+		}
+	}
+}
+
+// watchForErrors listens on 2 independent errors channels and report back to a main error channel.
+//
+// NOTE: this one does not need signaling, since any interruption bubbles up as error.
+func watchForErrors(
+	errorChan1, errorChan2 <-chan error,
+	outputChan chan<- error,
+	doneChan1, doneChan2 chan<- struct{}, wg *sync.WaitGroup) {
+	defer func() {
+		close(outputChan)
+		wg.Done()
+	}()
+
+	var (
+		err                            error
+		errorChan1Open, errorChan2Open bool = true, true
+	)
+	for errorChan1Open || errorChan2Open { // wait on both channels to close
+		select {
+		case err, errorChan1Open = <-errorChan1:
+			if errorChan1Open {
+				outputChan <- err
+				doneChan2 <- struct{}{}
+			} else {
+				errorChan1 = nil // no more selected case on this one
+				break
+			}
+		case err, errorChan2Open = <-errorChan2:
+			if errorChan2Open {
+				doneChan1 <- struct{}{}
+				outputChan <- err
+			} else {
+				errorChan2 = nil // no more selected case on this one
+				break
+			}
+		}
+	}
+}
+
+// fetchBundles waits on a channel of key batches and outputs batches of descriptors corresponding to these keys
+func fetchBundles(repo string, store storage.Store, settings CoreSettings,
+	keysChan <-chan []string,
+	batchChan chan<- model.BundleDescriptors, errorChan chan<- error,
+	doneChan <-chan struct{}, wg *sync.WaitGroup) {
+	defer func() {
+		close(batchChan)
+		close(errorChan)
+		wg.Done()
+	}()
+
+	for {
+		select {
+		case <-doneChan:
+			errorChan <- ErrInterrupted
+			return
+		case keyBatch, ok := <-keysChan:
+			if !ok {
+				return
+			}
+			batch, err := fetchBundleBatch(repo, store, settings, keyBatch)
+			if err != nil {
+				errorChan <- err
+				return
+			}
+			// send out a single batch of (ordered) bundle descriptors
+			batchChan <- batch
+		}
+	}
+}
+
+// fetchKeys fetches keys for bundles in batches, then close the keyBatchChan channel upon completion or error.
+func fetchKeys(repo string, store storage.Store, settings CoreSettings,
+	keyBatchChan chan<- []string, errorChan chan<- error,
+	doneChan <-chan struct{}, wg *sync.WaitGroup) {
+	defer func() {
+		close(keyBatchChan)
+		close(errorChan)
+		wg.Done()
+	}()
+
+	var (
+		ks   []string
+		next string
+		err  error
+	)
+
+	for {
+		// get a batch of keys
+		ks, next, err = store.KeysPrefix(context.Background(), next, model.GetArchivePathPrefixToBundles(repo), "/", settings.bundleBatchSize)
+		if err != nil {
+			select {
+			case errorChan <- err:
+				break
+			case <-doneChan:
+				errorChan <- ErrInterrupted
+				break
+			}
+			return
+		}
+
+		if len(ks) == 0 {
+			break
+		}
+
+		select {
+		case keyBatchChan <- ks:
+			break
+		case <-doneChan:
+			return
+		}
+
+		if next == "" {
+			break
+		}
+	}
+}
+
+// fetchBundleBatch performs a parallel fetch for a batch of bundles identified by their keys, then reorders the result by key
+func fetchBundleBatch(repo string, store storage.Store, settings CoreSettings, keys []string) (model.BundleDescriptors, error) {
 	var (
 		workers, wg sync.WaitGroup
 		werr        error
@@ -57,37 +370,42 @@ func ListBundles(repo string, store storage.Store, opts ...BundleListOption) ([]
 	keyChan := make(chan string)
 	errorChan := make(chan error)
 
-	for i := 0; i < minInt(settings.concurrentBundleList, len(ks)); i++ {
+	// spin workers pool
+	for i := 0; i < minInt(settings.concurrentBundleList, len(keys)); i++ {
 		workers.Add(1)
 		go getBundleAsync(repo, store, keyChan, bundleChan, errorChan, &workers)
 	}
 
-	bds := make([]model.BundleDescriptor, 0, typicalBundlesNum) // preallocate some typical number of bundles, e.g. 1000
+	bds := make(model.BundleDescriptors, 0, settings.bundleBatchSize)
 
+	// watch for results and coalesce
 	wg.Add(1)
 	go func(bundleChan <-chan model.BundleDescriptor, wg *sync.WaitGroup) {
 		defer wg.Done()
-		for bd := range bundleChan { // watch for results and coalesce
+		for bd := range bundleChan {
 			bds = append(bds, bd)
 		}
 	}(bundleChan, &wg)
 
+	// watch for errors
 	wg.Add(1)
-	go func(errorChan <-chan error, wg *sync.WaitGroup) { // watch for errors
+	go func(errorChan <-chan error, wg *sync.WaitGroup) {
 		defer wg.Done()
 		for err := range errorChan {
 			werr = err
 		}
 	}(errorChan, &wg)
 
-	for _, k := range ks { // distribute work
+	// distribute work
+	for _, k := range keys {
 		keyChan <- k
 	}
 
 	close(keyChan)
 
+	// wait for workers to complete
 	wg.Add(1)
-	go func(wg *sync.WaitGroup) { // wait for workers to complete
+	go func(wg *sync.WaitGroup) {
 		defer wg.Done()
 		workers.Wait()
 		close(bundleChan)
@@ -100,15 +418,16 @@ func ListBundles(repo string, store storage.Store, opts ...BundleListOption) ([]
 		return nil, werr
 	}
 
+	// sort result batch
+	sort.Sort(bds)
 	return bds, nil
 }
 
+// getBundleAsync fetches and unmarshalls the bundle descriptor for each single key submitted as input
 func getBundleAsync(repo string, store storage.Store,
 	input <-chan string,
 	output chan<- model.BundleDescriptor,
-	errorChan chan<- error,
-	wg *sync.WaitGroup) {
-
+	errorChan chan<- error, wg *sync.WaitGroup) {
 	// fetch descriptors
 	defer wg.Done()
 	for k := range input {
@@ -119,8 +438,7 @@ func getBundleAsync(repo string, store storage.Store,
 		}
 		r, err := store.Get(context.Background(), model.GetArchivePathToBundle(repo, apc.BundleID))
 		if err != nil {
-			// TODO: should be an error type (this creates a dependency on the actual implementation of the interface)
-			if strings.Contains(err.Error(), "object doesn't exist") {
+			if errors.Is(err, status.ErrNotExists) {
 				continue
 			}
 			errorChan <- err
@@ -153,7 +471,7 @@ func GetLatestBundle(repo string, store storage.Store) (string, error) {
 	if e != nil {
 		return "", e
 	}
-	ks, _, err := store.KeysPrefix(context.Background(), "", model.GetArchivePathPrefixToBundles(repo), "", 1000000)
+	ks, _, err := store.KeysPrefix(context.Background(), "", model.GetArchivePathPrefixToBundles(repo), "", maxMetaFilesToProcess)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/core/bundle_list_test.go
+++ b/pkg/core/bundle_list_test.go
@@ -6,21 +6,26 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
+	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/oneconcern/datamon/pkg/model"
 	"github.com/oneconcern/datamon/pkg/storage"
 	"github.com/oneconcern/datamon/pkg/storage/mockstorage"
+	"github.com/oneconcern/datamon/pkg/storage/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 type bundleFixture struct {
 	name          string
 	repo          string
 	wantError     bool
-	expected      []model.BundleDescriptor
+	expected      model.BundleDescriptors
 	errorContains []string
 }
 
@@ -34,95 +39,151 @@ func (testReadCloserWithErr) Close() error {
 	return nil
 }
 
-const tokStr = "token"
+func bundleTestCases() []bundleFixture {
+	return []bundleFixture{
+		{
+			name: "happy path",
+			repo: "happy/repo.json",
+			expected: model.BundleDescriptors{
+				{
+					ID:       "myID1",
+					LeafSize: 16,
+					Message:  "this is a message",
+					Version:  4,
+				},
+				{
+					ID:       "myID2",
+					LeafSize: 16,
+					Message:  "this is a message",
+					Version:  4,
+				},
+				{
+					ID:       "myID3",
+					LeafSize: 16,
+					Message:  "this is a message",
+					Version:  4,
+				},
+			},
+		},
+		{
+			name:     "happy with batches",
+			repo:     "happy/repo.json",
+			expected: expectedBatchFixture,
+		},
+		// error cases
+		{
+			name:          "no repo",
+			repo:          "norepo/repo.json",
+			wantError:     true,
+			errorContains: []string{"repo validation: Repo", "does not exist"},
+		},
+		{
+			name:          "no key",
+			repo:          "nokey/repo.json",
+			wantError:     true,
+			errorContains: []string{"storage error"},
+		},
+		{
+			name:          "invalid file name",
+			repo:          "invalid/repo.json",
+			wantError:     true,
+			errorContains: []string{"expected label"},
+		},
+		{
+			name:          "no archive path",
+			repo:          "noarchive/repo.json",
+			wantError:     true,
+			errorContains: []string{"get store error"},
+		},
+		{
+			name:          "invalid yaml",
+			repo:          "badyaml/repo.json",
+			wantError:     true,
+			errorContains: []string{"yaml:"},
+		},
+		{
+			name:          "inconsistent bundle ID",
+			repo:          "badID/repo.json",
+			wantError:     true,
+			errorContains: []string{"bundle IDs in descriptor", "archive path"},
+		},
+		{
+			name:          "io error",
+			repo:          "ioerr/repo.json",
+			wantError:     true,
+			errorContains: []string{"io error"},
+		},
+		// skipped bundle
+		{
+			name: "skipped bundle",
+			repo: "skipped/repo.json",
+			expected: []model.BundleDescriptor{
+				{
+					ID:       "myID1",
+					LeafSize: 16,
+					Message:  "this is a message",
+					Version:  4,
+				},
+				{
+					ID:       "myID3",
+					LeafSize: 16,
+					Message:  "this is a message",
+					Version:  4,
+				},
+			},
+		},
+		// n-th batch returns an error while fetching keys
+		{
+			name:          batchErrorTestcase,
+			repo:          "batch/repo.json",
+			expected:      expectedBatchFixture[0:25], // returned 5 first batches then bailed
+			wantError:     true,
+			errorContains: []string{"test key fetch error"},
+		},
+		// n-th batch returns an error while fetching bundle
+		{
+			name:          batchErrorRepoTestcase,
+			repo:          "batch/repo.json",
+			expected:      expectedBatchFixture[0:25], // returned 5 first batches then bailed
+			wantError:     true,
+			errorContains: []string{"test repo fetch error"},
+		},
+	}
+}
 
-var bundleTestCases = []bundleFixture{
-	{
-		name: "happy path",
-		repo: "happy/repo.json",
-		expected: []model.BundleDescriptor{
-			{
-				ID:       "myID1",
+const (
+	batchErrorRepoTestcase = "batch error repo"
+	batchErrorTestcase     = "batch error"
+)
+
+var (
+	initBatchKeysFixture sync.Once
+	keysBatchFixture     []string
+	expectedBatchFixture model.BundleDescriptors
+)
+
+func buildKeysBatchFixture(t *testing.T) func() {
+	return func() {
+		keysBatchFixture = make([]string, maxTestKeys)
+		expectedBatchFixture = make(model.BundleDescriptors, maxTestKeys)
+		for i := 0; i < maxTestKeys; i++ {
+			keysBatchFixture[i] = fmt.Sprintf("/key%0.3d/myID%0.3d/bundle.json", i, i)
+			expectedBatchFixture[i] = model.BundleDescriptor{
+				ID:       fmt.Sprintf("myID%0.3d", i),
 				LeafSize: 16,
 				Message:  "this is a message",
 				Version:  4,
-			},
-			{
-				ID:       "myID2",
-				LeafSize: 16,
-				Message:  "this is a message",
-				Version:  4,
-			},
-			{
-				ID:       "myID3",
-				LeafSize: 16,
-				Message:  "this is a message",
-				Version:  4,
-			},
-		},
-	},
-	// error cases
-	{
-		name:          "no repo",
-		repo:          "norepo/repo.json",
-		wantError:     true,
-		errorContains: []string{"repo validation: Repo", "does not exist"},
-	},
-	{
-		name:          "no key",
-		repo:          "nokey/repo.json",
-		wantError:     true,
-		errorContains: []string{"storage error"},
-	},
-	{
-		name:          "invalid file name",
-		repo:          "invalid/repo.json",
-		wantError:     true,
-		errorContains: []string{"expected label"},
-	},
-	{
-		name:          "no archive path",
-		repo:          "noarchive/repo.json",
-		wantError:     true,
-		errorContains: []string{"get store error"},
-	},
-	{
-		name:          "invalid yaml",
-		repo:          "badyaml/repo.json",
-		wantError:     true,
-		errorContains: []string{"yaml:"},
-	},
-	{
-		name:          "inconsistent bundle ID",
-		repo:          "badID/repo.json",
-		wantError:     true,
-		errorContains: []string{"bundle IDs in descriptor", "archive path"},
-	},
-	{
-		name:          "io error",
-		repo:          "ioerr/repo.json",
-		wantError:     true,
-		errorContains: []string{"io error"},
-	},
-	// skipped bundle
-	{
-		name: "skipped bundle",
-		repo: "skipped/repo.json",
-		expected: []model.BundleDescriptor{
-			{
-				ID:       "myID1",
-				LeafSize: 16,
-				Message:  "this is a message",
-				Version:  4,
-			},
-			{
-				ID:       "myID3",
-				LeafSize: 16,
-				Message:  "this is a message",
-				Version:  4,
-			},
-		},
-	},
+			}
+		}
+		require.Truef(t, sort.IsSorted(expectedBatchFixture), "got %v", expectedBatchFixture)
+	}
+}
+
+func buildYaml(id string) string {
+	return fmt.Sprintf(`id: '%s'
+leafSize: 16
+message: 'this is a message'
+version: 4`, id)
 }
 
 func mockedStore(testcase string) storage.Store {
@@ -134,7 +195,7 @@ func mockedStore(testcase string) storage.Store {
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, tokStr, nil
+				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
 			},
 			KeysFunc: func(_ context.Context) ([]string, error) {
 				return nil, nil
@@ -142,10 +203,44 @@ func mockedStore(testcase string) storage.Store {
 			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
 				parts := strings.Split(pth, "/")
 				id := parts[3]
-				return ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`id: '%s'
-leafSize: 16
-message: 'this is a message'
-version: 4`, id))), nil
+				return ioutil.NopCloser(strings.NewReader(buildYaml(id))), nil
+			},
+		}
+	case "happy with batches":
+		return &mockstorage.StoreMock{
+			HasFunc: func(_ context.Context, _ string) (bool, error) {
+				return true, nil
+			},
+			KeysPrefixFunc: func(_ context.Context, next string, _ string, _ string, count int) ([]string, string, error) {
+				index := 0
+				window := minInt(count, len(keysBatchFixture))
+
+				switch next {
+				case "":
+					break
+				default:
+					for i, key := range keysBatchFixture {
+						if key == next {
+							index = i
+							break
+						}
+					}
+				}
+
+				var following string
+				if index+window < len(keysBatchFixture) {
+					following = keysBatchFixture[index+window]
+				}
+				last := minInt(index+window, len(keysBatchFixture))
+				return keysBatchFixture[index:last], following, nil
+			},
+			KeysFunc: func(_ context.Context) ([]string, error) {
+				return nil, nil
+			},
+			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
+				parts := strings.Split(pth, "/")
+				id := parts[3]
+				return ioutil.NopCloser(strings.NewReader(buildYaml(id))), nil
 			},
 		}
 	case "no repo":
@@ -169,15 +264,12 @@ version: 4`, id))), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "labels/x/wrong/bundle.json"}, tokStr, nil
+				return []string{"/key1/myID1/bundle.json", "labels/x/wrong/bundle.json"}, "", nil
 			},
 			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
 				parts := strings.Split(pth, "/")
 				id := parts[3]
-				return ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`id: '%s'
-leafSize: 16
-message: 'this is a message'
-version: 4`, id))), nil
+				return ioutil.NopCloser(strings.NewReader(buildYaml(id))), nil
 			},
 		}
 	case "no archive path":
@@ -186,7 +278,7 @@ version: 4`, id))), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, tokStr, nil
+				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
 			},
 			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
 				return nil, errors.New("get store error")
@@ -198,7 +290,7 @@ version: 4`, id))), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, tokStr, nil
+				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
 			},
 			KeysFunc: func(_ context.Context) ([]string, error) {
 				return nil, nil
@@ -219,16 +311,13 @@ version: 4`, id))), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, tokStr, nil
+				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
 			},
 			KeysFunc: func(_ context.Context) ([]string, error) {
 				return nil, nil
 			},
 			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
-				return ioutil.NopCloser(strings.NewReader(`id: 'wrong'
-leafSize: 16
-message: 'this is a message'
-version: 4`)), nil
+				return ioutil.NopCloser(strings.NewReader(buildYaml("wrong"))), nil
 			},
 		}
 	case "io error":
@@ -237,7 +326,7 @@ version: 4`)), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, tokStr, nil
+				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
 			},
 			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
 				return testReadCloserWithErr{}, nil
@@ -249,7 +338,7 @@ version: 4`)), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/smurf.json", "/key3/myID3/bundle.json"}, tokStr, nil
+				return []string{"/key1/myID1/bundle.json", "/key2/myID2/smurf.json", "/key3/myID3/bundle.json"}, "", nil
 			},
 			KeysFunc: func(_ context.Context) ([]string, error) {
 				return nil, nil
@@ -258,42 +347,189 @@ version: 4`)), nil
 				parts := strings.Split(pth, "/")
 				id := parts[3]
 				if id == "myID2" {
-					return nil, errors.New("object doesn't exist")
+					return nil, status.ErrNotExists
 				}
-				return ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`id: '%s'
-leafSize: 16
-message: 'this is a message'
-version: 4`, id))), nil
+				return ioutil.NopCloser(strings.NewReader(buildYaml(id))), nil
+			},
+		}
+	case batchErrorTestcase:
+		return &mockstorage.StoreMock{
+			HasFunc: func(_ context.Context, _ string) (bool, error) {
+				return true, nil
+			},
+			KeysPrefixFunc: func(_ context.Context, next string, _ string, _ string, count int) ([]string, string, error) {
+				index := 0
+				window := minInt(count, len(keysBatchFixture))
+
+				switch next {
+				case "":
+					break
+				default:
+					for i, key := range keysBatchFixture {
+						if key == next {
+							index = i
+							break
+						}
+					}
+				}
+
+				if index > 4*testBatchSize {
+					return nil, "", errors.New("test key fetch error")
+				}
+
+				var following string
+				if index+window < len(keysBatchFixture) {
+					following = keysBatchFixture[index+window]
+				}
+				last := minInt(index+window, len(keysBatchFixture))
+				return keysBatchFixture[index:last], following, nil
+			},
+			KeysFunc: func(_ context.Context) ([]string, error) {
+				return nil, nil
+			},
+			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
+				parts := strings.Split(pth, "/")
+				id := parts[3]
+				return ioutil.NopCloser(strings.NewReader(buildYaml(id))), nil
+			},
+		}
+	case batchErrorRepoTestcase:
+		return &mockstorage.StoreMock{
+			HasFunc: func(_ context.Context, _ string) (bool, error) {
+				return true, nil
+			},
+			KeysPrefixFunc: func(_ context.Context, next string, _ string, _ string, count int) ([]string, string, error) {
+				index := 0
+				window := minInt(count, len(keysBatchFixture))
+
+				switch next {
+				case "":
+					break
+				default:
+					for i, key := range keysBatchFixture {
+						if key == next {
+							index = i
+							break
+						}
+					}
+				}
+
+				var following string
+				if index+window < len(keysBatchFixture) {
+					following = keysBatchFixture[index+window]
+				}
+				last := minInt(index+window, len(keysBatchFixture))
+				return keysBatchFixture[index:last], following, nil
+			},
+			KeysFunc: func(_ context.Context) ([]string, error) {
+				return nil, nil
+			},
+			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
+				parts := strings.Split(pth, "/")
+				id := parts[3]
+				index := 0
+				for i, key := range keysBatchFixture {
+					if strings.Contains(key, id) {
+						index = i
+						break
+					}
+				}
+				if index > 5*testBatchSize {
+					return nil, errors.New("test repo fetch error")
+				}
+
+				return ioutil.NopCloser(strings.NewReader(buildYaml(id))), nil
 			},
 		}
 	}
 	return nil
 }
 
+const (
+	testBatchSize = 5
+	maxTestKeys   = 100 * testBatchSize
+)
+
 func testListBundles(t *testing.T, concurrency int, i int) {
-	for _, toPin := range bundleTestCases {
+	initBatchKeysFixture.Do(buildKeysBatchFixture(t))
+	defer goleak.VerifyNone(t)
+
+	for _, toPin := range bundleTestCases() {
 		testcase := toPin
-		t.Run(fmt.Sprintf("%s-%d-%d", testcase.name, concurrency, i), func(t *testing.T) {
+
+		// ListBundles: blocking collection of bundles
+		t.Run(fmt.Sprintf("ListBundles-%s-%d-%d", testcase.name, concurrency, i), func(t *testing.T) {
 			t.Parallel()
 			mockStore := mockedStore(testcase.name)
-			res, err := ListBundles(testcase.repo, mockStore, ConcurrentBundleList(concurrency))
-			if testcase.wantError {
+			bundles, err := ListBundles(testcase.repo, mockStore, ConcurrentBundleList(concurrency), BundleBatchSize(testBatchSize))
+			assertBundles(t, testcase, bundles, err)
+		})
+
+		// ListBundlesApply emulating blocking collection of bundles
+		t.Run(fmt.Sprintf("ListBundlesApply-%s-%d-%d", testcase.name, concurrency, i), func(t *testing.T) {
+			t.Parallel()
+			mockStore := mockedStore(testcase.name)
+			bundles := make(model.BundleDescriptors, 0, typicalBundlesNum)
+			err := ListBundlesApply(testcase.repo, mockStore, func(bundle model.BundleDescriptor) error {
+				bundles = append(bundles, bundle)
+				return nil
+			}, ConcurrentBundleList(concurrency), BundleBatchSize(testBatchSize))
+			assertBundles(t, testcase, bundles, err)
+		})
+
+		// ListBundlesApply with a func failing randomly
+		t.Run(fmt.Sprintf("ListBundlesApplyFail-%s-%d-%d", testcase.name, concurrency, i), func(t *testing.T) {
+			t.Parallel()
+			mockStore := mockedStore(testcase.name)
+			bundles := make(model.BundleDescriptors, 0, typicalBundlesNum)
+			var fail bool
+			err := ListBundlesApply(testcase.repo, mockStore, func(bundle model.BundleDescriptor) error {
+				bundles = append(bundles, bundle)
+				fail = rand.Intn(2) > 0
+				if fail {
+					return errors.New("applied test func error")
+				}
+				return nil
+			}, ConcurrentBundleList(concurrency), BundleBatchSize(testBatchSize))
+
+			if fail {
 				require.Error(t, err)
-				for _, expectedMsg := range testcase.errorContains { // assert error message (opt-in)
-					assert.Contains(t, err.Error(), expectedMsg)
+				if !testcase.wantError {
+					assert.Contains(t, err.Error(), "applied test func")
+					return
+				}
+				switch testcase.name {
+				case batchErrorTestcase, batchErrorRepoTestcase:
+					assert.True(t, strings.Contains(err.Error(), testcase.errorContains[0]) || strings.Contains(err.Error(), "applied test func"))
+				default:
+					assertBundles(t, testcase, bundles, err)
 				}
 				return
 			}
-			require.NoError(t, err)
-			require.NotNil(t, res)
-			assert.ElementsMatch(t, testcase.expected, res)
+			assertBundles(t, testcase, bundles, err)
 		})
 	}
 }
 
+func assertBundles(t *testing.T, testcase bundleFixture, bundles model.BundleDescriptors, err error) {
+	if testcase.wantError {
+		require.Error(t, err)
+		for _, expectedMsg := range testcase.errorContains { // assert error message (opt-in)
+			assert.Contains(t, err.Error(), expectedMsg)
+		}
+
+		assert.Len(t, bundles, len(testcase.expected)) // assert result, possibly partial
+		return
+	}
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, testcase.expected, bundles)
+	assert.Truef(t, sort.IsSorted(bundles), "expected a sorted output, got: %v", bundles)
+}
+
 func TestListBundles(t *testing.T) {
-	for i := 0; i < 10; i++ {
-		for _, concurrency := range []int{0, 1, 50, 100, 400} {
+	for i := 0; i < 10; i++ { // check results remain stable over 10 independent iterations
+		for _, concurrency := range []int{0, 1, 50, 100, 400} { // test several concurrency parameterss
 			t.Logf("simulating ListBundles with concurrency-factor=%d, iteration=%d", concurrency, i)
 			testListBundles(t, concurrency, i)
 		}

--- a/pkg/model/bundle.go
+++ b/pkg/model/bundle.go
@@ -26,6 +26,22 @@ type BundleDescriptor struct {
 	_                      struct{}
 }
 
+// BundleDescriptors is a sortable slice of BundleDescriptor
+type BundleDescriptors []BundleDescriptor
+
+func (b BundleDescriptors) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+func (b BundleDescriptors) Len() int {
+	return len(b)
+}
+func (b BundleDescriptors) Less(i, j int) bool {
+	return b[i].ID < b[j].ID
+}
+func (b BundleDescriptors) Last() BundleDescriptor {
+	return b[len(b)-1]
+}
+
 // List of files part of a bundle.
 type BundleEntries struct {
 	BundleEntries []BundleEntry `json:"BundleEntries" yaml:"BundleEntries"`

--- a/pkg/storage/localfs/store.go
+++ b/pkg/storage/localfs/store.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/oneconcern/datamon/pkg/storage"
+	"github.com/oneconcern/datamon/pkg/storage/status"
 	"github.com/spf13/afero"
 )
 
@@ -57,11 +58,19 @@ func (r localReader) Read(p []byte) (n int, err error) {
 	return r.objectReader.Read(p)
 }
 
+func toSentinelErrors(err error) error {
+	// return sentinel errors defined by the status package
+	if os.IsNotExist(err) {
+		return status.ErrNotExists
+	}
+	return err
+}
+
 func (l *localFS) Get(ctx context.Context, key string) (io.ReadCloser, error) {
 	t, err := l.fs.Open(key)
 	return localReader{
 		objectReader: t,
-	}, err
+	}, toSentinelErrors(err)
 }
 
 type readCloser struct {

--- a/pkg/storage/status/status.go
+++ b/pkg/storage/status/status.go
@@ -1,0 +1,12 @@
+// Package status declares error constants returned by the variou
+// implementations of the Store interface.
+package status
+
+import "errors"
+
+var (
+	// Sentinel errors returned by implementations of interfaces defined by storage
+
+	// ErrNotExists indicates that the fetched object does not exist on storage
+	ErrNotExists = errors.New("object doesn't exist")
+)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -25,6 +25,7 @@ const (
 	ErrNotSupported errString = "not supported"
 	ErrExists       errString = "exists already"
 	ErrObjectTooBig errString = "object too big to be read into memory"
+	ErrNotExists    errString = "object doesn't exist"
 )
 
 // Store implementations know how to write entries to a K/V model.Store.


### PR DESCRIPTION
Improves #266, using the ` chan func() (...)`  pattern. Specifically trying to address:
> The error handling in the goroutines code is complex and required a lot of testing for blocking corner cases. This can be greatly improved by multiplexing values and errors on the same channel. At the moment, I am hesitating between chan struct{value: value_t, err: error} and chan func() 

See #267 to compare different approaches to multiplexing (identical but for the choice of channel multiplexing method).

* same functionality with less code thanks to channel w/error multiplexing
* enhanced parallel bundle retrieval: starve workers immediately on error