### PR TITLE
cmd pkg cleanup

### DIFF
--- a/cmd/datamon/cmd/bundle.go
+++ b/cmd/datamon/cmd/bundle.go
@@ -26,7 +26,9 @@ analogous to a git commit.
 A bundle is composed of individual files that are tracked and changed
 together.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/bundle_diff.go
+++ b/cmd/datamon/cmd/bundle_diff.go
@@ -39,7 +39,9 @@ var bundleDiffCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		datamonFlagsPtr := &datamonFlags
+		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("failed to initialize remote stores", err)
 		}
@@ -61,7 +63,10 @@ var bundleDiffCmd = &cobra.Command{
 			core.ConsumableStore(destinationStore),
 		)
 
-		bundleOpts := paramsToBundleOpts(remoteStores)
+		bundleOpts, err := optionInputs.bundleOpts(ctx)
+		if err != nil {
+			wrapFatalln("failed to initialize bundle options", err)
+		}
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
 		bundleOpts = append(bundleOpts,
@@ -94,7 +99,9 @@ var bundleDiffCmd = &cobra.Command{
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/bundle_list.go
+++ b/cmd/datamon/cmd/bundle_list.go
@@ -33,7 +33,9 @@ This is analogous to the "git log" command. The bundle ID works like a git commi
 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT , Updating test bundle`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		datamonFlagsPtr := &datamonFlags
+		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -47,7 +49,9 @@ This is analogous to the "git log" command. The bundle ID works like a git commi
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/bundle_list_file.go
+++ b/cmd/datamon/cmd/bundle_list_file.go
@@ -27,7 +27,9 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 ...`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		datamonFlagsPtr := &datamonFlags
+		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -37,7 +39,10 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 			wrapFatalln("determine bundle id", err)
 			return
 		}
-		bundleOpts := paramsToBundleOpts(remoteStores)
+		bundleOpts, err := optionInputs.bundleOpts(ctx)
+		if err != nil {
+			wrapFatalln("failed to initialize bundle options", err)
+		}
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
 		bundle := core.NewBundle(core.NewBDescriptor(),
@@ -57,7 +62,9 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/config_set.go
+++ b/cmd/datamon/cmd/config_set.go
@@ -39,13 +39,14 @@ config file created in /Users/ritesh/.datamon2/datamon.yaml
 config file created in /Users/ritesh/.config/.datamon/config.yaml
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, err := paramsToContributor(datamonFlags)
+		optionInputs := newCliOptionInputs(config, &datamonFlags)
+		_, err := optionInputs.contributor()
 		if err != nil {
 			wrapFatalln("failed to resolve contributor", err)
 			return
 		}
 
-		config := CLIConfig{
+		localConfig := CLIConfig{
 			Config:     datamonFlags.core.Config,
 			Context:    datamonFlags.context.Descriptor.Name,
 			Credential: datamonFlags.root.credFile,
@@ -56,7 +57,7 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 		if ext := filepath.Ext(file); ext != ".yaml" {
 			infoLogger.Printf("warning: the generated config file will contain a yaml document, but the file extension is %q", ext)
 		}
-		o, err := config.MarshalConfig()
+		o, err := localConfig.MarshalConfig()
 		if err != nil {
 			wrapFatalln("could not serialize config to yaml", err)
 			return

--- a/cmd/datamon/cmd/context.go
+++ b/cmd/datamon/cmd/context.go
@@ -23,7 +23,9 @@ var ContextCmd = &cobra.Command{
 	Long: "Commands to manage contexts. " +
 		"A context is an instance of Datamon with set of repos, runs, labels etc.",
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/context_create.go
+++ b/cmd/datamon/cmd/context_create.go
@@ -24,8 +24,13 @@ var ContextCreateCommand = &cobra.Command{
 }
 
 func createContext() {
+	optionInputs := newCliOptionInputs(config, &datamonFlags)
+	logger, err := optionInputs.getLogger()
+	if err != nil {
+		wrapFatalln("get logger", err)
+	}
 	configStore, err := gcs.New(context2.Background(), datamonFlags.core.Config, config.Credential,
-		gcs.Logger(config.mustGetLogger(datamonFlags)),
+		gcs.Logger(logger),
 	)
 	if err != nil {
 		wrapFatalln("failed to create config store", err)

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -12,6 +12,7 @@ import (
 	gcscontext "github.com/oneconcern/datamon/pkg/context/gcs"
 
 	"github.com/oneconcern/datamon/pkg/core"
+	"github.com/oneconcern/datamon/pkg/dlogger"
 
 	"github.com/docker/go-units"
 	"github.com/go-openapi/runtime/flagext"
@@ -21,6 +22,8 @@ import (
 	"github.com/oneconcern/datamon/pkg/storage/localfs"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 )
 
 type flagsT struct {
@@ -325,58 +328,33 @@ func addTemplateFlag(cmd *cobra.Command) string {
 	return c
 }
 
-/** parameters struct to other formats */
+/** parameters struct from other formats */
 
-func paramsToDatamonContext(ctx context.Context, params flagsT) (context2.Stores, error) {
-	// here we select a 100% gcs backend strategy (more elaborate strategies could be defined by the context pkg)
-	return gcscontext.MakeContext(ctx, params.context.Descriptor, config.Credential, gcs.Logger(config.mustGetLogger(params)))
+// apply config file + env vars to structure used to parse cli flags
+func (flags *flagsT) setDefaultsFromConfig(c *CLIConfig) {
+	if flags.context.Descriptor.Name == "" {
+		flags.context.Descriptor.Name = c.Context
+	}
+	if flags.core.Config == "" {
+		flags.core.Config = c.Config
+	}
 }
 
-func paramsToBundleOpts(stores context2.Stores) []core.BundleOption {
-	ops := []core.BundleOption{
-		core.ContextStores(stores),
-	}
-	return ops
+/** combined config (file + env var) and parameters (pflags) */
+
+type cliOptionInputs struct {
+	config *CLIConfig
+	params *flagsT
 }
 
-func paramsToSrcStore(ctx context.Context, params flagsT, create bool) (storage.Store, error) {
-	var err error
-	var consumableStorePath string
-
-	switch {
-	case params.bundle.DataPath == "":
-		consumableStorePath, err = ioutil.TempDir("", "datamon-mount-destination")
-		if err != nil {
-			return nil, fmt.Errorf("couldn't create temporary directory: %w", err)
-		}
-	case strings.HasPrefix(params.bundle.DataPath, "gs://"):
-		consumableStorePath = params.bundle.DataPath
-	default:
-		consumableStorePath, err = sanitizePath(params.bundle.DataPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to sanitize destination: %v: %w",
-				params.bundle.DataPath, err)
-		}
+func newCliOptionInputs(config *CLIConfig, params *flagsT) *cliOptionInputs {
+	return &cliOptionInputs{
+		config: config,
+		params: params,
 	}
-
-	if create {
-		createPath(consumableStorePath)
-	}
-
-	var sourceStore storage.Store
-	if strings.HasPrefix(consumableStorePath, "gs://") {
-		infoLogger.Println(consumableStorePath[4:])
-		sourceStore, err = gcs.New(ctx, consumableStorePath[5:], config.Credential, gcs.Logger(config.mustGetLogger(params)))
-		if err != nil {
-			return sourceStore, err
-		}
-	} else {
-		DieIfNotAccessible(consumableStorePath)
-		DieIfNotDirectory(consumableStorePath)
-		sourceStore = localfs.New(afero.NewBasePathFs(afero.NewOsFs(), consumableStorePath))
-	}
-	return sourceStore, nil
 }
+
+/** combined config and parameters to internal objects */
 
 // DestT defines the nomenclature for allowed destination types (e.g. Empty/NonEmpty)
 type DestT uint
@@ -387,13 +365,15 @@ const (
 	destTNonEmpty
 )
 
-func paramsToDestStore(params flagsT,
-	destT DestT,
+func (in *cliOptionInputs) destStore(destT DestT,
 	tmpdirPrefix string,
 ) (storage.Store, error) {
+	var params *flagsT
 	var err error
 	var consumableStorePath string
 	var destStore storage.Store
+
+	params = in.params
 
 	if tmpdirPrefix != "" && params.bundle.DataPath != "" {
 		tmpdirPrefix = ""
@@ -443,7 +423,124 @@ func paramsToDestStore(params flagsT,
 	return destStore, nil
 }
 
-func paramsToContributor(flags flagsT) (model.Contributor, error) {
+func (in *cliOptionInputs) datamonContext(ctx context.Context) (context2.Stores, error) {
+	logger, err := in.getLogger()
+	if err != nil {
+		return context2.New(), fmt.Errorf("get logger: %v", err)
+	}
+	// here we select a 100% gcs backend strategy (more elaborate strategies could be defined by the context pkg)
+	return gcscontext.MakeContext(ctx,
+		in.params.context.Descriptor,
+		in.config.Credential,
+		gcs.Logger(logger))
+}
+
+func (in *cliOptionInputs) srcStore(ctx context.Context, create bool) (storage.Store, error) {
+	var (
+		err                 error
+		consumableStorePath string
+	)
+	switch {
+	case in.params.bundle.DataPath == "":
+		consumableStorePath, err = ioutil.TempDir("", "datamon-mount-destination")
+		if err != nil {
+			return nil, fmt.Errorf("couldn't create temporary directory: %w", err)
+		}
+	case strings.HasPrefix(in.params.bundle.DataPath, "gs://"):
+		consumableStorePath = in.params.bundle.DataPath
+	default:
+		consumableStorePath, err = sanitizePath(in.params.bundle.DataPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to sanitize destination: %v: %w",
+				in.params.bundle.DataPath, err)
+		}
+	}
+
+	if create {
+		createPath(consumableStorePath)
+	}
+
+	var sourceStore storage.Store
+	if strings.HasPrefix(consumableStorePath, "gs://") {
+		logger, err := in.getLogger()
+		if err != nil {
+			return sourceStore, fmt.Errorf("get logger: %v", err)
+		}
+		infoLogger.Println(consumableStorePath[4:])
+		sourceStore, err = gcs.New(ctx,
+			consumableStorePath[5:],
+			in.config.Credential,
+			gcs.Logger(logger))
+		if err != nil {
+			return sourceStore, err
+		}
+	} else {
+		DieIfNotAccessible(consumableStorePath)
+		DieIfNotDirectory(consumableStorePath)
+		sourceStore = localfs.New(afero.NewBasePathFs(afero.NewOsFs(), consumableStorePath))
+	}
+	return sourceStore, nil
+}
+
+func (in *cliOptionInputs) bundleOpts(ctx context.Context) ([]core.BundleOption, error) {
+	stores, err := in.datamonContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ops := []core.BundleOption{
+		core.ContextStores(stores),
+	}
+	return ops, nil
+}
+
+func (in *cliOptionInputs) getLogger() (*zap.Logger, error) {
+	var err error
+	in.config.onceLogger.Do(func() {
+		in.config.logger, err = dlogger.GetLogger(in.params.root.logLevel)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to set log level: %v", err)
+	}
+	return in.config.logger, nil
+}
+
+func (in *cliOptionInputs) populateRemoteConfig() error {
+	flags := in.params
+	if flags.core.Config == "" {
+		return fmt.Errorf("set environment variable $DATAMON_GLOBAL_CONFIG or define remote config in the config file")
+	}
+	logger, err := in.getLogger()
+	if err != nil {
+		return fmt.Errorf("get logger: %v", err)
+	}
+	configStore, err := handleRemoteConfigErr(
+		gcs.New(context.Background(),
+			flags.core.Config,
+			config.Credential,
+			gcs.Logger(logger)))
+	if err != nil {
+		return fmt.Errorf("failed to get config store: %v", err)
+	}
+	rdr, err := handleContextErr(configStore.Get(context.Background(), model.GetPathToContext(flags.context.Descriptor.Name)))
+	if err != nil {
+		return fmt.Errorf("failed to get context details from config store for context %q: %v",
+			flags.context.Descriptor.Name, err)
+	}
+	b, err := ioutil.ReadAll(rdr)
+	if err != nil {
+		return fmt.Errorf("failed to read context details: %v", err)
+	}
+	contextDescriptor := model.Context{}
+	err = yaml.Unmarshal(b, &contextDescriptor)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal: %v", err)
+	}
+	flags.context.Descriptor = contextDescriptor
+	return nil
+}
+
+func (in *cliOptionInputs) contributor() (model.Contributor, error) {
+	flags := in.params
 	var credentials string
 	switch {
 	case flags.root.credFile != "":
@@ -458,6 +555,8 @@ func paramsToContributor(flags flagsT) (model.Contributor, error) {
 	}
 	return contributor, err
 }
+
+/** misc util */
 
 // requireFlags sets a flag (local to the command or inherited) as required
 func requireFlags(cmd *cobra.Command, flags ...string) {

--- a/cmd/datamon/cmd/label.go
+++ b/cmd/datamon/cmd/label.go
@@ -22,7 +22,9 @@ multiple labels can refer to the same bundle via its commit hash (bundle ID).`,
 	Example: `Latest
 production`,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/label_get.go
+++ b/cmd/datamon/cmd/label_get.go
@@ -21,7 +21,9 @@ Prints corresponding bundle information if the label exists,
 exits with ENOENT status otherwise.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		datamonFlagsPtr := &datamonFlags
+		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -52,7 +54,9 @@ exits with ENOENT status otherwise.`,
 
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/label_list.go
+++ b/cmd/datamon/cmd/label_list.go
@@ -32,7 +32,9 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		datamonFlagsPtr := &datamonFlags
+		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -47,7 +49,9 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT`,
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/label_set.go
+++ b/cmd/datamon/cmd/label_set.go
@@ -20,13 +20,13 @@ Setting a label is analogous to the git command "git tag {label}".`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 
-		contributor, err := paramsToContributor(datamonFlags)
+		optionInputs := newCliOptionInputs(config, &datamonFlags)
+		contributor, err := optionInputs.contributor()
 		if err != nil {
 			wrapFatalln("populate contributor struct", err)
 			return
 		}
-
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -62,7 +62,9 @@ Setting a label is analogous to the git command "git tag {label}".`,
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/repo.go
+++ b/cmd/datamon/cmd/repo.go
@@ -20,7 +20,9 @@ Repos are datasets with a unified lifecycle.
 They are versioned and managed via bundles.
 `,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/repo_create.go
+++ b/cmd/datamon/cmd/repo_create.go
@@ -23,12 +23,13 @@ This is analogous to the "git init ..." command.`,
 	Example: `% datamon repo create  --description "Ritesh's repo for testing" --repo ritesh-datamon-test-repo`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		contributor, err := paramsToContributor(datamonFlags)
+		optionInputs := newCliOptionInputs(config, &datamonFlags)
+		contributor, err := optionInputs.contributor()
 		if err != nil {
 			wrapFatalln("populate contributor struct", err)
 			return
 		}
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -46,7 +47,9 @@ This is analogous to the "git init ..." command.`,
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/repo_get.go
+++ b/cmd/datamon/cmd/repo_get.go
@@ -21,7 +21,9 @@ Prints corresponding repo information if the name exists,
 exits with ENOENT status otherwise.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		datamonFlagsPtr := &datamonFlags
+		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -46,7 +48,9 @@ exits with ENOENT status otherwise.`,
 		log.Println(buf.String())
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	},
 }
 

--- a/cmd/datamon/cmd/repo_list.go
+++ b/cmd/datamon/cmd/repo_list.go
@@ -27,7 +27,9 @@ var repoList = &cobra.Command{
 fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01:18.181535 +0100 CET`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		remoteStores, err := paramsToDatamonContext(ctx, datamonFlags)
+		datamonFlagsPtr := &datamonFlags
+		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
+		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -41,7 +43,9 @@ fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	}, // https://github.com/spf13/cobra/issues/458
 }
 

--- a/cmd/datamon/cmd/web.go
+++ b/cmd/datamon/cmd/web.go
@@ -18,7 +18,9 @@ var webSrv = &cobra.Command{
 	Long:  "A webserver process to browse datamon data",
 	Run: func(cmd *cobra.Command, args []string) {
 		infoLogger.Println("begin webserver")
-		stores, err := paramsToDatamonContext(context.Background(), datamonFlags)
+		datamonFlagsPtr := &datamonFlags
+		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
+		stores, err := optionInputs.datamonContext(context.Background())
 		if err != nil {
 			wrapFatalln("create remote stores", err)
 			return
@@ -67,7 +69,9 @@ var webSrv = &cobra.Command{
 		}
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		config.populateRemoteConfig(&datamonFlags)
+		if err := newCliOptionInputs(config, &datamonFlags).populateRemoteConfig(); err != nil {
+			wrapFatalln("populate remote config", err)
+		}
 	}, // https://github.com/spf13/cobra/issues/458
 }
 

--- a/pkg/web/packrd/packed-packr.go
+++ b/pkg/web/packrd/packed-packr.go
@@ -30,19 +30,17 @@ var _ = func() error {
 		b.SetResolver("bundle__list_files.html", packr.Pointer{ForwardBox: gk, ForwardPath: "3c6b203d09507d2f1c0b2aaed35018ca"})
 		b.SetResolver("home.html", packr.Pointer{ForwardBox: gk, ForwardPath: "d7602d28968a8d3e13daf46afa4c4dcf"})
 		b.SetResolver("repo__list_bundles.html", packr.Pointer{ForwardBox: gk, ForwardPath: "7f531d365b99ec22d6ea50c595c10767"})
-		}()
-
+	}()
 
 	func() {
 		b := packr.New("helperTmpls", "./tmpl/helpers")
 		b.SetResolver("base.html", packr.Pointer{ForwardBox: gk, ForwardPath: "f4f6932cbb872550b8c891eacfeaa15f"})
-		}()
-
+	}()
 
 	func() {
 		b := packr.New("static", "./public/assets")
 		b.SetResolver("css/vendor/normalize_8.0.1.css", packr.Pointer{ForwardBox: gk, ForwardPath: "496015eb8ecde2c26dc57cb316074843"})
-		}()
+	}()
 
 	return nil
 }()


### PR DESCRIPTION
these are some cleanup of the `cmd/datamon/cmd/` package.

the create and read tests for `config set` are separated out to #394 .