### PR TITLE
wrap_application.sh uses POSIX shebang

### DIFF
--- a/hack/fuse-demo/wrap_application.sh
+++ b/hack/fuse-demo/wrap_application.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 ### application wrapper (demo)
 # half of the container coordination sketch, a script like this one


### PR DESCRIPTION
this is a quick improvement noticed while lining up `wrap_datamon.sh` removal:  `wrap_application.sh` previously assumed `/bin/bash` to be available in an Argo DAG node's main container when using datamon with the pipelines tool.

since the availability of a POSIX standard shell at `/bin/sh` is gauranteed by linux distros and since the `shellcheck` in CI verifies that `wrap_application.sh` is POSIX-compliant, this is a relaxation or usage requirements to support a strictly larger set of uses, not a breaking change.