### PR TITLE
Fix paths to reflect deserialization choice.

### DIFF
--- a/cmd/metrics/cmd/mock_dest_store.go
+++ b/cmd/metrics/cmd/mock_dest_store.go
@@ -25,7 +25,7 @@ func (mds *mockDestStore) String() string {
 
 func (mds *mockDestStore) Has(ctx context.Context, key string) (bool, error) {
 	// detect and respond to RepoExists() call
-	if strings.HasPrefix(key, "repos/") && strings.HasSuffix(key, "/repo.json") {
+	if strings.HasPrefix(key, "repos/") && strings.HasSuffix(key, "/repo.yaml") {
 		return true, nil
 	}
 	return false, errors.New("mock destination store Has() unimpl (other than for RepoExists calls)")
@@ -50,7 +50,7 @@ func (mds *mockDestStore) Touch(ctx context.Context, objectName string) error {
 var fileListRe *regexp.Regexp
 
 func init() {
-	fileListRe = regexp.MustCompile(`bundle-files-\d+.json$`)
+	fileListRe = regexp.MustCompile(`bundle-files-\d+.yaml$`)
 }
 
 func (mds *mockDestStore) Put(ctx context.Context, key string, source io.Reader, exclusive bool) error {

--- a/pkg/core/bundle_list_test.go
+++ b/pkg/core/bundle_list_test.go
@@ -45,7 +45,7 @@ func bundleTestCases() []bundleFixture {
 	return []bundleFixture{
 		{
 			name: "happy path",
-			repo: "happy/repo.json",
+			repo: "happy/repo.yaml",
 			expected: model.BundleDescriptors{
 				{
 					ID:       "myID1",
@@ -69,56 +69,56 @@ func bundleTestCases() []bundleFixture {
 		},
 		{
 			name:     "happy with batches",
-			repo:     "happy/repo.json",
+			repo:     "happy/repo.yaml",
 			expected: expectedBatchFixture,
 		},
 		// error cases
 		{
 			name:          "no repo",
-			repo:          "norepo/repo.json",
+			repo:          "norepo/repo.yaml",
 			wantError:     true,
 			errorContains: []string{"repo validation: Repo", "does not exist"},
 		},
 		{
 			name:          "no key",
-			repo:          "nokey/repo.json",
+			repo:          "nokey/repo.yaml",
 			wantError:     true,
 			errorContains: []string{"storage error"},
 		},
 		{
 			name:          "invalid file name",
-			repo:          "invalid/repo.json",
+			repo:          "invalid/repo.yaml",
 			wantError:     true,
 			errorContains: []string{"expected label"},
 		},
 		{
 			name:          "no archive path",
-			repo:          "noarchive/repo.json",
+			repo:          "noarchive/repo.yaml",
 			wantError:     true,
 			errorContains: []string{"get store error"},
 		},
 		{
 			name:          "invalid yaml",
-			repo:          "badyaml/repo.json",
+			repo:          "badyaml/repo.yaml",
 			wantError:     true,
 			errorContains: []string{"yaml:"},
 		},
 		{
 			name:          "inconsistent bundle ID",
-			repo:          "badID/repo.json",
+			repo:          "badID/repo.yaml",
 			wantError:     true,
 			errorContains: []string{"bundle IDs in descriptor", "archive path"},
 		},
 		{
 			name:          "io error",
-			repo:          "ioerr/repo.json",
+			repo:          "ioerr/repo.yaml",
 			wantError:     true,
 			errorContains: []string{"io error"},
 		},
 		// skipped bundle
 		{
 			name: "skipped bundle",
-			repo: "skipped/repo.json",
+			repo: "skipped/repo.yaml",
 			expected: []model.BundleDescriptor{
 				{
 					ID:       "myID1",
@@ -137,7 +137,7 @@ func bundleTestCases() []bundleFixture {
 		// n-th batch returns an error while fetching keys
 		{
 			name:          batchErrorTestcase,
-			repo:          "batch/repo.json",
+			repo:          "batch/repo.yaml",
 			expected:      expectedBatchFixture[0:25], // returned 5 first batches then bailed
 			wantError:     true,
 			errorContains: []string{"test key fetch error"},
@@ -145,7 +145,7 @@ func bundleTestCases() []bundleFixture {
 		// n-th batch returns an error while fetching bundle
 		{
 			name:          batchErrorRepoTestcase,
-			repo:          "batch/repo.json",
+			repo:          "batch/repo.yaml",
 			expected:      expectedBatchFixture[0:25], // returned 5 first batches then bailed
 			wantError:     true,
 			errorContains: []string{"test repo fetch error"},
@@ -169,7 +169,7 @@ func buildKeysBatchFixture(t *testing.T) func() {
 		keysBatchFixture = make([]string, maxTestKeys)
 		expectedBatchFixture = make(model.BundleDescriptors, maxTestKeys)
 		for i := 0; i < maxTestKeys; i++ {
-			keysBatchFixture[i] = fmt.Sprintf("/key%0.3d/myID%0.3d/bundle.json", i, i)
+			keysBatchFixture[i] = fmt.Sprintf("/key%0.3d/myID%0.3d/bundle.yaml", i, i)
 			expectedBatchFixture[i] = model.BundleDescriptor{
 				ID:       fmt.Sprintf("myID%0.3d", i),
 				LeafSize: 16,
@@ -197,7 +197,7 @@ func mockedStore(testcase string) storage.Store {
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
+				return []string{"/key1/myID1/bundle.yaml", "/key2/myID2/bundle.yaml", "/key3/myID3/bundle.yaml"}, "", nil
 			},
 			KeysFunc: func(_ context.Context) ([]string, error) {
 				return nil, nil
@@ -266,7 +266,7 @@ func mockedStore(testcase string) storage.Store {
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "labels/x/wrong/bundle.json"}, "", nil
+				return []string{"/key1/myID1/bundle.yaml", "labels/x/wrong/bundle.yaml"}, "", nil
 			},
 			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
 				parts := strings.Split(pth, "/")
@@ -280,7 +280,7 @@ func mockedStore(testcase string) storage.Store {
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
+				return []string{"/key1/myID1/bundle.yaml", "/key2/myID2/bundle.yaml", "/key3/myID3/bundle.yaml"}, "", nil
 			},
 			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
 				return nil, errors.New("get store error")
@@ -292,7 +292,7 @@ func mockedStore(testcase string) storage.Store {
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
+				return []string{"/key1/myID1/bundle.yaml", "/key2/myID2/bundle.yaml", "/key3/myID3/bundle.yaml"}, "", nil
 			},
 			KeysFunc: func(_ context.Context) ([]string, error) {
 				return nil, nil
@@ -313,7 +313,7 @@ version: 4`, id))), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
+				return []string{"/key1/myID1/bundle.yaml", "/key2/myID2/bundle.yaml", "/key3/myID3/bundle.yaml"}, "", nil
 			},
 			KeysFunc: func(_ context.Context) ([]string, error) {
 				return nil, nil
@@ -328,7 +328,7 @@ version: 4`, id))), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/bundle.json", "/key3/myID3/bundle.json"}, "", nil
+				return []string{"/key1/myID1/bundle.yaml", "/key2/myID2/bundle.yaml", "/key3/myID3/bundle.yaml"}, "", nil
 			},
 			GetFunc: func(_ context.Context, pth string) (io.ReadCloser, error) {
 				return testReadCloserWithErr{}, nil
@@ -340,7 +340,7 @@ version: 4`, id))), nil
 				return true, nil
 			},
 			KeysPrefixFunc: func(_ context.Context, _ string, prefix string, delimiter string, count int) ([]string, string, error) {
-				return []string{"/key1/myID1/bundle.json", "/key2/myID2/smurf.json", "/key3/myID3/bundle.json"}, "", nil
+				return []string{"/key1/myID1/bundle.yaml", "/key2/myID2/smurf.yaml", "/key3/myID3/bundle.yaml"}, "", nil
 			},
 			KeysFunc: func(_ context.Context) ([]string, error) {
 				return nil, nil

--- a/pkg/core/bundle_test.go
+++ b/pkg/core/bundle_test.go
@@ -214,7 +214,7 @@ func validatePublishMetadata(t *testing.T, bundle *Bundle, publish bool) {
 	if publish {
 		consumableBundleEntries := readBundleEntries(consumableStore,
 			func(i uint64) string {
-				return ".datamon/" + bundleID + "-bundle-files-" + strconv.Itoa(int(i)) + ".json"
+				return ".datamon/" + bundleID + "-bundle-files-" + strconv.Itoa(int(i)) + ".yaml"
 			},
 			model.GetConsumablePathToBundle(bundleID))
 		compareBundleEntriesLists(consumableBundleEntries, metaBundleEntries)

--- a/pkg/model/bundle.go
+++ b/pkg/model/bundle.go
@@ -91,7 +91,7 @@ func (e ConsumableStorePathMetadataErr) Error() string {
  * parses the path and returns the input values to that function.
  */
 func GetConsumableStorePathMetadata(path string) (ConsumableStorePathMetadata, error) {
-	metaRe := regexp.MustCompile(`^\.datamon/(.*)\.json$`)
+	metaRe := regexp.MustCompile(`^\.datamon/(.*)\.yaml$`)
 	flRe := regexp.MustCompile(`^(.*)-bundle-files-(.*)$`)
 	info := ConsumableStorePathMetadata{}
 	metaMatch := metaRe.FindStringSubmatch(path)
@@ -117,7 +117,7 @@ func GetConsumableStorePathMetadata(path string) (ConsumableStorePathMetadata, e
 }
 
 func GetConsumablePathToBundle(bundleID string) string {
-	path := fmt.Sprint(".datamon/", bundleID, ".json")
+	path := fmt.Sprint(".datamon/", bundleID, ".yaml")
 	info, err := GetConsumableStorePathMetadata(path)
 	if err != nil {
 		panic(fmt.Errorf("path not valid against inverse function (programming error): %v", err))
@@ -133,7 +133,7 @@ func GetConsumablePathToBundle(bundleID string) string {
 }
 
 func GetConsumablePathToBundleFileList(bundleID string, index uint64) string {
-	path := fmt.Sprint(".datamon/", bundleID, "-bundle-files-", index, ".json")
+	path := fmt.Sprint(".datamon/", bundleID, "-bundle-files-", index, ".yaml")
 	info, err := GetConsumableStorePathMetadata(path)
 	if err != nil {
 		panic(fmt.Errorf("path not valid against inverse function (programming error): %v", err))
@@ -153,7 +153,7 @@ func GetConsumablePathToBundleFileList(bundleID string, index uint64) string {
 }
 
 func GetArchivePathToBundle(repo string, bundleID string) string {
-	return fmt.Sprint(getArchivePathToBundles(), repo, "/", bundleID, "/bundle.json")
+	return fmt.Sprint(getArchivePathToBundles(), repo, "/", bundleID, "/bundle.yaml")
 }
 
 func GetArchivePathPrefixToBundles(repo string) string {
@@ -165,8 +165,8 @@ func getArchivePathToBundles() string {
 }
 
 func GetArchivePathToBundleFileList(repo string, bundleID string, index uint64) string {
-	// <repo>-bundles/<bundle>/bundlefiles-<index>.json
-	return fmt.Sprint(getArchivePathToBundles(), repo, "/", bundleID, "/bundle-files-", index, ".json")
+	// <repo>-bundles/<bundle>/bundlefiles-<index>.yaml
+	return fmt.Sprint(getArchivePathToBundles(), repo, "/", bundleID, "/bundle-files-", index, ".yaml")
 }
 
 var labelNameRe *regexp.Regexp
@@ -192,7 +192,7 @@ func GetArchivePathComponents(archivePath string) (ArchivePathComponents, error)
 			Repo:      cs[1],
 		}, nil
 	}
-	if cs[2] == "repo.json" {
+	if cs[2] == "repo.yaml" {
 		return ArchivePathComponents{Repo: cs[1]}, nil
 	}
 	return ArchivePathComponents{
@@ -215,5 +215,5 @@ func IsGeneratedFile(file string) bool {
 }
 
 func init() {
-	labelNameRe = regexp.MustCompile(`^(.*)\.json$`)
+	labelNameRe = regexp.MustCompile(`^(.*)\.yaml$`)
 }

--- a/pkg/model/bundle_test.go
+++ b/pkg/model/bundle_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestGetArchivePathToBundle(t *testing.T) {
-	pathToBundleDescriptor := "bundles/myrepo/123/bundle.json"
+	pathToBundleDescriptor := "bundles/myrepo/123/bundle.yaml"
 	require.Equal(t, pathToBundleDescriptor,
 		GetArchivePathToBundle("myrepo", "123"))
 }
 
 func TestGetConsumablePathToBundleFileList(t *testing.T) {
-	pathToBundleFileList := "bundles/myrepo/123/bundle-files-10.json"
+	pathToBundleFileList := "bundles/myrepo/123/bundle-files-10.yaml"
 	require.Equal(t, pathToBundleFileList,
 		GetArchivePathToBundleFileList("myrepo", "123", 10))
 }
@@ -28,22 +28,22 @@ func TestGetArchivePathComponents(t *testing.T) {
 	var apc ArchivePathComponents
 	var err error
 	// core/bundle_list.go
-	bundleDescriptorPath1 := "bundles/test-repo/1Jbb3SicFGoKB7JQJZdCCwdBQwE/bundle.json"
+	bundleDescriptorPath1 := "bundles/test-repo/1Jbb3SicFGoKB7JQJZdCCwdBQwE/bundle.yaml"
 	apc, err = GetArchivePathComponents(bundleDescriptorPath1)
 	require.NoError(t, err)
 	require.Equal(t, apc.Repo, "test-repo")
 	require.Equal(t, apc.BundleID, "1Jbb3SicFGoKB7JQJZdCCwdBQwE")
-	require.Equal(t, apc.ArchiveFileName, "bundle.json")
+	require.Equal(t, apc.ArchiveFileName, "bundle.yaml")
 	require.Equal(t, apc.LabelName, "")
-	bundleFilelistPath1 := "bundles/test-repo/1Jbb3SicFGoKB7JQJZdCCwdBQwE/bundle-files-0.json"
+	bundleFilelistPath1 := "bundles/test-repo/1Jbb3SicFGoKB7JQJZdCCwdBQwE/bundle-files-0.yaml"
 	apc, err = GetArchivePathComponents(bundleFilelistPath1)
 	require.NoError(t, err)
 	require.Equal(t, apc.Repo, "test-repo")
 	require.Equal(t, apc.BundleID, "1Jbb3SicFGoKB7JQJZdCCwdBQwE")
-	require.Equal(t, apc.ArchiveFileName, "bundle-files-0.json")
+	require.Equal(t, apc.ArchiveFileName, "bundle-files-0.yaml")
 	require.Equal(t, apc.LabelName, "")
 	// core/repo_list.go
-	repoPath1 := "repos/test-repo/repo.json"
+	repoPath1 := "repos/test-repo/repo.yaml"
 	apc, err = GetArchivePathComponents(repoPath1)
 	require.NoError(t, err)
 	require.Equal(t, apc.Repo, "test-repo")
@@ -51,21 +51,21 @@ func TestGetArchivePathComponents(t *testing.T) {
 	require.Equal(t, apc.ArchiveFileName, "")
 	require.Equal(t, apc.LabelName, "")
 	// core/label_list.go
-	labelPath1 := "labels/test-repo/test-label.json"
+	labelPath1 := "labels/test-repo/test-label.yaml"
 	apc, err = GetArchivePathComponents(labelPath1)
 	require.NoError(t, err)
 	require.Equal(t, apc.Repo, "test-repo")
 	require.Equal(t, apc.BundleID, "")
 	require.Equal(t, apc.ArchiveFileName, "")
 	require.Equal(t, apc.LabelName, "test-label")
-	labelPath2 := "labels/test-repo/test.label.json"
+	labelPath2 := "labels/test-repo/test.label.yaml"
 	apc, err = GetArchivePathComponents(labelPath2)
 	require.NoError(t, err)
 	require.Equal(t, apc.Repo, "test-repo")
 	require.Equal(t, apc.BundleID, "")
 	require.Equal(t, apc.ArchiveFileName, "")
 	require.Equal(t, apc.LabelName, "test.label")
-	labelPath3 := "labels/test-repo/test.label.yaml"
+	labelPath3 := "labels/test-repo/test.label.json"
 	apc, err = GetArchivePathComponents(labelPath3)
 	require.NotNil(t, err)
 }

--- a/pkg/model/label.go
+++ b/pkg/model/label.go
@@ -30,5 +30,5 @@ func GetArchivePathPrefixToLabelPrefix(repo string, prefix string) string {
 
 // GetArchivePathToLabel gets the path to the label descriptor.
 func GetArchivePathToLabel(repo string, labelName string) string {
-	return fmt.Sprint(GetArchivePathPrefixToLabels(repo), labelName, ".json")
+	return fmt.Sprint(GetArchivePathPrefixToLabels(repo), labelName, ".yaml")
 }

--- a/pkg/model/repo.go
+++ b/pkg/model/repo.go
@@ -15,7 +15,7 @@ type RepoDescriptor struct {
 }
 
 func GetArchivePathToRepoDescriptor(repo string) string {
-	return fmt.Sprint("repos/", repo, "/", "repo.json")
+	return fmt.Sprint("repos/", repo, "/", "repo.yaml")
 }
 
 func getArchivePathToRepos() string {


### PR DESCRIPTION
This is an artifact of initial churn in code. The deserialization should
match the file path.

Signed-off-by: Ritesh H Shukla <ritesh@oneconcern.com>