### PR TITLE
godoc documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,13 @@ jobs:
             sudo apt-get install -y shellcheck
       - run:
           name: Install go tools
+          environment:
+            GO111MODULE: 'on'
           command: |
-            go get -u gotest.tools/gotestsum
-            go get -u github.com/matryer/moq
-            go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+            go get -u gotest.tools/gotestsum@latest
+            go get -u github.com/matryer/moq@latest
+            go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+            go clean -modcache
             mkdir -p /tmp/test-results
       - checkout
       # Restore bundle cache

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,5 @@ linters:
     - unparam
     - wsl
     - gocognit
-    - gomnd
 
 max-same-issues: 0

--- a/cmd/metrics/cmd/root.go
+++ b/cmd/metrics/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"runtime/pprof"
 
-	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/dlogger"
 
 	"github.com/spf13/cobra"
@@ -35,7 +34,6 @@ this executable exists to gather performance metrics, memory and cpu usage for e
 					log.Fatal(err)
 				}
 			}
-			core.MemProfDir = params.root.memProfPath
 			f, err := os.Create(params.root.cpuProfPath)
 			if err != nil {
 				log.Fatal(err)
@@ -51,6 +49,7 @@ this executable exists to gather performance metrics, memory and cpu usage for e
 	},
 }
 
+// Execute the selected command
 func Execute() {
 	var err error
 	if err = rootCmd.Execute(); err != nil {

--- a/cmd/metrics/cmd/upload.go
+++ b/cmd/metrics/cmd/upload.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/api/option"
 )
 
+// GCSParams defines some parameters for a Google Cloud Storage context
 type GCSParams struct {
 	MetadataBucket  string
 	BlobBucket      string
@@ -189,8 +190,12 @@ var uploadCmd = &cobra.Command{
 		)
 
 		logger.Debug("beginning upload")
-
-		err = core.Upload(context.Background(), bundle)
+		var opts []core.ListOption
+		if params.root.memProfPath != "" {
+			// add some extra memory profiling on specific critical parts (i.e. bundle Upload)
+			opts = append(opts, core.WithMemProf(params.root.memProfPath))
+		}
+		err = core.Upload(context.Background(), bundle, opts...)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,8 @@
+/*
+Package datamon provides CLI tooling to manage data at scale.
+
+The primary goal of datamon is to allow versioned data creation, access and
+tracking in an environment where data repositories and their lifecycles are
+linked.
+*/
+package datamon

--- a/pkg/context/config.go
+++ b/pkg/context/config.go
@@ -1,6 +1,0 @@
-/*
- * Copyright © 2019 One Concern
- *
- */
-
-package context

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,4 +1,7 @@
-// Copyright © 2019 One Concern
+/*
+ * Copyright © 2019 One Concern
+ *
+ */
 
 package context
 
@@ -11,7 +14,7 @@ import (
 	"github.com/oneconcern/datamon/pkg/storage"
 )
 
-// Stores for datamon.
+// Stores defines a complete context for datamon objects
 type Stores struct {
 	wal       storage.Store
 	readLog   storage.Store
@@ -21,50 +24,62 @@ type Stores struct {
 	_         struct{}
 }
 
+// NewStores creates a new instance of context stores
 func NewStores(wal, readLog, blob, metadata, vMetadata storage.Store) Stores {
 	return Stores{wal: wal, readLog: readLog, blob: blob, metadata: metadata, vMetadata: vMetadata}
 }
 
+// ReadLog yields the Read Log storage for a context
 func (c *Stores) ReadLog() storage.Store {
 	return c.readLog
 }
 
+// SetReadLog sets the context storage for Read Log
 func (c *Stores) SetReadLog(readLog storage.Store) {
 	c.readLog = readLog
 }
 
+// SetVMetadata sets the context storage for versioning metadata
 func (c *Stores) SetVMetadata(vMetadata storage.Store) {
 	c.vMetadata = vMetadata
 }
 
+// SetMetadata sets the context storage for metadata, other than versioning metadata
 func (c *Stores) SetMetadata(metadata storage.Store) {
 	c.metadata = metadata
 }
 
+// SetBlob sets the context storage for blobs
 func (c *Stores) SetBlob(blob storage.Store) {
 	c.blob = blob
 }
 
+// SetWal sets the context storage for Write Ahead Log
 func (c *Stores) SetWal(wal storage.Store) {
 	c.wal = wal
 }
 
+// Metadata yields the metadata storage for a context
 func (c *Stores) Metadata() storage.Store {
 	return c.metadata
 }
 
+// VMetadata yields the version metadata storage for a context
 func (c *Stores) VMetadata() storage.Store {
 	return c.vMetadata
 }
 
+// Blob yields the Blob storage for a context
 func (c *Stores) Blob() storage.Store {
 	return c.blob
 }
 
+// Wal yields the Write Ahead Log storage for a context
 func (c *Stores) Wal() storage.Store {
 	return c.wal
 }
 
+// CreateContext marshals and persists a context
 func CreateContext(ctx context.Context, configStore storage.Store, context model.Context) error {
 	// 1. Validate
 	err := model.ValidateContext(context)

--- a/pkg/context/doc.go
+++ b/pkg/context/doc.go
@@ -1,0 +1,7 @@
+/*
+ * Copyright © 2019 One Concern
+ *
+ */
+
+// Package context defines a datamon context to store all metadata and logs for objects
+package context

--- a/pkg/convert/unsafe.go
+++ b/pkg/convert/unsafe.go
@@ -1,6 +1,6 @@
 // +build !appengine
 
-package model
+package convert
 
 import (
 	"reflect"
@@ -21,18 +21,22 @@ func UnsafeStringToBytes(s string) []byte {
 	}))
 }
 
+// Uint64ToBytes converts a uint64 to []byte without memcopy
 func Uint64ToBytes(u *uint64) []byte {
 	return (*[sizeOfUintPtr]byte)(unsafe.Pointer(u))[:]
 }
 
+// Int64ToBytes converts a int64 to []byte without memcopy
 func Int64ToBytes(u *int64) []byte {
 	return (*[sizeOfUintPtr]byte)(unsafe.Pointer(u))[:]
 }
 
+// BytesToUint64 converts []byte to uint64 without memcopy
 func BytesToUint64(b []byte) uint64 {
 	return *(*uint64)(unsafe.Pointer(&b[0]))
 }
 
+// BytesToInt64 converts []byte to int64 without memcopy
 func BytesToInt64(b []byte) int64 {
 	return *(*int64)(unsafe.Pointer(&b[0]))
 }

--- a/pkg/core/bundle_diff.go
+++ b/pkg/core/bundle_diff.go
@@ -7,11 +7,15 @@ import (
 )
 
 const (
+	// DiffEntryTypeAdd indicates the bundle exhibits an extra entry
 	DiffEntryTypeAdd = iota
+	// DiffEntryTypeDel indicates the bundle exhibits a missing entry
 	DiffEntryTypeDel
+	// DiffEntryTypeDif indicates the bundle exhibits different entries
 	DiffEntryTypeDif
 )
 
+// DiffEntryType qualifies the type of difference between two bundles
 type DiffEntryType uint
 
 func (det DiffEntryType) String() string {
@@ -23,6 +27,7 @@ func (det DiffEntryType) String() string {
 	return diffEntryStrings[det]
 }
 
+// DiffEntry describes a single point of difference between two bundles
 type DiffEntry struct {
 	Type DiffEntryType
 	// could use a method rather than storing Name in order to curb memory use
@@ -31,6 +36,7 @@ type DiffEntry struct {
 	Additional model.BundleEntry
 }
 
+// BundleDiff describes all differences between two bundle
 type BundleDiff struct {
 	Entries []DiffEntry
 }

--- a/pkg/core/bundle_options.go
+++ b/pkg/core/bundle_options.go
@@ -1,0 +1,117 @@
+package core
+
+import (
+	context2 "github.com/oneconcern/datamon/pkg/context"
+	"github.com/oneconcern/datamon/pkg/model"
+	"github.com/oneconcern/datamon/pkg/storage"
+	"go.uber.org/zap"
+)
+
+// BundleOption is a functor to build a bundle with some options
+type BundleOption func(*Bundle)
+
+// BundleDescriptorOption is a functor to build a bundle descriptor with some options
+type BundleDescriptorOption func(descriptor *model.BundleDescriptor)
+
+// Message defines the message of the bundle descriptor
+func Message(m string) BundleDescriptorOption {
+	return func(b *model.BundleDescriptor) {
+		b.Message = m
+	}
+}
+
+// Contributors defines the list of contributors for a bundle descriptor
+func Contributors(c []model.Contributor) BundleDescriptorOption {
+	return func(b *model.BundleDescriptor) {
+		b.Contributors = c
+	}
+}
+
+// Contributor defines a single contributor for a bundle descriptor
+func Contributor(c model.Contributor) BundleDescriptorOption {
+	return Contributors([]model.Contributor{c})
+}
+
+// Parents defines the parents for a bundle descriptor
+func Parents(p []string) BundleDescriptorOption {
+	return func(b *model.BundleDescriptor) {
+		b.Parents = p
+	}
+}
+
+// Deduplication defines the deduplication scheme for a bundle descriptor
+func Deduplication(d string) BundleDescriptorOption {
+	return func(b *model.BundleDescriptor) {
+		b.Deduplication = d
+	}
+}
+
+// Repo defines the repo a bundle belongs to
+func Repo(r string) BundleOption {
+	return func(b *Bundle) {
+		b.RepoID = r
+	}
+}
+
+// ConsumableStore defines the consumable storage for a bundle
+func ConsumableStore(store storage.Store) BundleOption {
+	return func(b *Bundle) {
+		b.ConsumableStore = store
+	}
+}
+
+// ContextStores defines the set of stores to build a context for a bundle
+func ContextStores(cs context2.Stores) BundleOption {
+	return func(b *Bundle) {
+		b.contextStores = cs
+	}
+}
+
+// BundleID defines the ID for a bundle
+func BundleID(bID string) BundleOption {
+	return func(b *Bundle) {
+		b.BundleID = bID
+	}
+}
+
+// Streaming sets the streaming option flag for a bundle
+func Streaming(s bool) BundleOption {
+	return func(b *Bundle) {
+		b.Streamed = s
+	}
+}
+
+// SkipMissing indicates that bundle retrieval errors should be ignored. Currently not implementated.
+func SkipMissing(s bool) BundleOption {
+	return func(b *Bundle) {
+		b.SkipOnError = s
+	}
+}
+
+// Logger injects a logging facility into bundle core operations
+func Logger(l *zap.Logger) BundleOption {
+	return func(b *Bundle) {
+		b.l = l
+	}
+}
+
+// ConcurrentFileUploads tunes the level of concurrency when uploading bundle files
+func ConcurrentFileUploads(concurrentFileUploads int) BundleOption {
+	return func(b *Bundle) {
+		b.concurrentFileUploads = concurrentFileUploads
+	}
+}
+
+// ConcurrentFileDownloads tunes the level of concurrency when downloading bundle files
+func ConcurrentFileDownloads(concurrentFileDownloads int) BundleOption {
+	return func(b *Bundle) {
+		b.concurrentFileDownloads = concurrentFileDownloads
+	}
+}
+
+// ConcurrentFilelistDownloads tunes the level of concurrency when retrieving the list of files in a bundle
+func ConcurrentFilelistDownloads(concurrentFilelistDownloads int) BundleOption {
+	return func(b *Bundle) {
+		b.concurrentFilelistDownloads = concurrentFilelistDownloads
+	}
+}

--- a/pkg/core/bundle_read.go
+++ b/pkg/core/bundle_read.go
@@ -14,9 +14,9 @@ func errNotEOF(err error) bool {
 	return err != nil && err.Error() != "EOF"
 }
 
+// ReadAt reads some bundle data with an optional offset. Streamed bundles ignore the offset.
 func (b *Bundle) ReadAt(file *fsEntry, destination []byte, offset int64) (int, error) {
 	if !b.Streamed {
-
 		reader, err := b.ConsumableStore.GetAt(context.Background(), file.fullPath)
 		if err != nil {
 			return 0, fuse.EIO

--- a/pkg/core/doc.go
+++ b/pkg/core/doc.go
@@ -1,4 +1,4 @@
 /*
-Package core exposes core objects used by datamon
+Package core exposes core objects used by datamon: repos, bundles and labels.
 */
 package core

--- a/pkg/core/fs_common.go
+++ b/pkg/core/fs_common.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 
-	"github.com/oneconcern/datamon/pkg/model"
+	"github.com/oneconcern/datamon/pkg/convert"
 )
 
 func statFS() (err error) {
@@ -25,7 +25,7 @@ func statFS() (err error) {
 
 func formLookupKey(id fuseops.InodeID, childName string) []byte {
 	i := formKey(id)
-	c := model.UnsafeStringToBytes(childName)
+	c := convert.UnsafeStringToBytes(childName)
 	return append(i, c...)
 }
 

--- a/pkg/core/label.go
+++ b/pkg/core/label.go
@@ -16,13 +16,21 @@ import (
 	"github.com/oneconcern/datamon/pkg/storage"
 )
 
+// Label describes a bundle label.
+//
+// A label is a name given to a bundle, analogous to tags in git.
+// Examples: Latest, production.
 type Label struct {
 	Descriptor model.LabelDescriptor
 }
 
+// LabelOption is a functor to build labels
 type LabelOption func(*Label)
+
+// LabelDescriptorOption is a functor to build label descriptors
 type LabelDescriptorOption func(descriptor *model.LabelDescriptor)
 
+// LabelContributors sets a list of contributors for the label
 func LabelContributors(c []model.Contributor) LabelDescriptorOption {
 	return func(ld *model.LabelDescriptor) {
 		ld.Contributors = c
@@ -33,10 +41,12 @@ func getLabelStore(stores context2.Stores) storage.Store {
 	return stores.VMetadata()
 }
 
+// LabelContributor sets a single contributor for the label
 func LabelContributor(c model.Contributor) LabelDescriptorOption {
 	return LabelContributors([]model.Contributor{c})
 }
 
+// NewLabelDescriptor builds a new label descriptor
 func NewLabelDescriptor(descriptorOps ...LabelDescriptorOption) *model.LabelDescriptor {
 	ld := model.LabelDescriptor{
 		Timestamp: time.Now(),
@@ -47,12 +57,14 @@ func NewLabelDescriptor(descriptorOps ...LabelDescriptorOption) *model.LabelDesc
 	return &ld
 }
 
+// LabelName sets a name for the label
 func LabelName(name string) LabelOption {
 	return func(l *Label) {
 		l.Descriptor.Name = name
 	}
 }
 
+// NewLabel builds a new label with a descriptor
 func NewLabel(ld *model.LabelDescriptor, labelOps ...LabelOption) *Label {
 	if ld == nil {
 		ld = NewLabelDescriptor()
@@ -66,6 +78,7 @@ func NewLabel(ld *model.LabelDescriptor, labelOps ...LabelOption) *Label {
 	return &label
 }
 
+// UploadDescriptor persists the label descriptor for a bundle
 func (label *Label) UploadDescriptor(ctx context.Context, bundle *Bundle) error {
 	e := RepoExists(bundle.RepoID, bundle.contextStores)
 	if e != nil {
@@ -94,6 +107,7 @@ func (label *Label) UploadDescriptor(ctx context.Context, bundle *Bundle) error 
 	return nil
 }
 
+// DownloadDescriptor retrieves the label descriptor for a bundle
 func (label *Label) DownloadDescriptor(ctx context.Context, bundle *Bundle, checkRepoExists bool) error {
 	if checkRepoExists {
 		e := RepoExists(bundle.RepoID, bundle.contextStores)
@@ -124,6 +138,7 @@ func (label *Label) DownloadDescriptor(ctx context.Context, bundle *Bundle, chec
 	return nil
 }
 
+// GetLabelStore extracts the versioning metadata store from some context's stores
 func GetLabelStore(stores context2.Stores) storage.Store {
 	return getVMetaStore(stores)
 }

--- a/pkg/core/options.go
+++ b/pkg/core/options.go
@@ -7,9 +7,11 @@ type ListOption func(*Settings)
 
 // Settings defines various settings for core features
 type Settings struct {
-	concurrentList int
-	batchSize      int
-	doneChannel    chan struct{}
+	concurrentList   int
+	batchSize        int
+	doneChannel      chan struct{}
+	profilingEnabled bool
+	memProfDir       string
 }
 
 const (
@@ -49,9 +51,21 @@ func WithDoneChan(done chan struct{}) ListOption {
 	}
 }
 
+// WithMemProf enables profiling and sets the memory profile directory (defaults to the current working directory).
+// Currently, extra
+func WithMemProf(memProfDir string) ListOption {
+	return func(s *Settings) {
+		s.profilingEnabled = true
+		if memProfDir != "" {
+			s.memProfDir = memProfDir
+		}
+	}
+}
+
 func defaultSettings() Settings {
 	return Settings{
 		concurrentList: defaultListConcurrency,
 		batchSize:      defaultBatchSize,
+		memProfDir:     ".",
 	}
 }

--- a/pkg/core/profiling.go
+++ b/pkg/core/profiling.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+)
+
+func writeMemProfile(opts ...ListOption) error {
+	settings := defaultSettings()
+	for _, apply := range opts {
+		apply(&settings)
+	}
+	if dir := settings.memProfDir; dir != "" {
+		path := filepath.Join(dir, "upload_bundle.mem.prof")
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		err = pprof.Lookup("heap").WriteTo(f, 0)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/core/repo.go
+++ b/pkg/core/repo.go
@@ -10,6 +10,9 @@ import (
 	"github.com/oneconcern/datamon/pkg/storage"
 )
 
+// GetRepoStore extracts the metadata store from some context's stores
+//
+// NOTE: this is redundant with GetBundleStore
 func GetRepoStore(stores context.Stores) storage.Store {
 	return getMetaStore(stores)
 }

--- a/pkg/core/repo_create.go
+++ b/pkg/core/repo_create.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// CreateRepo persists a repository with a repo descriptor and some context's stores
 func CreateRepo(repo model.RepoDescriptor, stores context2.Stores) error {
 	store := GetRepoStore(stores) // TODO: Integrate with WAL.
 	err := model.ValidateRepo(repo)

--- a/pkg/core/repo_validate.go
+++ b/pkg/core/repo_validate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oneconcern/datamon/pkg/model"
 )
 
+// RepoExists checks for the existence of a repository by name in storage
 func RepoExists(repo string, stores context2.Stores) error {
 	exists, err := GetRepoStore(stores).Has(context.Background(), model.GetArchivePathToRepoDescriptor(repo))
 	if err != nil {
@@ -23,6 +24,7 @@ func RepoExists(repo string, stores context2.Stores) error {
 	return nil
 }
 
+// GetRepo retrieves a repository
 func GetRepo(repo string, stores context2.Stores) (*model.RepoDescriptor, error) {
 	store := stores.Metadata()
 	r, err := store.Get(context.Background(), model.GetArchivePathToRepoDescriptor(repo))

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -11,9 +11,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// ContextVersion indicates the version of the context model
 const ContextVersion = 1.0
 
-// Context defines the details for a Datamon context.
+// Context defines the details for a datamon context.
 type Context struct {
 	Name      string `json:"name" yaml:"name"`           // Name for the context
 	WAL       string `json:"wal" yaml:"wal"`             // WAL is the location for the log
@@ -30,36 +31,47 @@ func GetPathToContext(context string) string {
 	return context + "/" + "context.yaml"
 }
 
+// GetWALName yields the name of the Write Ahead Log store
 func GetWALName(context string, n string) string {
 	if n != "" {
 		return n
 	}
 	return context + "-wal"
 }
+
+// GetBlobName yields the name of the Blob store
 func GetBlobName(context string, n string) string {
 	if n != "" {
 		return n
 	}
 	return context + "-blob"
 }
+
+// GetMetadataName yields the name of the Metadata store
 func GetMetadataName(context string, n string) string {
 	if n != "" {
 		return n
 	}
 	return context + "-metadata"
 }
+
+// GetVMetadataName yields the name of the Versioning Metadata store
 func GetVMetadataName(context string, n string) string {
 	if n != "" {
 		return n
 	}
 	return context + "-v-metadata"
 }
+
+// GetReadLogName yields the name of the Read Log store
 func GetReadLogName(context string, n string) string {
 	if n != "" {
 		return n
 	}
 	return context + "-read-log"
 }
+
+// UnmarshalContext unmarshals a context from a YAML descriptor
 func UnmarshalContext(b []byte) (*Context, error) {
 	if b == nil {
 		return nil, fmt.Errorf("received nil entry to unmarshall")
@@ -69,11 +81,13 @@ func UnmarshalContext(b []byte) (*Context, error) {
 	return &c, err
 }
 
+// MarshalContext marshals a context as a YAML descriptor
 func MarshalContext(c *Context) ([]byte, error) {
 	b, err := yaml.Marshal(c)
 	return b, err
 }
 
+// ValidateContext checks the context is valid, i.e. all expected stores are well defined
 func ValidateContext(context Context) error {
 	var cause string
 	switch {

--- a/pkg/model/errors.go
+++ b/pkg/model/errors.go
@@ -1,0 +1,10 @@
+package model
+
+// ConsumableStorePathMetadataErr defines errors related to consumable store metadata
+type ConsumableStorePathMetadataErr struct {
+	msg string
+}
+
+func (e ConsumableStorePathMetadataErr) Error() string {
+	return e.msg
+}

--- a/pkg/model/label.go
+++ b/pkg/model/label.go
@@ -30,6 +30,8 @@ func (b LabelDescriptors) Len() int {
 func (b LabelDescriptors) Less(i, j int) bool {
 	return b[i].BundleID < b[j].BundleID
 }
+
+// Last label in a LabelDescriptors slice
 func (b LabelDescriptors) Last() LabelDescriptor {
 	return b[len(b)-1]
 }
@@ -38,6 +40,7 @@ func getArchivePathToLabels() string {
 	return "labels/"
 }
 
+// GetArchivePathPrefixToLabels yields the path to labels in a repo, given some prefixes
 func GetArchivePathPrefixToLabels(repo string, prefixes ...string) string {
 	return fmt.Sprint(getArchivePathToLabels(), repo+"/"+strings.Join(prefixes, "/"))
 }

--- a/pkg/model/repo.go
+++ b/pkg/model/repo.go
@@ -27,7 +27,7 @@ func (b RepoDescriptors) Less(i, j int) bool {
 	return b[i].Name < b[j].Name
 }
 
-// Last return the last entry in a slice of RepoDescriptors
+// Last returns the last entry in a slice of RepoDescriptors
 func (b RepoDescriptors) Last() RepoDescriptor {
 	return b[len(b)-1]
 }
@@ -41,10 +41,12 @@ func getArchivePathToRepos() string {
 	return "repos/"
 }
 
+// GetArchivePathPrefixToRepos yields the path to all repos
 func GetArchivePathPrefixToRepos() string {
 	return fmt.Sprint(getArchivePathToRepos())
 }
 
+// ValidateRepo validates a repository descriptor: name and description are required, name only contains letters, digits or '-'.
 func ValidateRepo(repo RepoDescriptor) error {
 	if repo.Name == "" {
 		return fmt.Errorf("empty field: repo name is empty")

--- a/pkg/model/wal.go
+++ b/pkg/model/wal.go
@@ -13,13 +13,16 @@ import (
 
 // All the serializable model for the WAL.
 
+// Entry defines a Write Ahead Log entry
 type Entry struct {
 	Token   string `json:"token" yaml:"token"`
 	Payload string `json:"payload" yaml:"payload"`
 }
 
+// TokenGeneratorPath is the path to the WAL token generator
 const TokenGeneratorPath = "WALTokenGeneratorPath"
 
+// NewEntry creates a new entry for the WAL
 func NewEntry(token string, payload string) *Entry {
 	return &Entry{
 		Token:   token,
@@ -27,6 +30,7 @@ func NewEntry(token string, payload string) *Entry {
 	}
 }
 
+// UnmarshalWAL unmarshals a WAL entry from a YAML descriptor
 func UnmarshalWAL(b []byte) (*Entry, error) {
 	if b == nil {
 		return nil, fmt.Errorf("received nil entry to unmarshall")
@@ -36,6 +40,7 @@ func UnmarshalWAL(b []byte) (*Entry, error) {
 	return &e, err
 }
 
+// MarshalWAL marshals a WAL entry as a YAML descriptor
 func MarshalWAL(entry *Entry) ([]byte, error) {
 	b, err := yaml.Marshal(entry)
 	return b, err

--- a/pkg/web/.gitignore
+++ b/pkg/web/.gitignore
@@ -1,0 +1,2 @@
+packrd/*
+*packr*.go


### PR DESCRIPTION
Beginning of some long standing effort to:
* fully document the datamon API and packages
* reduce the surface of the exposed interface and package level exported variables

* doc: added some godoc-friendly comments (pkg/core, pkg/model, pkg/context)
* refactor(core): refactored core mem profiling to work with options instead of package level constant
* refactor(model): moved unsafe pointer helpers to internal package
* refactor(model): moved regexp compilation to init

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>