### PR TITLE
fix(authentication): fixed error message, made email a required scope

### DIFF
--- a/pkg/auth/google/auth.go
+++ b/pkg/auth/google/auth.go
@@ -34,13 +34,19 @@ func (g Auth) Principal(credFile string) (model.Contributor, error) {
 		goption.WithScopes(goauth.UserinfoEmailScope, goauth.UserinfoProfileScope),
 	)
 	if err != nil {
-		return model.Contributor{}, fmt.Errorf("invalid credentials: %w", err)
+		return model.Contributor{}, fmt.Errorf("cannot create oauth service: %w", err)
 	}
 
 	u, err := svc.Userinfo.Get().Do()
 	if err != nil {
 		return model.Contributor{}, fmt.Errorf("cannot retrieve userinfo: %w", err)
 	}
+
+	if u.Email == "" {
+		return model.Contributor{}, fmt.Errorf("email scope is mandatory to run datamon")
+	}
+	// NOTE(frederic): at this moment, the profile scope is not required and we fall back
+	// on email for the name if the full name is not available.
 
 	return model.Contributor{
 		Email: u.Email,


### PR DESCRIPTION
* Addressed comments from review of #274 
* Made email availability a strict requirement (on scopes): it is provided by default when authenticating
through gcloud, but may be disabled: this should block datamon from proceeding further.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>