### PR TITLE
fix(errors): fixed race conditions with unduly mutable errors

### DIFF
--- a/cmd/datamon/cmd/bundle_get.go
+++ b/cmd/datamon/cmd/bundle_get.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oneconcern/datamon/pkg/core"
 	status "github.com/oneconcern/datamon/pkg/core/status"
+	"github.com/oneconcern/datamon/pkg/errors"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
@@ -29,11 +30,11 @@ exits with ENOENT status otherwise.`,
 		}
 
 		err = setLatestOrLabelledBundle(ctx, remoteStores)
-		if err == status.ErrNotFound {
-			wrapFatalWithCode(int(unix.ENOENT), "didn't find label %q", datamonFlags.label.Name)
-			return
-		}
 		if err != nil {
+			if errors.Is(err, status.ErrNotFound) {
+				wrapFatalWithCode(int(unix.ENOENT), "didn't find label %q", datamonFlags.label.Name)
+				return
+			}
 			wrapFatalln("determine bundle id", err)
 			return
 		}
@@ -47,11 +48,11 @@ exits with ENOENT status otherwise.`,
 		)
 
 		err = core.DownloadMetadata(ctx, bundle)
-		if err == status.ErrNotFound {
-			wrapFatalWithCode(int(unix.ENOENT), "didn't find bundle %q", datamonFlags.bundle.ID)
-			return
-		}
 		if err != nil {
+			if errors.Is(err, status.ErrNotFound) {
+				wrapFatalWithCode(int(unix.ENOENT), "didn't find bundle %q", datamonFlags.bundle.ID)
+				return
+			}
 			wrapFatalln("error downloading bundle information", err)
 			return
 		}

--- a/cmd/datamon/cmd/config.go
+++ b/cmd/datamon/cmd/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/oneconcern/datamon/pkg/errors"
 	"github.com/oneconcern/datamon/pkg/model"
 	"github.com/oneconcern/datamon/pkg/storage"
 	"github.com/oneconcern/datamon/pkg/storage/gcs"
@@ -101,10 +102,10 @@ func (*CLIConfig) populateRemoteConfig(flags *flagsT) {
 
 func handleRemoteConfigErr(store storage.Store, err error) (storage.Store, error) {
 	// provide extra explanation and guidance about the error
-	switch err {
-	case storagestatus.ErrInvalidResource:
+	switch {
+	case errors.Is(err, storagestatus.ErrInvalidResource):
 		return nil, fmt.Errorf("please check that the config bucket %v is a valid gcs bucket: %w", store, err)
-	case storagestatus.ErrNotExists:
+	case errors.Is(err, storagestatus.ErrNotExists):
 		return nil, fmt.Errorf("please check that the config bucket has been created in your remote config at %v: %w", store, err)
 	}
 	return store, err
@@ -112,10 +113,10 @@ func handleRemoteConfigErr(store storage.Store, err error) (storage.Store, error
 
 func handleContextErr(r io.ReadCloser, err error) (io.ReadCloser, error) {
 	// provide extra explanation and guidance about the error
-	switch err {
-	case storagestatus.ErrInvalidResource:
+	switch {
+	case errors.Is(err, storagestatus.ErrInvalidResource):
 		return nil, fmt.Errorf("please check that the config bucket is a valid gcs bucket: %w", err)
-	case storagestatus.ErrNotExists:
+	case errors.Is(err, storagestatus.ErrNotExists):
 		return nil, fmt.Errorf("please check that the context has been created in your remote config: %w", err)
 	}
 	return r, err

--- a/cmd/datamon/cmd/context_get.go
+++ b/cmd/datamon/cmd/context_get.go
@@ -12,6 +12,7 @@ import (
 
 	context2 "github.com/oneconcern/datamon/pkg/context"
 	status "github.com/oneconcern/datamon/pkg/core/status"
+	"github.com/oneconcern/datamon/pkg/errors"
 	"github.com/oneconcern/datamon/pkg/model"
 
 	"github.com/oneconcern/datamon/pkg/storage/gcs"
@@ -48,7 +49,7 @@ func getContext() {
 
 	var rcvdContext model.Context
 	datamonContext, err := context2.GetContext(context.Background(), configStore, contextName)
-	if err == status.ErrNotFound {
+	if errors.Is(err, status.ErrNotFound) {
 		wrapFatalWithCode(int(unix.ENOENT), "didn't find repo %q", datamonFlags.repo.RepoName)
 		return
 	}

--- a/cmd/datamon/cmd/label_get.go
+++ b/cmd/datamon/cmd/label_get.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oneconcern/datamon/pkg/core"
 	status "github.com/oneconcern/datamon/pkg/core/status"
+	"github.com/oneconcern/datamon/pkg/errors"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
@@ -34,7 +35,7 @@ exits with ENOENT status otherwise.`,
 			core.LabelName(datamonFlags.label.Name),
 		)
 		err = label.DownloadDescriptor(ctx, bundle, true)
-		if err == status.ErrNotFound {
+		if errors.Is(err, status.ErrNotFound) {
 			wrapFatalWithCode(int(unix.ENOENT), "didn't find label %q", datamonFlags.label.Name)
 			return
 		}

--- a/cmd/datamon/cmd/repo_get.go
+++ b/cmd/datamon/cmd/repo_get.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/oneconcern/datamon/pkg/core"
 	status "github.com/oneconcern/datamon/pkg/core/status"
+	"github.com/oneconcern/datamon/pkg/errors"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 )
 
+// GetRepoCommand retrieves the description of a repo
 var GetRepoCommand = &cobra.Command{
 	Use:   "get",
 	Short: "Get repo info by name",
@@ -27,11 +29,11 @@ exits with ENOENT status otherwise.`,
 		}
 		repoDescriptor, err := core.GetRepoDescriptorByRepoName(
 			remoteStores, datamonFlags.repo.RepoName)
-		if err == status.ErrNotFound {
-			wrapFatalWithCode(int(unix.ENOENT), "didn't find repo %q", datamonFlags.repo.RepoName)
-			return
-		}
 		if err != nil {
+			if errors.Is(err, status.ErrNotFound) {
+				wrapFatalWithCode(int(unix.ENOENT), "didn't find repo %q", datamonFlags.repo.RepoName)
+				return
+			}
 			wrapFatalln("error downloading repo information", err)
 			return
 		}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -49,8 +49,10 @@ func (e *Error) Wrap(err error) *Error {
 	if e == nil {
 		return &Error{msg: err.Error()}
 	}
-	e.err = err
-	return e
+	return &Error{
+		msg: e.msg,
+		err: err,
+	}
 }
 
 // WrapMessage wraps a nested message error as with fmt.Errorf()
@@ -83,7 +85,10 @@ func (e *Error) Is(target error) bool {
 	if e == nil {
 		return target == nil
 	}
-	if e == target {
+	if thisTgt, ok := target.(*Error); ok && e.msg == thisTgt.msg {
+		return true
+	}
+	if e.msg == target.Error() {
 		return true
 	}
 	if e.err != nil {


### PR DESCRIPTION
Error wrapping did introduce some race conditions by returning the _same_ variable
when wrapping, instead of _a copy_ of the error. This PR fixes the problem.

ATTENTION: this a prerequisite for releasing. PR #339 is based on top of this one.

* fixes #336

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>