### PR TITLE
fix(ci): exclude release job from untagged commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,8 +247,6 @@ workflows:
             - build_images
           filters:
             branches:
-              only:
-                - master
-                - v[0-9].*/
+              ignore: /.*/
             tags:
               only: /(^[^v].*)/


### PR DESCRIPTION
Merging goreleaser PR (#305) did break CI (attempts to release on every master...). Now fixed.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>