### PR TITLE
feat(authentication): first stab at supporting google oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,18 @@
 
 # CLI Guide
 
-Make sure your gcloud credentials have been setup.
+Make sure your gcloud credentials have been setup, with proper scopes.
 ```$bash
-gcloud auth application-default login
+gcloud auth application-default login --scopes https://www.googleapis.com/auth/cloud-platform,email,profile
 ```
+
+datamon will use your email and name from your Google ID account.
+
+> **NOTE**: by default `gcloud auth application-default login` will not allow applications to see your full profile
+> In that case, datamon will use your email as your user name.
+>
+> You may control your personal information stored by Google here: https://aboutme.google.com
+
 Download the datamon binary for mac or for linux on the
 [Releases Page](https://github.com/oneconcern/datamon/releases/)
 or use the
@@ -22,13 +30,10 @@ For non kubernetes use, it's necessary to supply gcloud credentials.
 
 ```bash
 # Replace path to gcloud credential file. Use absolute path
-% datamon config create --email ritesh@oneconcern.com --name "Ritesh H Shukla" --credential /Users/ritesh/.config/gcloud/application_default_credentials.json
+% datamon config create --credential /Users/ritesh/.config/gcloud/application_default_credentials.json
 ```
 
 Inside a kubernetes pod, Datamon will use kubernetes service credentials.
-```bash
-% datamon config create --name "Ritesh Shukla" --email ritesh@oneconcern.com
-```
 
 Check the config file, credential file will not be set in kubernetes deployment.
 ```bash
@@ -244,13 +249,13 @@ YAML might be
 
 ```yaml
 command: ["./wrap_datamon.sh"]
-args: ["-c", "/tmp/coord", "-d", "config create --name \"Coord\" --email coord-bot@oneconcern.com", "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo", "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream"]
+args: ["-c", "/tmp/coord", "-d", "config create", "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo", "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream"]
 ```
 
 or from the shell
 
 ```shell
-./wrap_datamon.sh -c /tmp/coord -d 'config create --name "Coord" --email coord-bot@oneconcern.com' -d 'bundle upload --path /tmp/upload --message "result of container coordination demo" --repo ransom-datamon-test-repo --label coordemo' -d 'bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream'
+./wrap_datamon.sh -c /tmp/coord -d 'config create' -d 'bundle upload --path /tmp/upload --message "result of container coordination demo" --repo ransom-datamon-test-repo --label coordemo' -d 'bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream'
 ```
 
 ##### `gcr.io/onec-co/datamon-pg-sidecar` -- `wrap_datamon_pg.sh`

--- a/cmd/datamon/cmd/cli_test.go
+++ b/cmd/datamon/cmd/cli_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -24,11 +23,9 @@ import (
 
 	gcsStorage "cloud.google.com/go/storage"
 	"github.com/oneconcern/datamon/internal"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 )
 
 const (
@@ -88,108 +85,6 @@ var testUploadTrees = [][]uploadTree{{
 },
 }
 
-type ExitMocks struct {
-	mock.Mock
-	exitStatuses []int
-}
-
-func (m *ExitMocks) Fatalf(format string, v ...interface{}) {
-	fmt.Println(format)
-	m.exitStatuses = append(m.exitStatuses, 1)
-}
-
-func (m *ExitMocks) Fatalln(v ...interface{}) {
-	fmt.Println(v...)
-	m.exitStatuses = append(m.exitStatuses, 1)
-}
-
-func (m *ExitMocks) Exit(code int) {
-	m.exitStatuses = append(m.exitStatuses, code)
-}
-
-func (m *ExitMocks) fatalCalls() int {
-	return len(m.exitStatuses)
-}
-
-func NewExitMocks() *ExitMocks {
-	exitMocks := ExitMocks{
-		exitStatuses: make([]int, 0),
-	}
-	return &exitMocks
-}
-
-// https://github.com/stretchr/testify/issues/610
-func MakeFatalfMock(m *ExitMocks) func(string, ...interface{}) {
-	return func(format string, v ...interface{}) {
-		m.Fatalf(format, v...)
-	}
-}
-
-func MakeFatallnMock(m *ExitMocks) func(...interface{}) {
-	return func(v ...interface{}) {
-		m.Fatalln(v...)
-	}
-}
-
-func MakeExitMock(m *ExitMocks) func(int) {
-	return func(code int) {
-		m.Exit(code)
-	}
-}
-
-var exitMocks *ExitMocks
-
-func setupTests(t *testing.T) func() {
-	os.RemoveAll(destinationDir)
-	ctx := context.Background()
-	exitMocks = NewExitMocks()
-	logFatalf = MakeFatalfMock(exitMocks)
-	logFatalln = MakeFatallnMock(exitMocks)
-	osExit = MakeExitMock(exitMocks)
-	btag := internal.RandStringBytesMaskImprSrc(15)
-	bucketMeta := "datamontestmeta-" + btag
-	bucketBlob := "datamontestblob-" + btag
-
-	client, err := gcsStorage.NewClient(ctx, option.WithScopes(gcsStorage.ScopeFullControl))
-	require.NoError(t, err, "couldn't create bucket client")
-	err = client.Bucket(bucketMeta).Create(ctx, "onec-co", nil)
-	require.NoError(t, err, "couldn't create metadata bucket")
-	err = client.Bucket(bucketBlob).Create(ctx, "onec-co", nil)
-	require.NoError(t, err, "couldn't create blob bucket")
-	params.repo.MetadataBucket = bucketMeta
-	params.repo.BlobBucket = bucketBlob
-	createAllTestUploadTrees(t)
-	cleanup := func() {
-		os.RemoveAll(destinationDir)
-		deleteBucket(ctx, t, client, bucketMeta)
-		deleteBucket(ctx, t, client, bucketBlob)
-	}
-	return cleanup
-}
-
-func runCmd(t *testing.T, cmd []string, intentMsg string, expectError bool) {
-	fatalCallsBefore := exitMocks.fatalCalls()
-	bucketMeta := params.repo.MetadataBucket
-	bucketBlob := params.repo.BlobBucket
-	contributorEmail := params.repo.ContributorEmail
-	contributorName := params.repo.ContributorName
-	params = paramsT{}
-	params.repo.MetadataBucket = bucketMeta
-	params.repo.BlobBucket = bucketBlob
-	params.repo.ContributorEmail = contributorEmail
-	params.repo.ContributorName = contributorName
-	params.bundle.ID = ""
-	rootCmd.SetArgs(cmd)
-	require.NoError(t, rootCmd.Execute(), "error executing '"+strings.Join(cmd, " ")+"' : "+intentMsg)
-	if expectError {
-		require.Equal(t, fatalCallsBefore+1, exitMocks.fatalCalls(),
-			"ran '"+strings.Join(cmd, " ")+"' expecting error and didn't see one in mocks : "+intentMsg)
-	} else {
-		require.Equal(t, fatalCallsBefore, exitMocks.fatalCalls(),
-			"unexpected error in mocks on '"+strings.Join(cmd, " ")+"' : "+intentMsg)
-	}
-}
-
 func TestCreateRepo(t *testing.T) {
 	cleanup := setupTests(t)
 	defer cleanup()
@@ -197,22 +92,16 @@ func TestCreateRepo(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create first test repo", false)
 	runCmd(t, []string{"repo",
 		"create",
 		"--description", "testing",
 		"--repo", repo2,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	runCmd(t, []string{"repo",
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "observe error on create repo with duplicate name", true)
 }
 
@@ -309,8 +198,6 @@ func TestRepoList(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create first test repo", false)
 	ll, err = listRepos(t)
 	require.NoError(t, err, "error out of listRepos() test helper")
@@ -325,9 +212,7 @@ func TestRepoList(t *testing.T) {
 		"create",
 		"--description", "testing too",
 		"--repo", repo2,
-		"--name", "tests2",
-		"--email", "datamon2@oneconcern.com",
-	}, "create second test repo", false)
+	}, "create second test repo", false, AuthMock{name: "tests2", email: "datamon2@oneconcern.com"})
 	ll, err = listRepos(t)
 	require.NoError(t, err, "error out of listRepos() test helper")
 	require.Equal(t, 2, len(ll), "two repos in list after second create")
@@ -356,8 +241,6 @@ func TestGetRepo(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repoName,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	runCmd(t, []string{"repo",
 		"get",
@@ -399,8 +282,6 @@ func TestUploadBundle(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create test repo", false)
 	for _, tree := range testUploadTrees {
 		testUploadBundle(t, tree[0])
@@ -414,8 +295,6 @@ func TestUploadBundle_filePath(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create test repo", false)
 	file := testUploadTrees[0][0]
 	runCmd(t, []string{"bundle",
@@ -462,8 +341,6 @@ func TestUploadBundleLabel(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create test repo", false)
 	file := testUploadTrees[0][0]
 	label := "testlabel"
@@ -565,15 +442,11 @@ func TestListBundles(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	runCmd(t, []string{"repo",
 		"create",
 		"--description", "testing",
 		"--repo", repo2,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 
 	bundles, err := listBundles(t, repo1)
@@ -596,8 +469,6 @@ func TestGetBundle(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	label := internal.RandStringBytesMaskImprSrc(8)
 	runCmd(t, []string{"bundle",
@@ -632,8 +503,6 @@ func TestGetLabel(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create first test repo", false)
 	runCmd(t, []string{"label",
 		"get",
@@ -704,15 +573,11 @@ func TestListLabels(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create first test repo", false)
 	runCmd(t, []string{"repo",
 		"create",
 		"--description", "testing",
 		"--repo", repo2,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	ll := listLabels(t, repo1)
 	require.Equal(t, len(ll), 0, "no labels created yet")
@@ -754,8 +619,6 @@ func TestSetLabel(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create first test repo", false)
 	ll := listLabels(t, repo1)
 	require.Equal(t, len(ll), 0, "no labels created yet")
@@ -843,8 +706,6 @@ func TestDownloadBundles(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	for i, tree := range testUploadTrees {
 		testDownloadBundle(t, tree, i+1)
@@ -873,8 +734,6 @@ func TestDiffBundle(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	//
 	runCmd(t, []string{"bundle",
@@ -1000,8 +859,6 @@ func TestUpdateBundle(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	//
 	runCmd(t, []string{"bundle",
@@ -1129,8 +986,6 @@ func TestDownloadBundleByLabel(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create test repo", false)
 	files := testUploadTrees[0]
 	file := files[0]
@@ -1275,8 +1130,6 @@ func TestListBundlesFiles(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create second test repo", false)
 	for i, tree := range testUploadTrees {
 		testListBundleFiles(t, tree, i+1)
@@ -1338,8 +1191,6 @@ func TestBundlesDownloadFiles(t *testing.T) {
 		"create",
 		"--description", "testing",
 		"--repo", repo1,
-		"--name", "tests",
-		"--email", "datamon@oneconcern.com",
 	}, "create repo", false)
 
 	testBundleDownloadFiles(t, testUploadTrees[0], 1)

--- a/cmd/datamon/cmd/config.go
+++ b/cmd/datamon/cmd/config.go
@@ -5,12 +5,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Config describes the CLI configuration.
 type Config struct {
 	// bug in viper? Need to keep names of fields the same as the serialized names..
 	Metadata   string `json:"metadata" yaml:"metadata"`
 	Blob       string `json:"blob" yaml:"blob"`
-	Email      string `json:"email" yaml:"email"`
-	Name       string `json:"name" yaml:"name"`
 	Credential string `json:"credential" yaml:"credential"`
 }
 
@@ -23,18 +22,7 @@ func newConfig() (*Config, error) {
 	return &config, nil
 }
 
-func (c *Config) setContributor(params *paramsT) {
-	if params.repo.ContributorEmail == "" {
-		params.repo.ContributorEmail = config.Email
-	}
-
-	if params.repo.ContributorName == "" {
-		params.repo.ContributorName = config.Name
-	}
-}
-
 func (c *Config) setRepoParams(params *paramsT) {
-	c.setContributor(params)
 	if params.repo.MetadataBucket == "" {
 		params.repo.MetadataBucket = config.Metadata
 		if params.repo.MetadataBucket == "" {

--- a/cmd/datamon/cmd/config_generate.go
+++ b/cmd/datamon/cmd/config_generate.go
@@ -27,8 +27,6 @@ var configGen = &cobra.Command{
 			return
 		}
 		config := Config{
-			Email:      params.repo.ContributorEmail,
-			Name:       params.repo.ContributorName,
 			Metadata:   params.repo.MetadataBucket,
 			Blob:       params.repo.BlobBucket,
 			Credential: params.root.credFile,
@@ -48,20 +46,11 @@ var configGen = &cobra.Command{
 }
 
 func init() {
-
-	requiredFlags := []string{addContributorEmail(configGen)}
-	requiredFlags = append(requiredFlags, addContributorName(configGen))
+	addContributorEmail(configGen)
+	addContributorName(configGen)
 	addBucketNameFlag(configGen)
 	addBlobBucket(configGen)
 	addCredentialFile(configGen)
-
-	for _, flag := range requiredFlags {
-		err := configGen.MarkFlagRequired(flag)
-		if err != nil {
-			wrapFatalln("mark required flag", err)
-			return
-		}
-	}
 
 	configCmd.AddCommand(configGen)
 }

--- a/cmd/datamon/cmd/deprecated.go
+++ b/cmd/datamon/cmd/deprecated.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var dummy string
+
+func addContributorEmail(cmd *cobra.Command) string {
+	contributorEmail := "email"
+	cmd.Flags().StringVar(&dummy, contributorEmail, "", "The email of the contributor")
+	_ = cmd.Flags().MarkDeprecated("email", "now ignored. Using oauth authentication instead")
+	return contributorEmail
+}
+
+func addContributorName(cmd *cobra.Command) string {
+	contributorName := "name"
+	cmd.Flags().StringVar(&dummy, contributorName, "", "The name of the contributor")
+	_ = cmd.Flags().MarkDeprecated("name", "now ignored. Using oauth authentication instead")
+	return contributorName
+}

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -21,7 +21,6 @@ type paramsT struct {
 		ID                string
 		DataPath          string
 		Message           string
-		ContributorEmail  string
 		MountPath         string
 		File              string
 		Daemonize         bool
@@ -38,12 +37,10 @@ type paramsT struct {
 		Name string
 	}
 	repo struct {
-		MetadataBucket   string
-		RepoName         string
-		BlobBucket       string
-		Description      string
-		ContributorEmail string
-		ContributorName  string
+		MetadataBucket string
+		RepoName       string
+		BlobBucket     string
+		Description    string
 	}
 	root struct {
 		credFile string
@@ -194,17 +191,6 @@ func addBlobBucket(cmd *cobra.Command) string {
 	return blob
 }
 
-func addContributorEmail(cmd *cobra.Command) string {
-	contributorEmail := "email"
-	cmd.Flags().StringVar(&params.repo.ContributorEmail, contributorEmail, "", "The email of the contributor")
-	return contributorEmail
-}
-func addContributorName(cmd *cobra.Command) string {
-	contributorName := "name"
-	cmd.Flags().StringVar(&params.repo.ContributorName, contributorName, "", "The name of the contributor")
-	return contributorName
-}
-
 func addCredentialFile(cmd *cobra.Command) string {
 	credential := "credential"
 	cmd.Flags().StringVar(&params.root.credFile, credential, "", "The path to the credential file")
@@ -286,6 +272,7 @@ func paramsToSrcStore(ctx context.Context, params paramsT, create bool) (storage
 	return sourceStore, nil
 }
 
+// DestT defines the nomenclature for allowed destination types (e.g. Empty/NonEmpty)
 type DestT uint
 
 const (
@@ -350,18 +337,6 @@ func paramsToDestStore(params paramsT,
 	return destStore, nil
 }
 
-func paramsToContributor(params paramsT) (model.Contributor, error) {
-	if params.repo.ContributorEmail == "" {
-		return model.Contributor{}, fmt.Errorf(
-			"contributor email must be set in config or as a cli param")
-	}
-	if params.repo.ContributorName == "" {
-		return model.Contributor{}, fmt.Errorf(
-			"contributor name must be set in config or as a cli param")
-	}
-
-	return model.Contributor{
-		Email: params.repo.ContributorEmail,
-		Name:  params.repo.ContributorName,
-	}, nil
+func paramsToContributor(_ paramsT) (model.Contributor, error) {
+	return authorizer.Principal(config.Credential)
 }

--- a/cmd/datamon/cmd/mocks_test.go
+++ b/cmd/datamon/cmd/mocks_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	gcsStorage "cloud.google.com/go/storage"
+	"github.com/oneconcern/datamon/internal"
+	"github.com/oneconcern/datamon/pkg/model"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+type ExitMocks struct {
+	mock.Mock
+	exitStatuses []int
+}
+
+func (m *ExitMocks) Fatalf(format string, v ...interface{}) {
+	fmt.Printf(format+"\n", v...)
+	m.exitStatuses = append(m.exitStatuses, 1)
+}
+
+func (m *ExitMocks) Fatalln(v ...interface{}) {
+	fmt.Println(v...)
+	m.exitStatuses = append(m.exitStatuses, 1)
+}
+
+func (m *ExitMocks) Exit(code int) {
+	m.exitStatuses = append(m.exitStatuses, code)
+}
+
+func (m *ExitMocks) fatalCalls() int {
+	return len(m.exitStatuses)
+}
+
+func NewExitMocks() *ExitMocks {
+	exitMocks := ExitMocks{
+		exitStatuses: make([]int, 0),
+	}
+	return &exitMocks
+}
+
+// https://github.com/stretchr/testify/issues/610
+func MakeFatalfMock(m *ExitMocks) func(string, ...interface{}) {
+	return func(format string, v ...interface{}) {
+		m.Fatalf(format, v...)
+	}
+}
+
+func MakeFatallnMock(m *ExitMocks) func(...interface{}) {
+	return func(v ...interface{}) {
+		m.Fatalln(v...)
+	}
+}
+
+func MakeExitMock(m *ExitMocks) func(int) {
+	return func(code int) {
+		m.Exit(code)
+	}
+}
+
+var exitMocks *ExitMocks
+
+type AuthMock struct {
+	email string
+	name  string
+}
+
+func (a AuthMock) Principal(_ string) (model.Contributor, error) {
+	return model.Contributor{
+		Name:  a.name,
+		Email: a.email,
+	}, nil
+}
+
+func setupTests(t *testing.T) func() {
+	os.RemoveAll(destinationDir)
+	ctx := context.Background()
+	exitMocks = NewExitMocks()
+	logFatalf = MakeFatalfMock(exitMocks)
+	logFatalln = MakeFatallnMock(exitMocks)
+	osExit = MakeExitMock(exitMocks)
+	btag := internal.RandStringBytesMaskImprSrc(15)
+	bucketMeta := "datamontestmeta-" + btag
+	bucketBlob := "datamontestblob-" + btag
+
+	client, err := gcsStorage.NewClient(ctx, option.WithScopes(gcsStorage.ScopeFullControl))
+	require.NoError(t, err, "couldn't create bucket client")
+	err = client.Bucket(bucketMeta).Create(ctx, "onec-co", nil)
+	require.NoError(t, err, "couldn't create metadata bucket")
+	err = client.Bucket(bucketBlob).Create(ctx, "onec-co", nil)
+	require.NoError(t, err, "couldn't create blob bucket")
+	params.repo.MetadataBucket = bucketMeta
+	params.repo.BlobBucket = bucketBlob
+	createAllTestUploadTrees(t)
+	cleanup := func() {
+		os.RemoveAll(destinationDir)
+		deleteBucket(ctx, t, client, bucketMeta)
+		deleteBucket(ctx, t, client, bucketBlob)
+	}
+	return cleanup
+}
+
+func runCmd(t *testing.T, cmd []string, intentMsg string, expectError bool, as ...AuthMock) {
+	fatalCallsBefore := exitMocks.fatalCalls()
+	bucketMeta := params.repo.MetadataBucket
+	bucketBlob := params.repo.BlobBucket
+	params = paramsT{}
+	params.repo.MetadataBucket = bucketMeta
+	params.repo.BlobBucket = bucketBlob
+
+	if len(as) == 0 {
+		authorizer = AuthMock{name: "tests", email: "datamon@oneconcern.com"}
+	} else {
+		for _, auth := range as {
+			authorizer = auth
+		}
+	}
+
+	params.bundle.ID = ""
+	rootCmd.SetArgs(cmd)
+	require.NoError(t, rootCmd.Execute(), "error executing '"+strings.Join(cmd, " ")+"' : "+intentMsg)
+	if expectError {
+		require.Equal(t, fatalCallsBefore+1, exitMocks.fatalCalls(),
+			"ran '"+strings.Join(cmd, " ")+"' expecting error and didn't see one in mocks : "+intentMsg)
+	} else {
+		require.Equal(t, fatalCallsBefore, exitMocks.fatalCalls(),
+			"unexpected error in mocks on '"+strings.Join(cmd, " ")+"' : "+intentMsg)
+	}
+}

--- a/cmd/datamon/cmd/repo_get.go
+++ b/cmd/datamon/cmd/repo_get.go
@@ -27,7 +27,7 @@ exits with ENOENT status otherwise.`,
 		repoDescriptor, err := core.GetRepoDescriptorByRepoName(
 			remoteStores.meta, params.repo.RepoName)
 		if err == core.ErrNotFound {
-			wrapFatalWithCode(int(unix.ENOENT), "didn't find repo '%v'", params.repo.RepoName)
+			wrapFatalWithCode(int(unix.ENOENT), "didn't find repo %q", params.repo.RepoName)
 			return
 		}
 		if err != nil {

--- a/cmd/datamon/cmd/root.go
+++ b/cmd/datamon/cmd/root.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/oneconcern/datamon/pkg/auth"
+	gauth "github.com/oneconcern/datamon/pkg/auth/google"
 	"github.com/spf13/cobra"
 )
 
@@ -49,6 +51,9 @@ var logFatalln = log.Fatalln
 var logFatalf = log.Fatalf
 var osExit = os.Exit
 
+// used to patch over calls to Authable.Principal() during test
+var authorizer auth.Authable = gauth.New()
+
 // infoLogger wraps informative messages to os.Stdout without cluttering expected output in tests.
 // To be used instead on fmt.Printf(os.Stdout, ...)
 var infoLogger = log.New(os.Stdout, "", 0)
@@ -62,7 +67,7 @@ func wrapFatalln(msg string, err error) {
 }
 
 func wrapFatalWithCode(code int, format string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, args...)
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
 	osExit(code)
 }
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,9 @@
+// Package auth allows for authenticating datamon against some external identity provider
+package auth
+
+import "github.com/oneconcern/datamon/pkg/model"
+
+// Authable knows how to retrieve a principal from credentials
+type Authable interface {
+	Principal(credFile string) (model.Contributor, error)
+}

--- a/pkg/auth/google/auth.go
+++ b/pkg/auth/google/auth.go
@@ -1,0 +1,67 @@
+package google
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/oneconcern/datamon/pkg/model"
+	goauth "google.golang.org/api/oauth2/v2"
+	goption "google.golang.org/api/option"
+)
+
+const timeout = 60 * time.Second
+
+// New returns a new instance of google Auth
+func New() Auth {
+	return Auth{}
+}
+
+// Auth implements Authable for google credentials
+type Auth struct {
+}
+
+// Principal queries google oauth2 with some local credentials to extract user
+// information (aka principal).
+//
+// By default, credentials are taken from your default application_default_credentials.
+// On linux, this is located at ~/.config/gcloud/application_default_credentials.json.
+func (g Auth) Principal(credFile string) (model.Contributor, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	svc, err := goauth.NewService(ctx,
+		goption.WithCredentialsFile(credFile),
+		goption.WithScopes(goauth.UserinfoEmailScope, goauth.UserinfoProfileScope),
+	)
+	if err != nil {
+		return model.Contributor{}, fmt.Errorf("invalid credentials: %w", err)
+	}
+
+	u, err := svc.Userinfo.Get().Do()
+	if err != nil {
+		return model.Contributor{}, fmt.Errorf("cannot retrieve userinfo: %w", err)
+	}
+
+	return model.Contributor{
+		Email: u.Email,
+		Name:  fullName(u),
+	}, nil
+}
+
+func fullName(u *goauth.Userinfoplus) (name string) {
+	if u.Name != "" {
+		name = u.Name
+		return
+	}
+	if u.GivenName != "" {
+		name += u.GivenName + " "
+	}
+	if u.FamilyName != "" {
+		name += u.FamilyName + " "
+	}
+	if name == "" {
+		// fall back on email if no nominative attributes are set
+		name = u.Email
+	}
+	return
+}

--- a/pkg/auth/google/auth_test.go
+++ b/pkg/auth/google/auth_test.go
@@ -1,0 +1,15 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrincipal(t *testing.T) {
+	p, err := New().Principal("")
+	require.NoError(t, err)
+	require.NotEmpty(t, p.Email)
+	require.NotEmpty(t, p.Name)
+	t.Logf("Tested principal: %#v", p)
+}

--- a/pkg/model/bundle.go
+++ b/pkg/model/bundle.go
@@ -64,23 +64,6 @@ type BundleEntry struct {
 	_            struct{}
 }
 
-// Contributor who created the object
-type Contributor struct {
-	Name  string `json:"name" yaml:"name"`
-	Email string `json:"email" yaml:"email"`
-	_     struct{}
-}
-
-func (c *Contributor) String() string {
-	if c.Email == "" {
-		return c.Name
-	}
-	if c.Name == "" {
-		return c.Email
-	}
-	return fmt.Sprintf("%s <%s>", c.Name, c.Email)
-}
-
 const (
 	ConsumableStorePathTypeDescriptor = iota
 	ConsumableStorePathTypeFileList

--- a/pkg/model/contributor.go
+++ b/pkg/model/contributor.go
@@ -1,0 +1,20 @@
+package model
+
+import "fmt"
+
+// Contributor who created the object
+type Contributor struct {
+	Name  string `json:"name" yaml:"name"`
+	Email string `json:"email" yaml:"email"`
+	_     struct{}
+}
+
+func (c *Contributor) String() string {
+	if c.Email == "" {
+		return c.Name
+	}
+	if c.Name == "" {
+		return c.Email
+	}
+	return fmt.Sprintf("%s <%s>", c.Name, c.Email)
+}


### PR DESCRIPTION
google oauth support for CLI

* at this moment, I am just warning CLI user of some deprecated --name/--email args. Please advise if you want to actually desupport those (will this support all use cases? I admit I am a bit lost given the possibility to change build flags etc)
* user name is no guaranteed from google userinf: using my own user for instance, I could see that this is not hydrated in google info. I set up a fall back on email as name, but we might want to make sure that users are better set up in google. Please advise.
* google oauth is an implementation of the new Authable interface, which at this moment, just gains access to the userinfo. We might want to augment that later on and make it a parameter. Now, this primarily serves the purpose of mocking auth for tests.
* I've added some minor fixes with logging output

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>