### PR TITLE
feat(bundle): optionally displays labels associated to a bundle

### DIFF
--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -34,6 +34,7 @@ type flagsT struct {
 		SkipOnError       bool
 		ConcurrencyFactor int
 		NameFilter        string
+		WithLabels        bool
 	}
 	web struct {
 		port      int
@@ -203,6 +204,12 @@ func addLabelPrefixFlag(cmd *cobra.Command) string {
 	prefixString := "prefix"
 	cmd.Flags().StringVar(&datamonFlags.label.Prefix, prefixString, "", "List labels starting with a prefix.")
 	return prefixString
+}
+
+func addWithLabelFlag(cmd *cobra.Command) string {
+	withLabels := "with-labels"
+	cmd.Flags().BoolVar(&datamonFlags.bundle.WithLabels, withLabels, false, "Include labels in the returned bundle metadata")
+	return withLabels
 }
 
 func addRepoNameOptionFlag(cmd *cobra.Command) string {

--- a/cmd/datamon/cmd/label.go
+++ b/cmd/datamon/cmd/label.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"text/template"
 
+	context2 "github.com/oneconcern/datamon/pkg/context"
+	"github.com/oneconcern/datamon/pkg/core"
+	"github.com/oneconcern/datamon/pkg/model"
 	"github.com/spf13/cobra"
 )
 
@@ -35,4 +38,15 @@ func init() {
 		const listLineTemplateString = `{{.Name}} , {{.BundleID}} , {{.Timestamp}}`
 		return template.Must(template.New("list line").Parse(listLineTemplateString))
 	}()
+}
+
+// getLabels is a helper to synchronously retrieve labels and enrich the result from other commands
+func getLabels(remoteStores context2.Stores) []model.LabelDescriptor {
+	labels, err := core.ListLabels(datamonFlags.repo.RepoName, remoteStores, "",
+		core.ConcurrentList(datamonFlags.core.ConcurrencyFactor),
+		core.BatchSize(datamonFlags.core.BatchSize))
+	if err != nil {
+		wrapFatalln("could not download label list: %w", err)
+	}
+	return labels
 }

--- a/docs/usage/datamon_bundle_get.md
+++ b/docs/usage/datamon_bundle_get.md
@@ -22,6 +22,7 @@ datamon bundle get [flags]
   -h, --help            help for get
       --label string    The human-readable name of a label
       --repo string     The name of this repository
+      --with-labels     Include labels in the returned bundle metadata
 ```
 
 ### Options inherited from parent commands

--- a/docs/usage/datamon_bundle_list.md
+++ b/docs/usage/datamon_bundle_list.md
@@ -28,6 +28,7 @@ datamon bundle list [flags]
       --concurrency-factor int   Heuristic on the amount of concurrency used by core operations. Concurrent retrieval of metadata is capped by the 'batch-size' parameter. Turn this value down to use less memory, increase for faster operations. (default 500)
   -h, --help                     help for list
       --repo string              The name of this repository
+      --with-labels              Include labels in the returned bundle metadata
 ```
 
 ### Options inherited from parent commands

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fredbi/go-github-selfupdate v1.2.0 h1:4wmtpH3u0JGRs7xWf29kdbb6wd2Om6t0DdyD+OWDFek=
-github.com/fredbi/go-github-selfupdate v1.2.0/go.mod h1:BZHw2H9JIH7wdyda/btlRRD+sgudn1RO1NbnvY27/Ng=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -213,6 +211,7 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
@@ -221,8 +220,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rhysd/go-github-selfupdate v1.1.0 h1:+aMomy69YCYxJ6kr13nYIgAJWSB1kHK5M5YpbmjQkWo=
-github.com/rhysd/go-github-selfupdate v1.1.0/go.mod h1:jbfShZ+Nl3IHUgr77kwQjObcWf1z961UAoD6p5LrPBU=
 github.com/rhysd/go-github-selfupdate v1.2.1 h1:CpU7O4BcHhvcXEBsQSKD50uQ1o4/qv/15Ev6TPAtU3s=
 github.com/rhysd/go-github-selfupdate v1.2.1/go.mod h1:BZHw2H9JIH7wdyda/btlRRD+sgudn1RO1NbnvY27/Ng=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
* fixes #235

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>

## Note to reviewers

This I consider an early experiment to gauge competing ideas about how to deal with CLI features that pertain to the "porcelain" layer.

While I am all in for some DSL approach that would eventually result in neater code, I have difficulties figuring out how it would actually look like.

This PR plays here the devil's advocate and is my 2 cents contribution to this interesting debate about implementing porcelain, with some code-grounded facts. No big deal if this PR is discarded....

I wanted to figure out a more accurate idea about how much of code/complexity such user requirements actually entail when implemented with the basic tooling the CLI is currently providing.

Regarding expected results, I followed the approach recommended by @ransomw1c in #235 (";" separators) and did not try to over-engineer it with some asynchronous fetching of labels.