### PR TITLE
Make flags for context config persistent at root.

### DIFF
--- a/cmd/datamon/cmd/bundle.go
+++ b/cmd/datamon/cmd/bundle.go
@@ -34,7 +34,6 @@ var bundleDescriptorTemplate *template.Template
 
 func init() {
 	rootCmd.AddCommand(bundleCmd)
-	addContextFlag(bundleCmd)
 
 	bundleDescriptorTemplate = func() *template.Template {
 		const listLineTemplateString = `{{.ID}} , {{.Timestamp}} , {{.Message}}`

--- a/cmd/datamon/cmd/config_set.go
+++ b/cmd/datamon/cmd/config_set.go
@@ -81,7 +81,5 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 
 func init() {
 	addCredentialFile(configGen)
-	addContextFlag(configGen)
-	addConfigFlag(configGen)
 	configCmd.AddCommand(configGen)
 }

--- a/cmd/datamon/cmd/context_create.go
+++ b/cmd/datamon/cmd/context_create.go
@@ -44,7 +44,5 @@ func init() {
 		addContextFlag(ContextCreateCommand),
 	)
 
-	addConfigFlag(ContextCreateCommand)
-
 	ContextCmd.AddCommand(ContextCreateCommand)
 }

--- a/cmd/datamon/cmd/context_get.go
+++ b/cmd/datamon/cmd/context_get.go
@@ -69,7 +69,5 @@ func init() {
 		addContextFlag(ContextGetCommand),
 	)
 
-	addConfigFlag(ContextGetCommand)
-
 	ContextCmd.AddCommand(ContextGetCommand)
 }

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -170,7 +170,7 @@ func addContextFlag(cmd *cobra.Command) string {
 
 func addConfigFlag(cmd *cobra.Command) string {
 	config := "config"
-	cmd.Flags().StringVar(&datamonFlags.core.Config, config, "", "Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')")
+	cmd.PersistentFlags().StringVar(&datamonFlags.core.Config, config, "", "Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')")
 	return config
 }
 

--- a/cmd/datamon/cmd/label.go
+++ b/cmd/datamon/cmd/label.go
@@ -30,7 +30,6 @@ var labelDescriptorTemplate *template.Template
 
 func init() {
 	rootCmd.AddCommand(labelCmd)
-	addContextFlag(labelCmd)
 
 	labelDescriptorTemplate = func() *template.Template {
 		const listLineTemplateString = `{{.Name}} , {{.BundleID}} , {{.Timestamp}}`

--- a/cmd/datamon/cmd/repo.go
+++ b/cmd/datamon/cmd/repo.go
@@ -28,7 +28,6 @@ var repoDescriptorTemplate *template.Template
 
 func init() {
 	rootCmd.AddCommand(repoCmd)
-	addContextFlag(repoCmd)
 
 	repoDescriptorTemplate = func() *template.Template {
 		const listLineTemplateString = `{{.Name}} , {{.Description}} , {{with .Contributor}}{{.Name}} , {{.Email}}{{end}} , {{.Timestamp}}`

--- a/cmd/datamon/cmd/root.go
+++ b/cmd/datamon/cmd/root.go
@@ -73,6 +73,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	authorizer = gauth.New()
 	addConfigFlag(rootCmd)
+	addContextFlag(rootCmd)
 	addUpgradeFlag(rootCmd)
 	addUpgradeForceFlag(rootCmd)
 }

--- a/docs/usage/datamon.md
+++ b/docs/usage/datamon.md
@@ -18,10 +18,11 @@ your data buckets are organized in repositories of versioned and tagged bundles 
 ### Options
 
 ```
-      --config string   Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --force           Forces upgrade even if the current version is not a released version
-  -h, --help            help for datamon
-      --upgrade         Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --force            Forces upgrade even if the current version is not a released version
+  -h, --help             help for datamon
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle.md
+++ b/docs/usage/datamon_bundle.md
@@ -17,14 +17,15 @@ together.
 ### Options
 
 ```
-      --context string   Set the context for datamon (default "dev")
-  -h, --help             help for bundle
+  -h, --help   help for bundle
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_diff.md
+++ b/docs/usage/datamon_bundle_diff.md
@@ -26,6 +26,7 @@ datamon bundle diff [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_download.md
+++ b/docs/usage/datamon_bundle_download.md
@@ -45,6 +45,7 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_download_file.md
+++ b/docs/usage/datamon_bundle_download_file.md
@@ -36,6 +36,7 @@ datamon bundle download file [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_get.md
+++ b/docs/usage/datamon_bundle_get.md
@@ -27,6 +27,7 @@ datamon bundle get [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_list.md
+++ b/docs/usage/datamon_bundle_list.md
@@ -33,6 +33,7 @@ datamon bundle list [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_list_files.md
+++ b/docs/usage/datamon_bundle_list_files.md
@@ -38,6 +38,7 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_mount.md
+++ b/docs/usage/datamon_bundle_mount.md
@@ -31,6 +31,7 @@ datamon bundle mount [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_mount_new.md
+++ b/docs/usage/datamon_bundle_mount_new.md
@@ -28,6 +28,7 @@ datamon bundle mount new [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_update.md
+++ b/docs/usage/datamon_bundle_update.md
@@ -26,6 +26,7 @@ datamon bundle update [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_bundle_upload.md
+++ b/docs/usage/datamon_bundle_upload.md
@@ -43,6 +43,7 @@ set label 'init'
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_config.md
+++ b/docs/usage/datamon_config.md
@@ -23,7 +23,9 @@ You may force a specific local config file using the $DATAMON_CONFIG environment
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_config_set.md
+++ b/docs/usage/datamon_config_set.md
@@ -45,8 +45,6 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 ### Options
 
 ```
-      --config string       Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string      Set the context for datamon (default "dev")
       --credential string   The path to the credential file
   -h, --help                help for set
 ```
@@ -54,7 +52,9 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context.md
+++ b/docs/usage/datamon_context.md
@@ -17,7 +17,9 @@ Commands to manage contexts. A context is an instance of Datamon with set of rep
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_create.md
+++ b/docs/usage/datamon_context_create.md
@@ -16,8 +16,6 @@ datamon context create [flags]
 
 ```
       --blob string       The name of the bucket hosting the datamon blobs
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
   -h, --help              help for create
       --meta string       The name of the bucket used by datamon metadata
       --read-log string   The name of the bucket hosting the read log
@@ -28,7 +26,9 @@ datamon context create [flags]
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_get.md
+++ b/docs/usage/datamon_context_get.md
@@ -15,15 +15,15 @@ datamon context get [flags]
 ### Options
 
 ```
-      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string   Set the context for datamon (default "dev")
-  -h, --help             help for get
+  -h, --help   help for get
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_list.md
+++ b/docs/usage/datamon_context_list.md
@@ -15,14 +15,15 @@ datamon context list [flags]
 ### Options
 
 ```
-      --config string   Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-  -h, --help            help for list
+  -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label.md
+++ b/docs/usage/datamon_label.md
@@ -27,14 +27,15 @@ production
 ### Options
 
 ```
-      --context string   Set the context for datamon (default "dev")
-  -h, --help             help for label
+  -h, --help   help for label
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label_get.md
+++ b/docs/usage/datamon_label_get.md
@@ -25,6 +25,7 @@ datamon label get [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_label_list.md
+++ b/docs/usage/datamon_label_list.md
@@ -34,6 +34,7 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_label_set.md
+++ b/docs/usage/datamon_label_set.md
@@ -33,6 +33,7 @@ datamon label set [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_repo.md
+++ b/docs/usage/datamon_repo.md
@@ -17,14 +17,15 @@ They are versioned and managed via bundles.
 ### Options
 
 ```
-      --context string   Set the context for datamon (default "dev")
-  -h, --help             help for repo
+  -h, --help   help for repo
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo_create.md
+++ b/docs/usage/datamon_repo_create.md
@@ -34,6 +34,7 @@ datamon repo create [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_repo_get.md
+++ b/docs/usage/datamon_repo_get.md
@@ -24,6 +24,7 @@ datamon repo get [flags]
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_repo_list.md
+++ b/docs/usage/datamon_repo_list.md
@@ -30,6 +30,7 @@ fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01
 ### Options inherited from parent commands
 
 ```
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
       --context string   Set the context for datamon (default "dev")
       --upgrade          Upgrades the current version then carries on with the specified command
 ```

--- a/docs/usage/datamon_upgrade.md
+++ b/docs/usage/datamon_upgrade.md
@@ -23,7 +23,9 @@ datamon upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_usage.md
+++ b/docs/usage/datamon_usage.md
@@ -22,7 +22,9 @@ datamon usage [flags]
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_version.md
+++ b/docs/usage/datamon_version.md
@@ -26,7 +26,9 @@ datamon version [flags]
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_web.md
+++ b/docs/usage/datamon_web.md
@@ -23,7 +23,9 @@ datamon web [flags]
 ### Options inherited from parent commands
 
 ```
-      --upgrade   Upgrades the current version then carries on with the specified command
+      --config string    Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string   Set the context for datamon (default "dev")
+      --upgrade          Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Context and config are global flags and need to be persistent.

Signed-off-by: Ritesh H Shukla <kerneltime@gmail.com>