### PR TITLE
Goreleaser debug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ executors:
   # TODO(frederic): add builder for alpine and compare
   docker_builder:
     working_directory: ~/project
+    environment:
+      GOOGLE_PROJECT_ID: "onec-co"
+      GOOGLE_COMPUTE_ZONE: us-west2-c
     docker:
       - image: circleci/golang
 
@@ -33,7 +36,7 @@ commands:
           name: Install packages with gcloud SDK installed locally
           command: |
             sudo apt-get update -y --quiet
-            sudo apt-get install --quiet lsb-release
+            sudo apt-get install --quiet lsb-release upx
             export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
             echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
             curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add
@@ -236,22 +239,39 @@ jobs:
     # > goreleaser needs access to github API, not only the git repo.
     # > Hence ssh key is not sufficient and GITHUB_TOKEN is required.
     steps:
+      - setup_remote_docker:
+          version: 18.09.3
+      - install_base
+      - checkout
+      - restore_cache:
+          keys:
+            - pkg-cache-{{ checksum "go.sum" }}
+            - pkg-cache-
+      - login_to_google
       - run:
           name: Prepare github release
           command: |
+            #PATH=${PATH}:/usr/local/go/bin:${GOPATH}/bin
+            PATH=${PATH}:${GOPATH}/bin
+            opts="--debug"
             # self-installing goreleaser
-            curl -sL https://git.io/goreleaser > goreleaser
-            chmod u+x goreleaser
+            curl -sL https://git.io/goreleaser > ${GOPATH}/bin/goreleaser
+            chmod u+x ${GOPATH}/bin/goreleaser
             release_notes="./notes/NOTES.${CIRCLE_TAG}.md"
-            if [[ -n ${CIRCLE_TAG} && -f ${RELEASE_NOTES} ]] ; then
+            if [[ -n "${CIRCLE_TAG}" && -f ${RELEASE_NOTES} ]] ; then
               # use custom release notes
               echo "Adding release notes ${release_notes}"
-              opts="--release-notes ${release_notes}"
+              opts="${opts} --release-notes ${release_notes}"
+            else
               # otherwise, leaves standard changelog from goreleaser
               # (picks up all commits)
+              echo "No release notes provided: standard changelog applies"
+            fi
+            if [[ -z "${CIRCLE_TAG}" ]] ; then
+              echo "No tag defined for this commit. goleaser will fail [test purpose]"
             fi
             echo "Preparing release ${CIRCLE_TAG}"
-            ./goreleaser ${opts-""}
+            goreleaser ${opts} 2>&1
 
 workflows:
   version: 2
@@ -314,4 +334,5 @@ workflows:
               only: /^v.*/
             branches:
               only:
+                - goreleaser-debug
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,4 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              only:
-                - goreleaser-debug
-                - master
+              ignore: /.*/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ archives:
     builds:
       - migrate
       - datamon_metrics
-    name_template: '{{ .ProjectName }}_tools_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    name_template: '{{ .ProjectName }}-tools_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format: 'tar.gz'
     # TODO(frederic): add release notes/changelog when we have one
     files:
@@ -98,7 +98,4 @@ brews:
     install: |
       bin.install "datamon"
     test: |
-      # TODO(frederic): this hack will no longer be necessary when we remove this
-      # global env requirement for command "version".
-      ENV["DATAMON_GLOBAL_CONFIG"] = "x"
       system "#{bin}/datamon", "version"

--- a/cmd/datamon/cmd/self_upgrade.go
+++ b/cmd/datamon/cmd/self_upgrade.go
@@ -16,10 +16,13 @@ import (
 )
 
 const (
-	githubRepo = "fredbi/datamon"
+	githubRepo = "oneconcern/datamon"
 )
 
-var releaseDescriptorTemplate *template.Template
+var (
+	releaseDescriptorTemplate *template.Template
+	assetFilter               selfupdate.Option
+)
 
 func init() {
 	releaseDescriptorTemplate = func() *template.Template {
@@ -34,6 +37,7 @@ Release Notes: {{ .ReleaseNotes }}
 `
 		return template.Must(template.New("release").Parse(releaseTemplateString))
 	}()
+	assetFilter = selfupdate.AssetFilter("^datamon([^-]?.?)_")
 }
 
 func applyReleaseTemplate(release *selfupdate.Release) error {
@@ -75,7 +79,7 @@ func doSelfUpgrade(opts upgradeFlags) error {
 		selfupdate.EnableLog()
 	}
 
-	latest, err := selfupdate.UpdateCommand(opts.selfBinary, v, githubRepo)
+	latest, err := selfupdate.UpdateCommand(opts.selfBinary, v, githubRepo, assetFilter)
 	if err != nil {
 		return errors.New("binary update failed").Wrap(err)
 	}
@@ -90,7 +94,6 @@ func doSelfUpgrade(opts upgradeFlags) error {
 	}
 	return nil
 }
-
 func doCheckVersion() error {
 	isRelease := false
 	version := NewVersionInfo().Version
@@ -102,7 +105,7 @@ func doCheckVersion() error {
 		isRelease = true
 	}
 
-	latest, found, err := selfupdate.DefaultUpdater().DetectLatest(githubRepo)
+	latest, found, err := selfupdate.DefaultUpdater().DetectLatest(githubRepo, assetFilter)
 	if err != nil {
 		return errors.New(fmt.Sprintf("could not fetch release from github repo (%s)", githubRepo)).Wrap(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/oneconcern/datamon
 
 // NOTE: goleak is a test dependency based on master and not the latest release (stalled)
+// NOTE: rhyds/go-github.-selfupdate carries out binary self update. My fork fixes an issue with
+// multi-artifacts releases (will prompty push PR to owner)
+replace github.com/rhysd/go-github-selfupdate => github.com/fredbi/go-github-selfupdate v1.2.0
 
 require (
 	cloud.google.com/go v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fredbi/go-github-selfupdate v1.2.0 h1:4wmtpH3u0JGRs7xWf29kdbb6wd2Om6t0DdyD+OWDFek=
+github.com/fredbi/go-github-selfupdate v1.2.0/go.mod h1:BZHw2H9JIH7wdyda/btlRRD+sgudn1RO1NbnvY27/Ng=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
> I know this one is quite hard to review because it interacts with many things.
> My apologies for that. It is probably not that easy to release the releaser...

> I've tried to add a much material as I could to get some understanding of what's going on here.
> You may also have a look at some CI pipeline executions (yes, many failed over the past few days...).

- onboards regression fix PR #337 
- fixes CI stuff preventing release (many little things that required some ssh in-container debug)
- temporarily enables releasing from a branch with special name "goreleaser-debug", for debugging purpose
- successfully tested on some dummy prebeta tags (tags and release artifacts since removed)
- verified that the homebrew-datamon repo is properly updated

Additional manual tests (beyond CI):
- [x] `brew tap oneconcern/datamon && brew install datamon && datamon version`: ok
- [x] `datamon upgrade`: OK, when built from source: `datamon upgrade --force` ok

## UPDATE
Now that CI can properly deploy a release, I've added a last commit to remove the debug branch to be able to deploy a release (filter is from master only atm).

Screenshots from pre-beta runs:
![release_1](https://user-images.githubusercontent.com/14262513/70915590-668d5b80-201a-11ea-8888-123764355c8d.png)

![release_2](https://user-images.githubusercontent.com/14262513/70915606-6b520f80-201a-11ea-89bd-f84de0c0e277.png)

![release_3](https://user-images.githubusercontent.com/14262513/70915615-7016c380-201a-11ea-9a88-0ba515260fc9.png)
