### PR TITLE
refact(context): make context an interface

### DIFF
--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	context2 "github.com/oneconcern/datamon/pkg/context"
+	gcscontext "github.com/oneconcern/datamon/pkg/context/gcs"
 
 	"github.com/oneconcern/datamon/pkg/core"
 
@@ -283,39 +284,8 @@ func addTargetFlag(cmd *cobra.Command) string {
 /** parameters struct to other formats */
 
 func paramsToDatamonContext(ctx context.Context, params flagsT) (context2.Stores, error) {
-	stores := context2.Stores{}
-
-	meta, err := gcs.New(ctx, params.context.Descriptor.Metadata, config.Credential)
-	if err != nil {
-		return context2.Stores{}, fmt.Errorf("failed to initialize metadata store, err:%s", err)
-	}
-	stores.SetMetadata(meta)
-
-	blob, err := gcs.New(ctx, params.context.Descriptor.Blob, config.Credential)
-	if err != nil {
-		return context2.Stores{}, fmt.Errorf("failed to initialize blob store, err:%s", err)
-	}
-	stores.SetBlob(blob)
-
-	v, err := gcs.New(ctx, params.context.Descriptor.VMetadata, config.Credential)
-	if err != nil {
-		return context2.Stores{}, fmt.Errorf("failed to initialize vmetadata store, err:%s", err)
-	}
-	stores.SetVMetadata(v)
-
-	w, err := gcs.New(ctx, params.context.Descriptor.WAL, config.Credential)
-	if err != nil {
-		return context2.Stores{}, fmt.Errorf("failed to initialize wal store, err:%s", err)
-	}
-	stores.SetWal(w)
-
-	r, err := gcs.New(ctx, params.context.Descriptor.ReadLog, config.Credential)
-	if err != nil {
-		return context2.Stores{}, fmt.Errorf("failed to initialize read log store, err:%s", err)
-	}
-	stores.SetReadLog(r)
-
-	return stores, nil
+	// here we select a 100% gcs backend strategy (more elaborate strategies could be defined by the context pkg)
+	return gcscontext.MakeContext(ctx, params.context.Descriptor, config.Credential)
 }
 
 func paramsToBundleOpts(stores context2.Stores) []core.BundleOption {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -16,7 +16,38 @@ import (
 )
 
 // Stores defines a complete context for datamon objects
-type Stores struct {
+type Stores interface {
+	// Metadata yields the metadata storage for a context
+	Metadata() storage.Store
+	// SetMetadata sets the context storage for metadata, other than versioning metadata
+	SetMetadata(metadata storage.Store)
+
+	// ReadLog yields the Read Log storage for a context
+	ReadLog() storage.Store
+	// SetReadLog sets the context storage for Read Log
+	SetReadLog(readLog storage.Store)
+
+	// VMetadata yields the version metadata storage for a context
+	VMetadata() storage.Store
+	// SetVMetadata sets the context storage for versioning metadata
+	SetVMetadata(vMetadata storage.Store)
+
+	// Blob yields the Blob storage for a context
+	Blob() storage.Store
+	// SetBlob sets the context storage for blobs
+	SetBlob(blob storage.Store)
+
+	// Wal yields the Write Ahead Log storage for a context
+	Wal() storage.Store
+	// SetWal sets the context storage for Write Ahead Log
+	SetWal(wal storage.Store)
+}
+
+// type safeguard
+var _ Stores = &defaultStores{}
+
+// defaultStores is the default implementation of Stores
+type defaultStores struct {
 	wal       storage.Store
 	readLog   storage.Store
 	blob      storage.Store
@@ -25,78 +56,83 @@ type Stores struct {
 	_         struct{}
 }
 
+// New creates a new empty instance of context stores, to be set with the Setxxx methods.
+func New() Stores {
+	return &defaultStores{}
+}
+
 // NewStores creates a new instance of context stores
 func NewStores(wal, readLog, blob, metadata, vMetadata storage.Store) Stores {
-	return Stores{wal: wal, readLog: readLog, blob: blob, metadata: metadata, vMetadata: vMetadata}
+	return &defaultStores{wal: wal, readLog: readLog, blob: blob, metadata: metadata, vMetadata: vMetadata}
 }
 
 // ReadLog yields the Read Log storage for a context
-func (c *Stores) ReadLog() storage.Store {
+func (c *defaultStores) ReadLog() storage.Store {
 	return c.readLog
 }
 
 // SetReadLog sets the context storage for Read Log
-func (c *Stores) SetReadLog(readLog storage.Store) {
+func (c *defaultStores) SetReadLog(readLog storage.Store) {
 	c.readLog = readLog
 }
 
 // SetVMetadata sets the context storage for versioning metadata
-func (c *Stores) SetVMetadata(vMetadata storage.Store) {
+func (c *defaultStores) SetVMetadata(vMetadata storage.Store) {
 	c.vMetadata = vMetadata
 }
 
 // SetMetadata sets the context storage for metadata, other than versioning metadata
-func (c *Stores) SetMetadata(metadata storage.Store) {
+func (c *defaultStores) SetMetadata(metadata storage.Store) {
 	c.metadata = metadata
 }
 
 // SetBlob sets the context storage for blobs
-func (c *Stores) SetBlob(blob storage.Store) {
+func (c *defaultStores) SetBlob(blob storage.Store) {
 	c.blob = blob
 }
 
 // SetWal sets the context storage for Write Ahead Log
-func (c *Stores) SetWal(wal storage.Store) {
+func (c *defaultStores) SetWal(wal storage.Store) {
 	c.wal = wal
 }
 
 // Metadata yields the metadata storage for a context
-func (c *Stores) Metadata() storage.Store {
+func (c *defaultStores) Metadata() storage.Store {
 	return c.metadata
 }
 
 // VMetadata yields the version metadata storage for a context
-func (c *Stores) VMetadata() storage.Store {
+func (c *defaultStores) VMetadata() storage.Store {
 	return c.vMetadata
 }
 
 // Blob yields the Blob storage for a context
-func (c *Stores) Blob() storage.Store {
+func (c *defaultStores) Blob() storage.Store {
 	return c.blob
 }
 
 // Wal yields the Write Ahead Log storage for a context
-func (c *Stores) Wal() storage.Store {
+func (c *defaultStores) Wal() storage.Store {
 	return c.wal
 }
 
-// CreateContext marshals and persists a context
+// CreateContext marshals and persists a context in the remote config
 func CreateContext(ctx context.Context, configStore storage.Store, context model.Context) error {
 	// 1. Validate
 	err := model.ValidateContext(context)
 	if err != nil {
-		return fmt.Errorf("validation for new context %s failed, err: %v", context.Name, err)
+		return fmt.Errorf("validation for new context %s failed, err: %w", context.Name, err)
 	}
 	// 2. Serialize
 	b, err := model.MarshalContext(&context)
 	if err != nil {
-		return fmt.Errorf("failed to serialize context: %v", err)
+		return fmt.Errorf("failed to serialize context: %w", err)
 	}
 	// 3. Create only
 	path := model.GetPathToContext(context.Name)
 	err = configStore.Put(ctx, path, bytes.NewReader(b), storage.NoOverWrite)
 	if err != nil {
-		return fmt.Errorf("failed to write context %v: %v", context, err)
+		return fmt.Errorf("failed to write context %v: %w", context, err)
 	}
 	return nil
 }

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -52,7 +52,7 @@ func TestNewContext(t *testing.T) {
 				vMetadata: s4,
 				readLog:   s5,
 			},
-			want: Stores{
+			want: &defaultStores{
 				wal:       s1,
 				blob:      s2,
 				metadata:  s3,

--- a/pkg/context/gcs/doc.go
+++ b/pkg/context/gcs/doc.go
@@ -1,0 +1,3 @@
+// Package gcs is a gcs implementation of the datamon context, with
+// all context stores as gcs buckets
+package gcs

--- a/pkg/context/gcs/gcs_context.go
+++ b/pkg/context/gcs/gcs_context.go
@@ -1,0 +1,47 @@
+package gcs
+
+import (
+	"context"
+
+	context2 "github.com/oneconcern/datamon/pkg/context"
+	"github.com/oneconcern/datamon/pkg/context/status"
+	"github.com/oneconcern/datamon/pkg/model"
+	gcsstore "github.com/oneconcern/datamon/pkg/storage/gcs"
+)
+
+// MakeContext initializes all gcs stores in a context described by its model, with some gcs credentials
+func MakeContext(ctx context.Context, descriptor model.Context, creds string) (context2.Stores, error) {
+	stores := context2.New()
+
+	meta, err := gcsstore.New(ctx, descriptor.Metadata, creds)
+	if err != nil {
+		return nil, status.ErrInitMetadata.Wrap(err)
+	}
+	stores.SetMetadata(meta)
+
+	blob, err := gcsstore.New(ctx, descriptor.Blob, creds)
+	if err != nil {
+		return nil, status.ErrInitBlob.Wrap(err)
+	}
+	stores.SetBlob(blob)
+
+	v, err := gcsstore.New(ctx, descriptor.VMetadata, creds)
+	if err != nil {
+		return nil, status.ErrInitVMetadata.Wrap(err)
+	}
+	stores.SetVMetadata(v)
+
+	w, err := gcsstore.New(ctx, descriptor.WAL, creds)
+	if err != nil {
+		return nil, status.ErrInitWAL.Wrap(err)
+	}
+	stores.SetWal(w)
+
+	r, err := gcsstore.New(ctx, descriptor.ReadLog, creds)
+	if err != nil {
+		return nil, status.ErrInitRLog.Wrap(err)
+	}
+	stores.SetReadLog(r)
+
+	return stores, nil
+}

--- a/pkg/context/status/status.go
+++ b/pkg/context/status/status.go
@@ -1,0 +1,21 @@
+// Package status defines errors for datamon context
+package status
+
+import (
+	"github.com/oneconcern/datamon/pkg/errors"
+)
+
+var (
+	// datamon context errors
+
+	// ErrInitMetadata indicates that we could not initialize the metadata store for this context
+	ErrInitMetadata = errors.New("failed to initialize metadata store")
+	// ErrInitBlob indicates that we could not initialize the blob store for this context
+	ErrInitBlob = errors.New("failed to initialize blob store")
+	// ErrInitVMetadata indicates that we could not initialize the versioned metadata for this context
+	ErrInitVMetadata = errors.New("failed to initialize vmetadata store")
+	// ErrInitWAL indicates that we could not initialize the write-ahead-log for this context
+	ErrInitWAL = errors.New("failed to initialize wal store")
+	// ErrInitRLog indicates that we could not initialize the read log for this context
+	ErrInitRLog = errors.New("failed to initialize read log store")
+)

--- a/pkg/core/bundle.go
+++ b/pkg/core/bundle.go
@@ -87,6 +87,9 @@ func (b *Bundle) BlobStore() storage.Store {
 }
 
 func getBlobStore(stores context2.Stores) storage.Store {
+	if stores == nil {
+		return nil
+	}
 	return stores.Blob()
 }
 
@@ -96,6 +99,9 @@ func (b *Bundle) MetaStore() storage.Store {
 }
 
 func getMetaStore(stores context2.Stores) storage.Store {
+	if stores == nil {
+		return nil
+	}
 	return stores.Metadata()
 }
 
@@ -104,6 +110,9 @@ func (b *Bundle) VMetaStore() storage.Store {
 	return getVMetaStore(b.contextStores)
 }
 func getVMetaStore(stores context2.Stores) storage.Store {
+	if stores == nil {
+		return nil
+	}
 	return stores.VMetadata()
 }
 
@@ -113,6 +122,9 @@ func (b *Bundle) WALStore() storage.Store {
 }
 
 func getWALStore(stores context2.Stores) storage.Store {
+	if stores == nil {
+		return nil
+	}
 	return stores.Wal()
 }
 
@@ -121,6 +133,9 @@ func (b *Bundle) ReadLogStore() storage.Store {
 	return getReadLogStore(b.contextStores)
 }
 func getReadLogStore(stores context2.Stores) storage.Store {
+	if stores == nil {
+		return nil
+	}
 	return stores.ReadLog()
 }
 

--- a/pkg/core/bundle_test.go
+++ b/pkg/core/bundle_test.go
@@ -57,7 +57,7 @@ func TestBundle(t *testing.T) {
 	blobStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), blobDir))
 	reArchiveBlob := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), reArchiveBlobDir))
 	reArchive := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), reArchiveMetaDir))
-	dmc := context2.Stores{}
+	dmc := context2.New()
 	dmc.SetMetadata(metaStore)
 	require.NoError(t, CreateRepo(model.RepoDescriptor{
 		Name:        repo,
@@ -68,6 +68,8 @@ func TestBundle(t *testing.T) {
 			Email: "t@test.com",
 		},
 	}, dmc))
+
+	dmc = context2.New()
 	dmc.SetMetadata(reArchive)
 	require.NoError(t, CreateRepo(model.RepoDescriptor{
 		Name:        repo,
@@ -80,6 +82,7 @@ func TestBundle(t *testing.T) {
 	}, dmc))
 
 	bd := NewBDescriptor()
+	dmc = context2.New()
 	dmc.SetMetadata(metaStore)
 	dmc.SetBlob(blobStore)
 	bundle := NewBundle(bd,
@@ -97,6 +100,7 @@ func TestBundle(t *testing.T) {
 	validatePublish(t, consumableStore, bundleEntriesFileCount)
 
 	/* bundle id is set on upload */
+	dmc = context2.New()
 	dmc.SetBlob(reArchiveBlob)
 	dmc.SetMetadata(reArchive)
 	archiveBundle2 := NewBundle(bd,
@@ -119,7 +123,7 @@ func paramedTestPublishMetadata(t *testing.T, publish bool) {
 	consumableStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), destinationDir))
 	metaStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), metaDir))
 	blobStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), blobDir))
-	dmc := context2.Stores{}
+	dmc := context2.New()
 	dmc.SetMetadata(metaStore)
 	require.NoError(t, CreateRepo(model.RepoDescriptor{
 		Name:        repo,
@@ -132,6 +136,7 @@ func paramedTestPublishMetadata(t *testing.T, publish bool) {
 	}, dmc))
 
 	bd := NewBDescriptor()
+	dmc = context2.New()
 	dmc.SetMetadata(metaStore)
 	dmc.SetBlob(blobStore)
 	bundle := NewBundle(bd,


### PR DESCRIPTION
 refact(context): make context an interface
9900184

* transformed Context as an interface, with our default basic implementation kept private
* moved gcs specific section of cmd/flags.go used to initialize context stores on gcs to a helper sub package of context,
  which provides a context storage strategy 100% backed by gcs (we might want to create later more elaborate strategies)

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>

