### PR TITLE
fixup CI vs tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,7 @@ jobs:
               # otherwise, leaves standard changelog from goreleaser
               # (picks up all commits)
             fi
+            echo "Preparing release ${CIRCLE_TAG}"
             ./goreleaser ${opts-""}
 
 workflows:
@@ -284,7 +285,7 @@ workflows:
             - go_test
             - build_images
           filters:
+            tags:
+              only: /^v.*/
             branches:
               ignore: /.*/
-            tags:
-              only: /(^[^v].*)/


### PR DESCRIPTION
@kerneltime the release job did not trigger on your latest tagging attempt.
I checked and fixed the CI config which was mixing up filters with branches.

I've launched a dummy circleCI job on my fork and the release job now kicks in.

The way to apply the fix after merger is:
- remove the v2.0.0-beta tag from your local and origin (and basically all remotes you might have)
- retag after this commit
- `git push origin v2.0.0-beta` 


Obviously I cannot run a full fledged CI on my fork, because I am missing the whole circleCI context on my personal circleCI config.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>