### PR TITLE
feat(upload): added option to preserve bundleID on upload

### DIFF
--- a/cmd/datamon/cmd/bundle_preserve_disable.go
+++ b/cmd/datamon/cmd/bundle_preserve_disable.go
@@ -1,0 +1,6 @@
+// +build !bundle_preserve
+
+package cmd
+
+// enableBundlePreserve enables to have the --bundle in datamon upload and be able to rewrite history with ad'hoc bundle IDs
+const enableBundlePreserve = false

--- a/cmd/datamon/cmd/bundle_preserve_enable.go
+++ b/cmd/datamon/cmd/bundle_preserve_enable.go
@@ -1,0 +1,6 @@
+// +build bundle_preserve
+
+package cmd
+
+// enableBundlePreserve enables to have the --bundle in datamon upload and be able to rewrite history with ad'hoc bundle IDs
+const enableBundlePreserve = true

--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -61,6 +61,10 @@ set label 'init'
 		bundleOpts = append(bundleOpts,
 			core.ConcurrentFileUploads(getConcurrencyFactor(fileUploadsByConcurrencyFactor)))
 		bundleOpts = append(bundleOpts, core.Logger(config.mustGetLogger(datamonFlags)))
+		// feature guard
+		if enableBundlePreserve {
+			bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
+		}
 
 		bundle := core.NewBundle(bd,
 			bundleOpts...,
@@ -126,6 +130,11 @@ func init() {
 	addSkipMissingFlag(uploadBundleCmd)
 	addConcurrencyFactorFlag(uploadBundleCmd, 100)
 	addLogLevel(uploadBundleCmd)
+
+	// feature guard
+	if enableBundlePreserve {
+		addBundleFlag(uploadBundleCmd)
+	}
 
 	bundleCmd.AddCommand(uploadBundleCmd)
 }

--- a/pkg/core/bundle.go
+++ b/pkg/core/bundle.go
@@ -264,6 +264,21 @@ func implUpload(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint, 
 	if err := RepoExists(bundle.RepoID, bundle.contextStores); err != nil {
 		return err
 	}
+	if bundle.BundleID != "" {
+		// case of bundleID preservation
+		id, err := ksuid.Parse(bundle.BundleID)
+		if err != nil {
+			return fmt.Errorf("invalid bundleID (ksuid) specified: %w", err)
+		}
+		bundle.setBundleID(id.String())
+		exists, err := bundle.Exists(ctx)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return fmt.Errorf("bundleID %s already exists on this store", id.String())
+		}
+	}
 	return uploadBundle(ctx, bundle, bundleEntriesPerFile, getKeys, opts...)
 }
 

--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -223,9 +223,11 @@ func uploadBundle(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint
 	}
 
 	// Upload the files and the bundle list
-	err = bundle.InitializeBundleID()
-	if err != nil {
-		return err
+	if bundle.BundleID == "" {
+		err = bundle.InitializeBundleID()
+		if err != nil {
+			return err
+		}
 	}
 
 	filePackedC := make(chan filePacked)


### PR DESCRIPTION
This option is interesting to migrate bundles from one store to another while preserving the initial ID.
Preservation allows for migration jobs to be idempotent and to restart on errors.

TODO(fred): tested manually so far, needs some U.T

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>