### PR TITLE
feat: leverages error wrapping

### DIFF
--- a/cmd/datamon/cmd/config.go
+++ b/cmd/datamon/cmd/config.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/oneconcern/datamon/pkg/model"
 	"github.com/oneconcern/datamon/pkg/storage/gcs"
+	storagestatus "github.com/oneconcern/datamon/pkg/storage/status"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
@@ -37,15 +39,27 @@ func (c *CLIConfig) setDatamonParams(flags *flagsT) {
 	}
 }
 
+func extraMsg(msg, about string, err error) string {
+	// provide extra explanation and guidance about the error
+	switch err {
+	case storagestatus.ErrInvalidResource:
+		return fmt.Sprintf("%s: please check that the config bucket %q is a valid gcs bucket", msg, about)
+	case storagestatus.ErrNotExists:
+		return fmt.Sprintf("%s: please check that the context has been created in your config", msg)
+	}
+	return msg
+}
+
 func (*CLIConfig) populateRemoteConfig(flags *flagsT) {
 	configStore, err := gcs.New(context.Background(), flags.core.Config, config.Credential)
 	if err != nil {
-		wrapFatalln("failed to get context details", err)
+		wrapFatalln(extraMsg("failed to get config store", flags.core.Config, err), err)
 		return
 	}
 	rdr, err := configStore.Get(context.Background(), model.GetPathToContext(flags.context.Descriptor.Name))
 	if err != nil {
-		wrapFatalln("failed to get context details from config store for "+flags.context.Descriptor.Name, err)
+		wrapFatalln(extraMsg("failed to get context details from config store for context "+
+			flags.context.Descriptor.Name, flags.core.Config, err), err)
 		return
 	}
 	b, err := ioutil.ReadAll(rdr)

--- a/cmd/datamon/cmd/config_generate.go
+++ b/cmd/datamon/cmd/config_generate.go
@@ -24,7 +24,11 @@ The configuration file will be placed in $HOME/` + datamonDir + `/datamon.yaml`,
 % datamon config create --credential /Users/ritesh/.config/gcloud/application_default_credentials.json,
 
 # Replace path to gcloud credential file (use absolute path here)
-% datamon config create --credential /Users/ritesh/.config/gcloud/application_default_credentials.json`,
+% datamon config create --credential /Users/ritesh/.config/gcloud/application_default_credentials.json
+
+# Specify a config bucket to store context details
+% datamon config create --config fred-datamon-config --context test-context
+`,
 	Run: func(cmd *cobra.Command, args []string) {
 		_, err := paramsToContributor(datamonFlags)
 		if err != nil {

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -167,7 +167,7 @@ func addContextFlag(cmd *cobra.Command) string {
 
 func addConfigFlag(cmd *cobra.Command) string {
 	config := "config"
-	cmd.Flags().StringVar(&datamonFlags.core.Config, config, "", "Set the config backend store to use")
+	cmd.Flags().StringVar(&datamonFlags.core.Config, config, "", "Set the config backend store to use (do not set the scheme, e.g. 'gs://')")
 	return config
 }
 

--- a/cmd/datamon/cmd/self_upgrade.go
+++ b/cmd/datamon/cmd/self_upgrade.go
@@ -107,7 +107,7 @@ func doCheckVersion() error {
 		return errors.New(fmt.Sprintf("could not fetch release from github repo (%s)", githubRepo)).Wrap(err)
 	}
 	if !found {
-		return errors.New(fmt.Sprintf("no matching release from github repo (%s)", githubRepo)).Wrap(err)
+		return errors.New(fmt.Sprintf("no matching release from github repo (%s)", githubRepo))
 	}
 
 	if isRelease && latest.Version.Equals(v) {

--- a/cmd/datamon/cmd/self_upgrade_test.go
+++ b/cmd/datamon/cmd/self_upgrade_test.go
@@ -14,10 +14,12 @@ import (
 
 func TestSelfUpgrade(t *testing.T) {
 	err := doCheckVersion()
-	if strings.Contains(err.Error(), "no matching release from github repo") ||
-		strings.Contains(err.Error(), "could not fetch release from github repo") {
-		t.Logf("upgrade test disabled: repo artifacts not ready yet: %v", err)
-		t.SkipNow()
+	if err != nil {
+		if strings.Contains(err.Error(), "no matching release from github repo") ||
+			strings.Contains(err.Error(), "could not fetch release from github repo") {
+			t.Logf("upgrade test disabled: repo artifacts not ready yet: %v", err)
+			t.SkipNow()
+		}
 	}
 	require.NoError(t, err)
 

--- a/docs/usage/datamon.md
+++ b/docs/usage/datamon.md
@@ -18,7 +18,7 @@ your data buckets are organized in repositories of versioned and tagged bundles 
 ### Options
 
 ```
-      --config string   Set the config backend store to use
+      --config string   Set the config backend store to use (do not set the scheme, e.g. 'gs://')
       --force           Forces upgrade even if the current version is not a released version
   -h, --help            help for datamon
       --upgrade         Upgrades the current version then carries on with the specified command

--- a/docs/usage/datamon_config_create.md
+++ b/docs/usage/datamon_config_create.md
@@ -23,12 +23,16 @@ datamon config create [flags]
 
 # Replace path to gcloud credential file (use absolute path here)
 % datamon config create --credential /Users/ritesh/.config/gcloud/application_default_credentials.json
+
+# Specify a config bucket to store context details
+% datamon config create --config fred-datamon-config --context test-context
+
 ```
 
 ### Options
 
 ```
-      --config string       Set the config backend store to use
+      --config string       Set the config backend store to use (do not set the scheme, e.g. 'gs://')
       --context string      Set the context for datamon (default "dev")
       --credential string   The path to the credential file
   -h, --help                help for create

--- a/docs/usage/datamon_context_create.md
+++ b/docs/usage/datamon_context_create.md
@@ -16,7 +16,7 @@ datamon context create [flags]
 
 ```
       --blob string       The name of the bucket hosting the datamon blobs
-      --config string     Set the config backend store to use
+      --config string     Set the config backend store to use (do not set the scheme, e.g. 'gs://')
   -h, --help              help for create
       --meta string       The name of the bucket used by datamon metadata
       --read-log string   The name of the bucket hosting the read log

--- a/docs/usage/datamon_context_get.md
+++ b/docs/usage/datamon_context_get.md
@@ -15,7 +15,7 @@ datamon context get [flags]
 ### Options
 
 ```
-      --config string   Set the config backend store to use
+      --config string   Set the config backend store to use (do not set the scheme, e.g. 'gs://')
   -h, --help            help for get
 ```
 

--- a/pkg/core/bundle_list.go
+++ b/pkg/core/bundle_list.go
@@ -9,7 +9,7 @@ import (
 
 	context2 "github.com/oneconcern/datamon/pkg/context"
 
-	"errors"
+	"github.com/oneconcern/datamon/pkg/errors"
 
 	"gopkg.in/yaml.v2"
 

--- a/pkg/core/repo_list.go
+++ b/pkg/core/repo_list.go
@@ -2,11 +2,12 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"sort"
 	"sync"
+
+	"github.com/oneconcern/datamon/pkg/errors"
 
 	context2 "github.com/oneconcern/datamon/pkg/context"
 	"github.com/oneconcern/datamon/pkg/core/status"

--- a/pkg/core/status/status.go
+++ b/pkg/core/status/status.go
@@ -9,4 +9,6 @@ var (
 	ErrInterrupted = errors.New("background processing interrupted")
 	// ErrNotFound indicates an object was not found
 	ErrNotFound = errors.New("not found")
+	// ErrUnexpectedUpdate indicates an update operation was attempted on some immutable store
+	ErrUnexpectedUpdate = errors.New("unexpected update")
 )

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,4 +15,18 @@ func TestError(t *testing.T) {
 	assert.True(t, Is(e, e1))
 	assert.True(t, Is(e, e2))
 	assert.True(t, e3 == e2)
+}
+
+func TestStringer(t *testing.T) {
+	e1 := New("cause1")
+	e2 := New("cause2").Wrap(e1)
+	e3 := New("cause3").Wrap(e2)
+	expected := "cause3: cause2: cause1"
+	assert.Equal(t, expected, e3.Error())
+	assert.Equal(t, expected, e3.String())
+	assert.Equal(t, expected, fmt.Sprintf("%v", e3))
+
+	e4 := e3.Wrap(fmt.Errorf("std error"))
+	expected = "cause3: std error"
+	assert.Equal(t, expected, fmt.Sprintf("%v", e4))
 }

--- a/pkg/storage/doc.go
+++ b/pkg/storage/doc.go
@@ -1,0 +1,4 @@
+// Copyright © 2018 One Concern
+
+// Package storage provides interface to handle objects storeed on some backend storage, e.g. gcs, S3.
+package storage

--- a/pkg/storage/gcs/errors.go
+++ b/pkg/storage/gcs/errors.go
@@ -1,0 +1,42 @@
+package gcs
+
+import (
+	"strings"
+
+	"github.com/oneconcern/datamon/pkg/storage/status"
+	"google.golang.org/api/googleapi"
+)
+
+func apiErrors(err *googleapi.Error) error {
+	switch err.Code {
+	case 400:
+		if strings.Contains(err.Body, "bucket is not valid") {
+			return status.ErrInvalidResource.Wrap(err)
+		}
+		// TODO(fred): extends qualification of well known errors
+		return status.ErrStorageAPI.Wrap(err)
+	case 401:
+		return status.ErrUnauthorized.Wrap(err)
+	case 403:
+		return status.ErrForbidden.Wrap(err)
+	case 404:
+		return status.ErrNotFound.Wrap(err)
+	default:
+		return status.ErrStorageAPI.Wrap(err)
+	}
+}
+
+func toSentinelErrors(err error) error {
+	// return sentinel errors defined by the status package
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "object doesn't exist") {
+		// TODO(fred): should correspond to some google API error
+		return status.ErrNotExists.Wrap(err)
+	}
+	if typedErr, isGoogle := err.(*googleapi.Error); isGoogle {
+		return apiErrors(typedErr)
+	}
+	return err
+}

--- a/pkg/storage/localfs/store.go
+++ b/pkg/storage/localfs/store.go
@@ -4,7 +4,6 @@ package localfs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,7 +12,7 @@ import (
 	"time"
 
 	"github.com/oneconcern/datamon/pkg/storage"
-	"github.com/oneconcern/datamon/pkg/storage/status"
+	storagestatus "github.com/oneconcern/datamon/pkg/storage/status"
 	"github.com/spf13/afero"
 )
 
@@ -63,7 +62,7 @@ func (r localReader) Read(p []byte) (n int, err error) {
 func toSentinelErrors(err error) error {
 	// return sentinel errors defined by the status package
 	if os.IsNotExist(err) {
-		return status.ErrNotExists
+		return storagestatus.ErrNotExists
 	}
 	return err
 }
@@ -157,7 +156,7 @@ func (l *localFS) Keys(ctx context.Context) ([]string, error) {
 
 //TODO discuss the implementation with @Ivan & @Ritesh
 func (l *localFS) KeysPrefix(ctx context.Context, token, prefix, delimiter string, count int) ([]string, string, error) {
-	return nil, "", errors.New("unimplemented")
+	return nil, "", storagestatus.ErrNotImplemented
 }
 
 func (l *localFS) Clear(ctx context.Context) error {

--- a/pkg/storage/multi.go
+++ b/pkg/storage/multi.go
@@ -1,3 +1,5 @@
+// Copyright © 2018 One Concern
+
 package storage
 
 import (

--- a/pkg/storage/status/status.go
+++ b/pkg/storage/status/status.go
@@ -1,3 +1,5 @@
+// Copyright © 2018 One Concern
+
 // Package status declares error constants returned by the various
 // implementations of the Store interface.
 //
@@ -6,11 +8,30 @@
 // of its implementions.
 package status
 
-import "errors"
+import "github.com/oneconcern/datamon/pkg/errors"
 
 var (
 	// Sentinel errors returned by implementations of interfaces defined by storage
 
 	// ErrNotExists indicates that the fetched object does not exist on storage
 	ErrNotExists = errors.New("object doesn't exist")
+
+	// ErrNotFound indicates that the backend API call did not find the target resource
+	ErrNotFound = errors.New("not found")
+	// ErrUnauthorized indicates that you don't provided correct credentials to the API
+	ErrUnauthorized = errors.New("unauthorized")
+	// ErrForbidden indicates that the backend API forbids access to the target resource
+	ErrForbidden = errors.New("forbidden")
+	// ErrNotSupported indicates that the backend API does not support this call
+	ErrNotSupported = errors.New("not supported")
+	// ErrExists indicates that the resource already exists and cannot be overridden
+	ErrExists = errors.New("exists already")
+	// ErrObjectTooBig indicates that the object is too big and cannot be handled by datamon
+	ErrObjectTooBig = errors.New("object too big to be read into memory")
+	// ErrInvalidResource indicates that the storage resource has an invalid name
+	ErrInvalidResource = errors.New("invalid storage resource name")
+	// ErrStorageAPI indicates any other storage AI error
+	ErrStorageAPI = errors.New("storage API error")
+	// ErrNotImplemented tells that this feature has not been implemented yet
+	ErrNotImplemented = errors.New("not implemented")
 )

--- a/pkg/storage/sthree/errors.go
+++ b/pkg/storage/sthree/errors.go
@@ -1,0 +1,53 @@
+package sthree
+
+import (
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/oneconcern/datamon/pkg/errors"
+	"github.com/oneconcern/datamon/pkg/storage/status"
+)
+
+func filterErrNotExists(err error) error {
+	if errors.Is(err, status.ErrNotExists) || errors.Is(err, status.ErrNotFound) {
+		return nil
+	}
+	return err
+}
+
+func apiErrors(err awserr.RequestFailure) error {
+	// handle S3 API errors
+	// https://docs.aws.amazon.com/sdk-for-go/api/aws/awserr/#RequestFailure
+	switch err.StatusCode() {
+	case 400:
+		if err.Code() == "InvalidBucketName" {
+			return status.ErrInvalidResource.Wrap(err)
+		}
+		return status.ErrStorageAPI.Wrap(err)
+	case 401:
+		return status.ErrUnauthorized.Wrap(err)
+	case 403:
+		return status.ErrForbidden.Wrap(err)
+	case 404:
+		switch err.Code() {
+		case "NoSuchKey", "NoSuchBucket", "NotFound": // NotFound is a code produced by miniio and not an official AWS code
+			// storable objects
+			return status.ErrNotExists.Wrap(err)
+		default:
+			// generic S3 object
+			return status.ErrNotFound.Wrap(err)
+		}
+	default:
+		return status.ErrStorageAPI.Wrap(err)
+	}
+}
+
+func toSentinelErrors(err error) error {
+	// return sentinel errors defined by the status package
+	// see: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
+	if err == nil {
+		return nil
+	}
+	if awsErr, isAWS := err.(awserr.RequestFailure); isAWS {
+		return apiErrors(awsErr)
+	}
+	return err
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -10,10 +10,7 @@ import (
 
 //go:generate moq -out ./mockstorage/store.go -pkg mockstorage . Store
 
-type errString string
-
 const MaxObjectSizeInMemory = 2 * 1024 * 1024 * 1024 // 2 gigs
-func (e errString) Error() string                    { return string(e) }
 
 const (
 	// Adding these to make code more readable when looking at Put Call
@@ -22,14 +19,6 @@ const (
 )
 
 type NewKey = bool
-
-const (
-	ErrNotFound     errString = "not found"
-	ErrForbidden    errString = "forbidden"
-	ErrNotSupported errString = "not supported"
-	ErrExists       errString = "exists already"
-	ErrObjectTooBig errString = "object too big to be read into memory"
-)
 
 type Attributes struct {
 	Created time.Time


### PR DESCRIPTION
* pkg (storage, core): wrap underlying API errors and process well-known error statuses
* CLI: add more detailed guidance on well-known errors (e.g. invalid bucket, unknown context)

**NOTE**: if we all agree on the idea behind this PR (which starts levering my previous error wrapper), I'll start generalizing error wrapping in packages. Step-by-step CLI testing shall also drive toward more "extra guidance"-like handling.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>