### PR TITLE
Add support for capturing the deduplication scheme.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,6 @@ linters:
     - unparam
     - wsl
     - gocognit
-    - gomnd
+    #- gomnd
 
 max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,6 @@ linters:
     - unparam
     - wsl
     - gocognit
-    #- gomnd
+    - gomnd
 
 max-same-issues: 0

--- a/pkg/core/bundle.go
+++ b/pkg/core/bundle.go
@@ -85,6 +85,11 @@ func Parents(p []string) BundleDescriptorOption {
 		b.Parents = p
 	}
 }
+func Deduplication(d string) BundleDescriptorOption {
+	return func(b *model.BundleDescriptor) {
+		b.Deduplication = d
+	}
+}
 
 func NewBDescriptor(descriptorOps ...BundleDescriptorOption) *model.BundleDescriptor {
 	bd := model.BundleDescriptor{
@@ -96,6 +101,7 @@ func NewBDescriptor(descriptorOps ...BundleDescriptorOption) *model.BundleDescri
 		Contributors:           nil,
 		BundleEntriesFileCount: 0,
 		Version:                model.CurrentBundleVersion,
+		Deduplication:          cafs.DeduplicationBlake,
 	}
 	for _, apply := range descriptorOps {
 		apply(&bd)

--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -5,6 +5,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"hash/crc32"
 	"io"
 	"os"
@@ -313,8 +314,18 @@ func uploadBundle(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint
 	return nil
 }
 
-func uploadBundleDescriptor(ctx context.Context, bundle *Bundle) error {
+func validateBundle(bundle *Bundle) bool {
+	if bundle.BundleDescriptor.Deduplication == "" {
+		bundle.l.Error("failed to validate bundle, Deduplication scheme not set")
+		return false
+	}
+	return true
+}
 
+func uploadBundleDescriptor(ctx context.Context, bundle *Bundle) error {
+	if !validateBundle(bundle) {
+		return fmt.Errorf("failed to validate bundle")
+	}
 	buffer, err := yaml.Marshal(bundle.BundleDescriptor)
 	if err != nil {
 		return err

--- a/pkg/model/bundle.go
+++ b/pkg/model/bundle.go
@@ -15,14 +15,15 @@ const (
 
 // BundleDescriptor represents a commit which is a file tree with the changes to the repository.
 type BundleDescriptor struct {
-	LeafSize               uint32        `json:"leafSize" yaml:"leafSize"` // Each bundles blobs are independently generated
-	ID                     string        `json:"id" yaml:"id"`
-	Message                string        `json:"message" yaml:"message"`
-	Parents                []string      `json:"parents,omitempty" yaml:"parents,omitempty"`
-	Timestamp              time.Time     `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
-	Contributors           []Contributor `json:"contributors" yaml:"contributors"`
-	BundleEntriesFileCount uint64        `json:"count" yaml:"count"`                         // Number of files which have BundleDescriptor Entries
-	Version                uint64        `json:"version,omitempty" yaml:"version,omitempty"` // Version for the bundle
+	LeafSize               uint32        `json:"leafSize" yaml:"leafSize"`                               // Each bundles blobs are independently generated
+	ID                     string        `json:"id" yaml:"id"`                                           // Unique ID for the bundle.
+	Message                string        `json:"message" yaml:"message"`                                 // Message for the commit/bundle
+	Parents                []string      `json:"parents,omitempty" yaml:"parents,omitempty"`             // Bundles with parent child relation
+	Timestamp              time.Time     `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`         // Local wall clock time
+	Contributors           []Contributor `json:"contributors" yaml:"contributors"`                       // Contributor for the bundle
+	BundleEntriesFileCount uint64        `json:"count" yaml:"count"`                                     // Number of files which have BundleDescriptor Entries
+	Version                uint64        `json:"version,omitempty" yaml:"version,omitempty"`             // Version for the bundle
+	Deduplication          string        `json:"deduplication,omitempty" yaml:"deduplication,omitempty"` // Type of deduplication used
 	_                      struct{}
 }
 


### PR DESCRIPTION
Currently there is a single deduplication scheme but we should add
support to list the deduplication scheme in preparation for adding
other schemes.

Signed-off-by: Ritesh H Shukla <ritesh@oneconcern.com>