### PR TITLE
fix(core): failed to create backing file now displays as a warning, not an error

### DIFF
--- a/pkg/core/fs_common.go
+++ b/pkg/core/fs_common.go
@@ -121,7 +121,7 @@ func (fs *fsMutable) createNode(lk []byte, parentINode fuseops.InodeID, childNam
 		if err != nil {
 			fs.backingFiles[iNodeID] = &file
 		} else {
-			fs.l.Error("failed to create backing file",
+			fs.l.Warn("failed to create backing file: open file will retry this",
 				zap.Error(err),
 				zap.String("child", childName),
 				zap.Uint64("parent", uint64(parentINode)))


### PR DESCRIPTION
Signed-off-by: Frederic BIDON <frederic@oneconcern.com>