### PR TITLE
fixup CI filters again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,25 +258,50 @@ workflows:
   build_and_test:
     jobs:
       - go_lint:
-         context: "OC Common"
+          context: "OC Common"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
 
       - go_test:
           context: "OC Common"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
 
       - fuse_sidecar_test:
           context: "OC Common"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
 
       - build_images:
           context: "OC Common"
           requires:
             - go_lint
             - go_test
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
 
       - build_demo_images:
           context: "OC Common"
           requires:
             - go_lint
             - go_test
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
 
       - publish_release:
           context: "OC Common"
@@ -288,4 +313,5 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only:
+                - master


### PR DESCRIPTION
I've done this dozen of times and every time, I get confused with CircleCI filtering rules.

Hope it's better now, as this run seems to show up as expected: https://app.circleci.com/github/fredbi/datamon/pipelines

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>