### PR TITLE
[wip] web ui dbg

### DIFF
--- a/cmd/datamon/cmd/repo_list.go
+++ b/cmd/datamon/cmd/repo_list.go
@@ -33,6 +33,9 @@ fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01
 			wrapFatalln("create remote stores", err)
 			return
 		}
+
+	fmt.Printf("using remote stores:\n%v\n", remoteStores)
+
 		err = core.ListReposApply(remoteStores, applyRepoTemplate,
 			core.ConcurrentList(datamonFlags.core.ConcurrencyFactor),
 			core.BatchSize(datamonFlags.core.BatchSize))

--- a/cmd/datamon/cmd/web.go
+++ b/cmd/datamon/cmd/web.go
@@ -25,6 +25,9 @@ var webSrv = &cobra.Command{
 			wrapFatalln("create remote stores", err)
 			return
 		}
+
+	fmt.Printf("using remote stores:\n%v\n", stores)
+
 		s, err := web.NewServer(web.ServerParams{
 			Stores:     stores,
 			Credential: config.Credential,
@@ -48,7 +51,7 @@ func init() {
 	addWebPortFlag(webSrv)
 
 	/* core datamonFlags */
-	//	addMetadataBucket(repoList)
+	addContextFlag(webSrv)
 
 	rootCmd.AddCommand(webSrv)
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -116,6 +116,11 @@ func (c *defaultStores) Wal() storage.Store {
 	return c.wal
 }
 
+func (c *defaultStores) String() string {
+	return fmt.Sprintf("wal: %q, readLog: %q, blob: %q, metadata %q, vMetadata: %q",
+		c.wal, c.readLog, c.blob, c.metadata, c.vMetadata)
+}
+
 // CreateContext marshals and persists a context in the remote config
 func CreateContext(ctx context.Context, configStore storage.Store, context model.Context) error {
 	// 1. Validate


### PR DESCRIPTION
the `web` command is out of commission after the config bucket and context structure changes.

this patch is to restore the `web` command.
