### PR TITLE
Wrapping errors

### DIFF
--- a/pkg/auth/google/auth.go
+++ b/pkg/auth/google/auth.go
@@ -2,9 +2,9 @@ package google
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/oneconcern/datamon/pkg/auth/status"
 	"github.com/oneconcern/datamon/pkg/model"
 	goauth "google.golang.org/api/oauth2/v2"
 	goption "google.golang.org/api/option"
@@ -34,16 +34,16 @@ func (g Auth) Principal(credFile string) (model.Contributor, error) {
 		goption.WithScopes(goauth.UserinfoEmailScope, goauth.UserinfoProfileScope),
 	)
 	if err != nil {
-		return model.Contributor{}, fmt.Errorf("cannot create oauth service: %w", err)
+		return model.Contributor{}, status.ErrAuthService.Wrap(err)
 	}
 
 	u, err := svc.Userinfo.Get().Do()
 	if err != nil {
-		return model.Contributor{}, fmt.Errorf("cannot retrieve userinfo: %w", err)
+		return model.Contributor{}, status.ErrUserinfo.Wrap(err)
 	}
 
 	if u.Email == "" {
-		return model.Contributor{}, fmt.Errorf("email scope is mandatory to run datamon")
+		return model.Contributor{}, status.ErrEmailScope
 	}
 	// NOTE(frederic): at this moment, the profile scope is not required and we fall back
 	// on email for the name if the full name is not available.

--- a/pkg/auth/status/status.go
+++ b/pkg/auth/status/status.go
@@ -1,0 +1,25 @@
+// Package status declares error constants returned by the various
+// implementations of the Authable interface.
+//
+// NOTE: such constants are located in a separate package to avoid
+// creating undue cyclical dependencies between pkg/store and one
+// of its implementions.
+package status
+
+import "github.com/oneconcern/datamon/pkg/errors"
+
+var (
+	// Sentinel errors returned by implementations of interfaces defined by auth
+
+	// ErrInvalidCredentials indicates that the credentials passed are invalid
+	ErrInvalidCredentials = errors.New("invalid credentials")
+
+	// ErrUserinfo indicates that user information could not be retrieved
+	ErrUserinfo = errors.New("could not retrieve userinfo")
+
+	// ErrAuthService indicates that we coud not instantiate an authentication service
+	ErrAuthService = errors.New("could not create oauth service")
+
+	// ErrEmailScope indicates that the email scope is missing from the credentials
+	ErrEmailScope = errors.New("email scope is mandatory to run datamon")
+)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,61 @@
+// Package errors augments the standard errors
+// provided by fmt (https://golang.org/src/fmt/errors.go)
+// with a Wrap() method to wrap errors without resorting
+// to fmt.Errorf("%w", err).
+package errors
+
+import (
+	stderr "errors"
+)
+
+var _ error = New("")
+
+// New Error
+func New(msg string) *Error {
+	return &Error{msg: msg}
+}
+
+// Error augments the standard error interface with a Wrap method.
+//
+// The main difference with github.com/pkg/errors is that we are wrapping
+// errors from errors, not from text.
+type Error struct {
+	msg string
+	err error
+}
+
+// Error message
+func (e *Error) Error() string {
+	return e.msg
+}
+
+// Unwrap nested error
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+// Wrap a nested error
+func (e *Error) Wrap(err error) *Error {
+	e.err = err
+	return e
+}
+
+// Is of some error type?
+func (e *Error) Is(target error) bool {
+	return e == target || e.err == target
+}
+
+// As finds the first error in err's chain that matches target, and if so, sets target to that error value and returns true.
+// (a shortcut to standard lib errors.As)
+func As(err error, target interface{}) bool {
+	return stderr.As(err, target)
+}
+
+// Is reports whether any error in err's chain matches target
+// (a shortcut to standard lib errors.As)
+func Is(err, target error) bool {
+	return stderr.Is(err, target)
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError(t *testing.T) {
+	e1 := New("cause1")
+	e2 := New("cause2").Wrap(e1)
+	e := New("dummy").Wrap(e2)
+	e3 := e.Unwrap()
+	assert.True(t, Is(e, e1))
+	assert.True(t, Is(e, e2))
+	assert.True(t, e3 == e2)
+}


### PR DESCRIPTION
This is an experimental PR attempting to wrap errors in a clean and concise way, 
based on the new go1.13 native error handling.
I am still thinking that the ` fmt.Errorf("%w", err)` hack is untidy...

I applied this to the new `auth` package to illustrate usage. Feedback welcome.