### PR TITLE
coreFS minor enhancements

### DIFF
--- a/cmd/datamon/cmd/bundle_mutable_mount.go
+++ b/cmd/datamon/cmd/bundle_mutable_mount.go
@@ -9,6 +9,7 @@ import (
 	daemonizer "github.com/jacobsa/daemonize"
 
 	"github.com/oneconcern/datamon/pkg/core"
+	"github.com/oneconcern/datamon/pkg/dlogger"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +53,12 @@ The destination path is a temporary staging area for write operations.`,
 		bundle := core.NewBundle(bd,
 			bundleOpts...,
 		)
-		fs, err := core.NewMutableFS(bundle, datamonFlags.bundle.DataPath)
+		logger, err := dlogger.GetLogger(datamonFlags.root.logLevel)
+		if err != nil {
+			onDaemonError("failed to set log level", err)
+			return
+		}
+		fs, err := core.NewMutableFS(bundle, datamonFlags.bundle.DataPath, logger)
 		if err != nil {
 			onDaemonError("create mutable filesystem", err)
 			return

--- a/pkg/core/fs_common.go
+++ b/pkg/core/fs_common.go
@@ -65,6 +65,10 @@ func (fs *fsCommon) opStart(op interface{}) {
 		logger.Debug("Start", zap.Uint64("id", uint64(t.Inode)))
 	case *fuseops.ReleaseFileHandleOp:
 		logger.Debug("Start", zap.Uint64("hndl", uint64(t.Handle)))
+	case *fuseops.RmDirOp:
+		logger.Debug("Start", zap.Uint64("id", uint64(t.Parent)), zap.String("name", t.Name))
+	case *fuseops.UnlinkOp:
+		logger.Debug("Start", zap.Uint64("id", uint64(t.Parent)), zap.String("name", t.Name))
 	}
 	logger.Debug("Start", zap.Any("op", op))
 }
@@ -102,6 +106,10 @@ func (fs *fsCommon) opEnd(op interface{}, err error) {
 		logger.Debug("End", zap.Uint64("id", uint64(t.Inode)), zap.Error(err))
 	case *fuseops.ReleaseFileHandleOp:
 		logger.Debug("End", zap.Uint64("hndl", uint64(t.Handle)), zap.Error(err))
+	case *fuseops.RmDirOp:
+		logger.Debug("End", zap.Uint64("id", uint64(t.Parent)), zap.String("name", t.Name), zap.Error(err))
+	case *fuseops.UnlinkOp:
+		logger.Debug("End", zap.Uint64("id", uint64(t.Parent)), zap.String("name", t.Name), zap.Error(err))
 	}
 	logger.Debug("End", zap.Any("op", op), zap.Error(err))
 }

--- a/pkg/core/fs_integration_test.go
+++ b/pkg/core/fs_integration_test.go
@@ -41,8 +41,7 @@ func TestMount(t *testing.T) {
 		ConsumableStore(consumableStore),
 		BlobStore(blobStore),
 	)
-	l, _ := zap.NewProduction()
-	fs, err := NewReadOnlyFS(bundle, l)
+	fs, err := NewReadOnlyFS(bundle, zap.NewNop())
 	require.NoError(t, err)
 	_ = os.Mkdir(pathToMount, 0777|os.ModeDir)
 	err = fs.MountReadOnly(pathToMount)
@@ -72,7 +71,7 @@ func TestMutableMount(t *testing.T) {
 		ConsumableStore(consumableStore),
 		BlobStore(blobStore),
 	)
-	fs, _ := NewMutableFS(bundle, "/tmp/")
+	fs, _ := NewMutableFS(bundle, "/tmp/", zap.NewNop())
 	_ = os.Mkdir(pathToMount, 0777|os.ModeDir)
 	err := fs.MountMutable(pathToMount)
 	require.NoError(t, err)

--- a/pkg/core/fs_ro_ops.go
+++ b/pkg/core/fs_ro_ops.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"time"
@@ -20,87 +19,30 @@ import (
 	"github.com/jacobsa/fuse/fuseutil"
 )
 
+var _ fuseutil.FileSystem = &readOnlyFsInternal{}
+
+type readOnlyFsInternal struct {
+	fsCommon
+
+	// Get iNode for path. This is needed to generate directory entries without imposing a strict order of traversal.
+	fsDirStore *iradix.Tree
+
+	// Get fsEntry for an iNode. Speed up stat and other calls keyed by iNode
+	fsEntryStore *iradix.Tree
+
+	// List of children for a given iNode. Maps inode id to list of children. This stitches the fuse FS together.
+	readDirMap map[fuseops.InodeID][]fuseutil.Dirent
+
+	// readonly
+	isReadOnly bool
+}
+
 func (fs *readOnlyFsInternal) StatFS(
 	ctx context.Context,
 	op *fuseops.StatFSOp) (err error) {
 	return statFS()
 }
 
-func (fs *readOnlyFsInternal) opStart(op interface{}) {
-	switch t := op.(type) {
-	case *fuseops.ReadFileOp:
-		fs.l.Debug("Start",
-			zap.String("Request", fmt.Sprintf("%T", op)),
-			zap.String("repo", fs.bundle.RepoID),
-			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(t.Inode)),
-			zap.Int("buffer", len(t.Dst)),
-			zap.Int64("offset", t.Offset),
-		)
-		return
-	case *fuseops.WriteFileOp:
-		fs.l.Debug("Start",
-			zap.String("Request", fmt.Sprintf("%T", op)),
-			zap.String("repo", fs.bundle.RepoID),
-			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(t.Inode)),
-		)
-		return
-	case *fuseops.ReadDirOp:
-		fs.l.Debug("Start",
-			zap.String("Request", fmt.Sprintf("%T", op)),
-			zap.String("repo", fs.bundle.RepoID),
-			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(t.Inode)),
-		)
-		return
-	}
-	fs.l.Debug("Start",
-		zap.String("Request", fmt.Sprintf("%T", op)),
-		zap.String("repo", fs.bundle.RepoID),
-		zap.String("bundle", fs.bundle.BundleID),
-		zap.Any("op", op),
-	)
-}
-func (fs *readOnlyFsInternal) opEnd(op interface{}, err error) {
-	switch t := op.(type) {
-	case *fuseops.ReadFileOp:
-		fs.l.Debug("End",
-			zap.String("Request", fmt.Sprintf("%T", op)),
-			zap.String("repo", fs.bundle.RepoID),
-			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(t.Inode)),
-			zap.Int64("offset", t.Offset),
-			zap.Error(err),
-		)
-		return
-	case *fuseops.WriteFileOp:
-		fs.l.Debug("End",
-			zap.String("Request", fmt.Sprintf("%T", op)),
-			zap.String("repo", fs.bundle.RepoID),
-			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(t.Inode)),
-			zap.Error(err),
-		)
-		return
-	case *fuseops.ReadDirOp:
-		fs.l.Debug("End",
-			zap.String("Request", fmt.Sprintf("%T", op)),
-			zap.String("repo", fs.bundle.RepoID),
-			zap.String("bundle", fs.bundle.BundleID),
-			zap.Uint64("inode", uint64(t.Inode)),
-			zap.Error(err),
-		)
-		return
-	}
-	fs.l.Debug("End",
-		zap.String("Request", fmt.Sprintf("%T", op)),
-		zap.String("repo", fs.bundle.RepoID),
-		zap.String("bundle", fs.bundle.BundleID),
-		zap.Any("op", op),
-		zap.Error(err),
-	)
-}
 func typeAssertToFsEntry(p interface{}) *fsEntry {
 	fe := p.(fsEntry)
 	return &fe
@@ -147,93 +89,11 @@ func (fs *readOnlyFsInternal) GetInodeAttributes(
 	return nil
 }
 
-func (fs *readOnlyFsInternal) SetInodeAttributes(
-	ctx context.Context,
-	op *fuseops.SetInodeAttributesOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
 func (fs *readOnlyFsInternal) ForgetInode(
 	ctx context.Context,
 	op *fuseops.ForgetInodeOp) (err error) {
 	fs.opStart(op)
 	defer fs.opEnd(op, err)
-	return
-}
-
-func (fs *readOnlyFsInternal) MkDir(
-	ctx context.Context,
-	op *fuseops.MkDirOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) MkNode(
-	ctx context.Context,
-	op *fuseops.MkNodeOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) CreateFile(
-	ctx context.Context,
-	op *fuseops.CreateFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) CreateSymlink(
-	ctx context.Context,
-	op *fuseops.CreateSymlinkOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-// Hard links are not supported in datamon.
-func (fs *readOnlyFsInternal) CreateLink(
-	ctx context.Context,
-	op *fuseops.CreateLinkOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) Rename(
-	ctx context.Context,
-	op *fuseops.RenameOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) RmDir(
-	ctx context.Context,
-	op *fuseops.RmDirOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) Unlink(
-	ctx context.Context,
-	op *fuseops.UnlinkOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
 	return
 }
 
@@ -317,99 +177,11 @@ func (fs *readOnlyFsInternal) ReadFile(
 	return err
 }
 
-func (fs *readOnlyFsInternal) WriteFile(
-	ctx context.Context,
-	op *fuseops.WriteFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) SyncFile(
-	ctx context.Context,
-	op *fuseops.SyncFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) FlushFile(
-	ctx context.Context,
-	op *fuseops.FlushFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
 func (fs *readOnlyFsInternal) ReleaseFileHandle(
 	ctx context.Context,
 	op *fuseops.ReleaseFileHandleOp) (err error) {
 	fs.opStart(op)
 	defer fs.opEnd(op, err)
-	return
-}
-
-func (fs *readOnlyFsInternal) ReadSymlink(
-	ctx context.Context,
-	op *fuseops.ReadSymlinkOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) RemoveXattr(
-	ctx context.Context,
-	op *fuseops.RemoveXattrOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) GetXattr(
-	ctx context.Context,
-	op *fuseops.GetXattrOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) ListXattr(
-	ctx context.Context,
-	op *fuseops.ListXattrOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) SetXattr(
-	ctx context.Context,
-	op *fuseops.SetXattrOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
-	return
-}
-
-func (fs *readOnlyFsInternal) Destroy() {
-	fs.l.Info("Destroy",
-		zap.String("repo", fs.bundle.RepoID),
-		zap.String("bundle", fs.bundle.BundleID),
-	)
-}
-
-func (fs *readOnlyFsInternal) Fallocate(
-	ctx context.Context,
-	op *fuseops.FallocateOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
-	err = fuse.ENOSYS
 	return
 }
 
@@ -772,31 +544,6 @@ func (fs *readOnlyFsInternal) insertDatamonFSEntry(
 	fs.readDirMap[parentInode] = childEntries
 
 	return nil
-}
-
-type readOnlyFsInternal struct {
-
-	// Backing bundle for this FS.
-	bundle *Bundle
-
-	// Get iNode for path. This is needed to generate directory entries without imposing a strict order of traversal.
-	fsDirStore *iradix.Tree
-
-	// Get fsEntry for an iNode. Speed up stat and other calls keyed by iNode
-	fsEntryStore *iradix.Tree
-
-	// Fast lookup of parent iNode id + child name, returns iNode of child. This is a common operation and it's speed is
-	// important.
-	lookupTree *iradix.Tree
-
-	// List of children for a given iNode. Maps inode id to list of children. This stitches the fuse FS together.
-	readDirMap map[fuseops.InodeID][]fuseutil.Dirent
-
-	// readonly
-	isReadOnly bool
-
-	// logger
-	l *zap.Logger
 }
 
 // fsEntry is a node in the filesystem.

--- a/pkg/core/fs_test.go
+++ b/pkg/core/fs_test.go
@@ -42,9 +42,11 @@ func TestFormLookupKey(t *testing.T) {
 func TestCreate(t *testing.T) {
 	child := "child"
 	fs := fsMutable{
-		bundle:     nil,
+		fsCommon: fsCommon{
+			bundle:     nil,
+			lookupTree: iradix.New(),
+		},
 		iNodeStore: iradix.New(),
-		lookupTree: iradix.New(),
 		readDirMap: make(map[fuseops.InodeID]map[fuseops.InodeID]*fuseutil.Dirent),
 		lock:       sync.Mutex{},
 		iNodeGenerator: iNodeGenerator{


### PR DESCRIPTION
fix(core): removed explicit stubbed FS methods and replaced them by imported fuse lib NotImplemented versions

This makes it easier to update the dependency to the fuse package (but we lose the logging of non implemented methods)

* fixes #332

fix(core): factorized type declaration and logging on core FS implementations

Same logging mechanism and interface drives both ro and rw implementations.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>