### PR TITLE
feat(web): added auto-start with browser on datamon web CLI

### DIFF
--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -36,7 +36,8 @@ type flagsT struct {
 		NameFilter        string
 	}
 	web struct {
-		port int
+		port      int
+		noBrowser bool
 	}
 	label struct {
 		Prefix string
@@ -180,8 +181,15 @@ func addBatchSizeFlag(cmd *cobra.Command) string {
 }
 
 func addWebPortFlag(cmd *cobra.Command) string {
-	cmd.Flags().IntVar(&datamonFlags.web.port, webPort, 3003, "Port number for the web server")
+	webPort := "port"
+	cmd.Flags().IntVar(&datamonFlags.web.port, webPort, 0, "Port number for the web server (defaults to random port)")
 	return webPort
+}
+
+func addWebNoBrowserFlag(cmd *cobra.Command) string {
+	c := "no-browser"
+	cmd.Flags().BoolVar(&datamonFlags.web.noBrowser, c, false, "Disable automatic launch of a browser")
+	return c
 }
 
 func addLabelNameFlag(cmd *cobra.Command) string {

--- a/docs/usage/datamon_bundle_mount_new.md
+++ b/docs/usage/datamon_bundle_mount_new.md
@@ -18,6 +18,7 @@ datamon bundle mount new [flags]
       --daemonize            Whether to run the command as a daemonized process
       --destination string   The path to the download dir
   -h, --help                 help for new
+      --label string         The human-readable name of a label
       --message string       The message describing the new bundle
       --mount string         The path to the mount dir
       --repo string          The name of this repository

--- a/docs/usage/datamon_web.md
+++ b/docs/usage/datamon_web.md
@@ -6,7 +6,7 @@ Webserver
 
 ### Synopsis
 
-A webserver process to browse Datamon data
+A webserver process to browse datamon data
 
 ```
 datamon web [flags]
@@ -15,8 +15,9 @@ datamon web [flags]
 ### Options
 
 ```
-  -h, --help       help for web
-      --port int   Port number for the web server (default 3003)
+  -h, --help         help for web
+      --no-browser   Disable automatic launch of a browser
+      --port int     Port number for the web server (defaults to random port)
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/nightlyone/lockfile v0.0.0-20180618180623-0ad87eef1443
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/pelletier/go-toml v1.6.0 // indirect
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/rhysd/go-github-selfupdate v1.2.1
 	github.com/rogpeppe/go-internal v1.5.0 // indirect
 	github.com/segmentio/ksuid v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=


### PR DESCRIPTION
* changed default port to random, --port can still be used to specify a port
* added no-browser flag, to prevent launching of browser

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>