### PR TITLE
Improve error logging.

### DIFF
--- a/pkg/cafs/writer.go
+++ b/pkg/cafs/writer.go
@@ -137,7 +137,7 @@ func pFlush(
 			err = destination.Put(context.TODO(), pather(leafKey.String()), bytes.NewReader(buffer), storage.OverWrite)
 		}
 		if err != nil {
-			errC <- fmt.Errorf("write segment file: %s, err: %v", pather(leafKey.String()), err)
+			errC <- fmt.Errorf("write segment file: %s, err: %w", pather(leafKey.String()), err)
 			return
 		}
 		fmt.Printf("Uploading blob:%s\n", leafKey.String())
@@ -194,7 +194,7 @@ func (w *fsWriter) flush(isLastNode bool) (int, error) {
 			err = w.store.Put(context.TODO(), w.pather(leafKey.String()), bytes.NewReader(w.buf[:w.offset]), storage.OverWrite)
 		}
 		if err != nil {
-			return 0, fmt.Errorf("write segment file: %s err:%v", w.pather(leafKey.String()), err)
+			return 0, fmt.Errorf("write segment file: %s err:%w", w.pather(leafKey.String()), err)
 		}
 		fmt.Printf("Uploading blob:%s, bytes:%d\n", leafKey.String(), w.offset)
 	} else {

--- a/pkg/cafs/writer.go
+++ b/pkg/cafs/writer.go
@@ -137,7 +137,7 @@ func pFlush(
 			err = destination.Put(context.TODO(), pather(leafKey.String()), bytes.NewReader(buffer), storage.OverWrite)
 		}
 		if err != nil {
-			errC <- fmt.Errorf("write segment file: %v", err)
+			errC <- fmt.Errorf("write segment file: %s, err: %v", pather(leafKey.String()), err)
 			return
 		}
 		fmt.Printf("Uploading blob:%s\n", leafKey.String())
@@ -194,7 +194,7 @@ func (w *fsWriter) flush(isLastNode bool) (int, error) {
 			err = w.store.Put(context.TODO(), w.pather(leafKey.String()), bytes.NewReader(w.buf[:w.offset]), storage.OverWrite)
 		}
 		if err != nil {
-			return 0, fmt.Errorf("write segment file: %v", err)
+			return 0, fmt.Errorf("write segment file: %s err:%v", w.pather(leafKey.String()), err)
 		}
 		fmt.Printf("Uploading blob:%s, bytes:%d\n", leafKey.String(), w.offset)
 	} else {


### PR DESCRIPTION
Include the actual key that failed, it is needed to be able to sort
through the service providers logs.

Signed-off-by: Ritesh H Shukla <ritesh@oneconcern.com>