### PR TITLE
feat: context list CLI

### DIFF
--- a/cmd/datamon/cmd/context.go
+++ b/cmd/datamon/cmd/context.go
@@ -6,8 +6,11 @@
 package cmd
 
 import (
+	"context"
 	"text/template"
 
+	"github.com/oneconcern/datamon/pkg/storage"
+	"github.com/oneconcern/datamon/pkg/storage/gcs"
 	"github.com/spf13/cobra"
 )
 
@@ -28,10 +31,24 @@ var contextTemplate *template.Template
 
 func init() {
 	rootCmd.AddCommand(ContextCmd)
-	addContextFlag(ContextCmd)
 
 	contextTemplate = func() *template.Template {
-		const listLineTemplateString = `{{.Version}} , {{.Name}} , {{.WAL}} , {{.ReadLog}} , {{.Blob}} , {{.Metadata}} , {{.VMetadata}}`
+		const listLineTemplateString = `Model Version: {{.Version}}
+Name: {{.Name}}
+WAL: {{.WAL}}
+ReadLog: {{.ReadLog}}
+Blob: {{.Blob}}
+Metadata: {{.Metadata}}
+Version Metadata: {{.VMetadata}}
+`
 		return template.Must(template.New("list line").Parse(listLineTemplateString))
 	}()
+}
+
+func mustGetConfigStore() storage.Store {
+	configStore, err := gcs.New(context.Background(), datamonFlags.core.Config, config.Credential)
+	if err != nil {
+		wrapFatalln("failed to create config store", err)
+	}
+	return configStore
 }

--- a/cmd/datamon/cmd/context.go
+++ b/cmd/datamon/cmd/context.go
@@ -33,14 +33,7 @@ func init() {
 	rootCmd.AddCommand(ContextCmd)
 
 	contextTemplate = func() *template.Template {
-		const listLineTemplateString = `Model Version: {{.Version}}
-Name: {{.Name}}
-WAL: {{.WAL}}
-ReadLog: {{.ReadLog}}
-Blob: {{.Blob}}
-Metadata: {{.Metadata}}
-Version Metadata: {{.VMetadata}}
-`
+		const listLineTemplateString = `Model Version: {{.Version}}, Name: {{.Name}}, WAL: {{.WAL}}, ReadLog: {{.ReadLog}}, Blob: {{.Blob}}, Metadata: {{.Metadata}}, Version Metadata: {{.VMetadata}}`
 		return template.Must(template.New("list line").Parse(listLineTemplateString))
 	}()
 }

--- a/cmd/datamon/cmd/context_create.go
+++ b/cmd/datamon/cmd/context_create.go
@@ -26,7 +26,7 @@ var ContextCreateCommand = &cobra.Command{
 func createContext() {
 	configStore, err := gcs.New(context2.Background(), datamonFlags.core.Config, config.Credential)
 	if err != nil {
-		wrapFatalln("failed to create config store. ", err)
+		wrapFatalln("failed to create config store", err)
 	}
 	err = context.CreateContext(context2.Background(), configStore, datamonFlags.context.Descriptor)
 	if err != nil {

--- a/cmd/datamon/cmd/context_get.go
+++ b/cmd/datamon/cmd/context_get.go
@@ -15,7 +15,6 @@ import (
 	"github.com/oneconcern/datamon/pkg/errors"
 	"github.com/oneconcern/datamon/pkg/model"
 
-	"github.com/oneconcern/datamon/pkg/storage/gcs"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 )
@@ -31,15 +30,12 @@ var ContextGetCommand = &cobra.Command{
 }
 
 func getContext() {
-	configStore, err := gcs.New(context.Background(), datamonFlags.core.Config, config.Credential)
-	if err != nil {
-		wrapFatalln("failed to create config store. ", err)
-	}
+	configStore := mustGetConfigStore()
 	contextName := datamonFlags.context.Descriptor.Name
 	has, err := configStore.Has(context.Background(),
 		model.GetPathToContext(contextName))
 	if err != nil {
-		wrapFatalln("failed to test if context exists. ", err)
+		wrapFatalln("context does not exist", err)
 		return
 	}
 	if !has {

--- a/cmd/datamon/cmd/context_list.go
+++ b/cmd/datamon/cmd/context_list.go
@@ -4,3 +4,36 @@
  */
 
 package cmd
+
+import (
+	"log"
+
+	"github.com/oneconcern/datamon/pkg/core"
+	"github.com/spf13/cobra"
+)
+
+// ContextListCommand is a command to list all available contexts
+var ContextListCommand = &cobra.Command{
+	Use:   "list",
+	Short: "List available contexts",
+	Long:  "List all available contexts in a remote configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		listContexts()
+	},
+}
+
+func listContexts() {
+	configStore := mustGetConfigStore()
+	contexts, err := core.ListContexts(configStore)
+	if err != nil {
+		wrapFatalln("list contexts error", err)
+		return
+	}
+	log.Printf("%v", contexts)
+}
+
+func init() {
+	addConfigFlag(ContextListCommand)
+
+	ContextCmd.AddCommand(ContextListCommand)
+}

--- a/docs/usage/datamon_context.md
+++ b/docs/usage/datamon_context.md
@@ -11,8 +11,7 @@ Commands to manage contexts. A context is an instance of Datamon with set of rep
 ### Options
 
 ```
-      --context string   Set the context for datamon (default "dev")
-  -h, --help             help for context
+  -h, --help   help for context
 ```
 
 ### Options inherited from parent commands
@@ -26,4 +25,5 @@ Commands to manage contexts. A context is an instance of Datamon with set of rep
 * [datamon](datamon.md)	 - Datamon helps building ML pipelines
 * [datamon context create](datamon_context_create.md)	 - Create a context
 * [datamon context get](datamon_context_get.md)	 - Get a context info
+* [datamon context list](datamon_context_list.md)	 - List available contexts
 

--- a/docs/usage/datamon_context_create.md
+++ b/docs/usage/datamon_context_create.md
@@ -17,6 +17,7 @@ datamon context create [flags]
 ```
       --blob string       The name of the bucket hosting the datamon blobs
       --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string    Set the context for datamon (default "dev")
   -h, --help              help for create
       --meta string       The name of the bucket used by datamon metadata
       --read-log string   The name of the bucket hosting the read log
@@ -27,8 +28,7 @@ datamon context create [flags]
 ### Options inherited from parent commands
 
 ```
-      --context string   Set the context for datamon (default "dev")
-      --upgrade          Upgrades the current version then carries on with the specified command
+      --upgrade   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_get.md
+++ b/docs/usage/datamon_context_get.md
@@ -15,15 +15,15 @@ datamon context get [flags]
 ### Options
 
 ```
-      --config string   Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-  -h, --help            help for get
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+  -h, --help             help for get
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --context string   Set the context for datamon (default "dev")
-      --upgrade          Upgrades the current version then carries on with the specified command
+      --upgrade   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_list.md
+++ b/docs/usage/datamon_context_list.md
@@ -1,0 +1,31 @@
+**Version: dev**
+
+## datamon context list
+
+List available contexts
+
+### Synopsis
+
+List all available contexts in a remote configuration
+
+```
+datamon context list [flags]
+```
+
+### Options
+
+```
+      --config string   Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+  -h, --help            help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --upgrade   Upgrades the current version then carries on with the specified command
+```
+
+### SEE ALSO
+
+* [datamon context](datamon_context.md)	 - Commands to manage contexts.
+

--- a/pkg/context/status/status.go
+++ b/pkg/context/status/status.go
@@ -10,12 +10,16 @@ var (
 
 	// ErrInitMetadata indicates that we could not initialize the metadata store for this context
 	ErrInitMetadata = errors.New("failed to initialize metadata store")
+
 	// ErrInitBlob indicates that we could not initialize the blob store for this context
 	ErrInitBlob = errors.New("failed to initialize blob store")
+
 	// ErrInitVMetadata indicates that we could not initialize the versioned metadata for this context
 	ErrInitVMetadata = errors.New("failed to initialize vmetadata store")
+
 	// ErrInitWAL indicates that we could not initialize the write-ahead-log for this context
 	ErrInitWAL = errors.New("failed to initialize wal store")
+
 	// ErrInitRLog indicates that we could not initialize the read log for this context
 	ErrInitRLog = errors.New("failed to initialize read log store")
 )

--- a/pkg/core/context_list.go
+++ b/pkg/core/context_list.go
@@ -1,0 +1,46 @@
+package core
+
+import (
+	"context"
+	"sort"
+
+	"github.com/oneconcern/datamon/pkg/core/status"
+	"github.com/oneconcern/datamon/pkg/model"
+	"github.com/oneconcern/datamon/pkg/storage"
+)
+
+const (
+	typicalContextsNum = 16 // default number of allocated memory slots for contexts in a config
+)
+
+// ListContexts provides the list of available contexts in a remote configuration store, sorted.
+func ListContexts(config storage.Store) ([]string, error) {
+	contexts := make([]string, 0, typicalContextsNum)
+	iterator := func(next string) ([]string, string, error) {
+		return config.KeysPrefix(context.Background(), next, model.GetArchivePathPrefixToContexts(), "", typicalContextsNum)
+	}
+
+	var (
+		keys []string
+		next string
+		err  error
+	)
+	for {
+		keys, next, err = iterator(next)
+		if err != nil {
+			return nil, status.ErrConfigContext.Wrap(err)
+		}
+		for _, k := range keys {
+			c, erp := model.GetArchivePathComponents(k)
+			if erp != nil {
+				return nil, status.ErrConfigContext.Wrap(err)
+			}
+			contexts = append(contexts, c.Context)
+		}
+		if next == "" {
+			break
+		}
+	}
+	sort.Strings(contexts)
+	return contexts, nil
+}

--- a/pkg/core/status/status.go
+++ b/pkg/core/status/status.go
@@ -8,8 +8,13 @@ import (
 var (
 	// ErrInterrupted signals that the current background processing has been interrupted
 	ErrInterrupted = errors.New("background processing interrupted")
+
 	// ErrNotFound indicates an object was not found
 	ErrNotFound = errors.New("not found")
+
 	// ErrUnexpectedUpdate indicates an update operation was attempted on some immutable store
 	ErrUnexpectedUpdate = errors.New("unexpected update")
+
+	// ErrConfigContext indicates an error while attempting to retrieve contexts from a remote config store
+	ErrConfigContext = errors.New("error retrieving contexts from config store")
 )

--- a/pkg/model/context.go
+++ b/pkg/model/context.go
@@ -7,6 +7,7 @@ package model
 
 import (
 	"fmt"
+	"path"
 
 	"gopkg.in/yaml.v2"
 )
@@ -30,8 +31,16 @@ type Context struct {
 
 // GetPathToContext returns the path to the context descriptor.
 func GetPathToContext(context string) string {
-	// TODO: should probably add "contexts/" to be able to efficiently list available contexts
-	return context + "/" + contextDescriptorFile
+	return path.Join(getArchivePathToContexts(), context, contextDescriptorFile)
+}
+
+// GetArchivePathPrefixToContexts returns the path to the list of contexts
+func GetArchivePathPrefixToContexts() string {
+	return getArchivePathToContexts()
+}
+
+func getArchivePathToContexts() string {
+	return fmt.Sprint("contexts/")
 }
 
 // GetWALName yields the name of the Write Ahead Log store

--- a/pkg/model/paths.go
+++ b/pkg/model/paths.go
@@ -28,6 +28,7 @@ type ArchivePathComponents struct {
 	BundleID        string
 	ArchiveFileName string
 	LabelName       string
+	Context         string
 }
 
 // GetArchivePathComponents yields all components from an archive path.
@@ -38,10 +39,11 @@ type ArchivePathComponents struct {
 // The return value might be changed to an interface type in later iterations.
 func GetArchivePathComponents(archivePath string) (ArchivePathComponents, error) {
 	const (
-		maxPos    = 4
-		labelPos  = 3 // as in: labels/{repo}/{label}/label.yaml
-		repoPos   = 2 // as in: repos/{repo}/repo.yaml
-		bundlePos = 3 // as in: bundles/{repo}/{bundleID}/bundle.yaml
+		maxPos     = 4
+		labelPos   = 3 // as in: labels/{repo}/{label}/label.yaml
+		repoPos    = 2 // as in: repos/{repo}/repo.yaml
+		bundlePos  = 3 // as in: bundles/{repo}/{bundleID}/bundle.yaml
+		contextPos = 2 // as in: contexts/{context}/context.yaml
 	)
 	cs := strings.SplitN(archivePath, "/", maxPos)
 	switch cs[0] { // we always have at least 1 element
@@ -95,7 +97,15 @@ func GetArchivePathComponents(archivePath string) (ArchivePathComponents, error)
 				fmt.Errorf("path is invalid, last element in the path should be either empty, %q or \"%s[nnn].yaml\". components: %v, path: %s",
 					bundleDescriptorFile, bundleFilesIndexPrefix, cs, archivePath)
 		}
-	// TODO: contexts
+	case "contexts":
+		if len(cs) < contextPos+1 {
+			return ArchivePathComponents{},
+				fmt.Errorf("path is invalid: expect path to context to have %d parts: %s", contextPos+1, archivePath)
+		}
+		return ArchivePathComponents{
+			ArchiveFileName: cs[contextPos],
+			Context:         cs[contextPos-1],
+		}, nil // placeholder in case of more parsing
 	default:
 		return ArchivePathComponents{}, fmt.Errorf("path is invalid: %v, path: %s", cs, archivePath)
 	}


### PR DESCRIPTION
* adds datamon context list command
* revisits remote config metadata structure for contexts, i.e. adds path `contexts/{context}`
* makes context rendering more explicit (template)
* fixes [RES-1438]

## ATTENTION
The CI ~~does not pass because this PR~~ now passes -- This PR brings a breaking change to the structure of the remote config. If we agree on the principle of this change, I can make it to work by adapting the remote config (simply copying the */context.yaml into contexts/*/context.yaml in the config bucket).

~~For the moment, I am not changing the test remote config that Ransom did create.~~

@ransomw1c I've now adapted the remote config bucket used by the fuse test, but did not remove anything yet: just copied the context.yaml definitions into the new `/contexts/{xxxx}/context.yaml` 

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>

[RES-1438]: https://oneconcern.atlassian.net/browse/RES-1438