### PR TITLE
test(cli): added CLI test to cover workshop sessions items

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,22 @@ commands:
             GOROOT: /usr/local/go
             GOPATH: /go
           command: |
-            GO_VERSION=1.13.5
+            GO_VERSION=1.13.7
             CI_USER=$(id -u)
-            sudo apt-get install --quiet fuse
+            PATH=/home/circleci/.linuxbrew/bin:$PATH
+            sudo apt-get install -qq --yes build-essential curl file git fuse linuxbrew-wrapper
 
             cd /tmp
+            echo
+            echo "Installing standalone linuxbrew..."
+            echo
+            # do it twice: a hack to work around https://stackoverflow.com/questions/38410020/homebrew-error-update-report-should-not-be-called-directly
+            (brew update < /dev/null)||(brew update < /dev/null)
+
+            # TODO(fred): get latest from github.api/google...
+            echo
+            echo "Installing golang ${GO_VERSION}..."
+            echo
             wget --no-verbose https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
             sudo tar -xf go${GO_VERSION}.linux-amd64.tar.gz
             sudo mv /usr/local/go /usr/local/go.old || true
@@ -199,19 +210,22 @@ jobs:
       - install_tools
       - login_to_google
       - run:
-          name: Run golang tests in integration environment
+          name: Prepare golang tests in integration environment
           command: |
             export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
-            mkdir -p ~/extra
             mkdir -p /tmp/test-fuse-results
-            echo $GCLOUD_SERVICE_KEY > ~/extra/appcredentials.json
-            export GOOGLE_APPLICATION_CREDENTIALS=$HOME/extra/appcredentials.json
             hack/go-generate.sh
             go mod download
-            # make install-minio
-            env
-            gotestsum --junitfile /tmp/test-fuse-results/go-test-report.xml --format standard-verbose -- \
-            -tags fuse_cli,fsintegration -run Mount  ./pkg/core ./cmd/datamon/cmd -timeout 20m
+      - run:
+          name: Run golang tests in integration environment
+          command: |
+            mkdir -p ~/extra
+            echo $GCLOUD_SERVICE_KEY > ~/extra/appcredentials.json
+            export PATH=$GOPATH/bin:$GOROOT/bin:/home/circleci/.linuxbrew/bin:$PATH
+            export GOOGLE_APPLICATION_CREDENTIALS=~/extra/appcredentials.json
+            gotestsum \
+              --junitfile /tmp/test-fuse-results/go-test-report.xml --format standard-verbose -- \
+              -tags fuse_cli,fsintegration -run '(Mount)|(Workshop)'  ./pkg/core ./cmd/datamon/cmd -timeout 20m
       - save_cache:
           key: pkg-cache-{{ checksum "go.sum" }}
           paths:
@@ -318,7 +332,7 @@ jobs:
 
   publish_release:
     executor: docker_builder
-    # TODO(frederic):
+    # NOTE:
     # - acquire GITHUB_TOKEN for onecrobot to push to homebrew-datamon repo
     #
     # > goreleaser needs access to github API, not only the git repo.

--- a/cmd/datamon/cmd/cli_fuse_test.go
+++ b/cmd/datamon/cmd/cli_fuse_test.go
@@ -32,6 +32,7 @@ func testLogger(t testing.TB) *zap.Logger {
 	// a logger for the test sequence itself
 	return dlogger.MustGetLogger("debug").With(zap.String("test", t.Name()))
 }
+
 func testCommand(t testing.TB, withPipe, withEnv bool, target string, args ...string) (*exec.Cmd, io.ReadCloser) {
 	// NOTE: this starts a process, not a goroutine like for other tests
 	// That is primarily because we want to send a signal to the process

--- a/cmd/datamon/cmd/cli_fuse_test.go
+++ b/cmd/datamon/cmd/cli_fuse_test.go
@@ -4,19 +4,19 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/oneconcern/datamon/internal"
 	"github.com/oneconcern/datamon/pkg/dlogger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,16 +32,24 @@ func testLogger(t testing.TB) *zap.Logger {
 	// a logger for the test sequence itself
 	return dlogger.MustGetLogger("debug").With(zap.String("test", t.Name()))
 }
-func testCommand(t testing.TB, target string, args ...string) (*exec.Cmd, io.ReadCloser) {
+func testCommand(t testing.TB, withPipe, withEnv bool, target string, args ...string) (*exec.Cmd, io.ReadCloser) {
 	// NOTE: this starts a process, not a goroutine like for other tests
 	// That is primarily because we want to send a signal to the process
 	// in order to unmount.
 	cmd := exec.Command(target, args...)
-	cmd.Env = append(cmd.Env, "DATAMON_CONTEXT="+os.Getenv("DATAMON_CONTEXT")) // TODO(fred): not sure this is used
-	cmd.Env = append(cmd.Env, "DATAMON_GLOBAL_CONFIG="+os.Getenv("DATAMON_GLOBAL_CONFIG"))
+	cmd.Env = []string{}
+	if withEnv {
+		cmd.Env = append(cmd.Env, "GOOGLE_APPLICATION_CREDENTIALS="+os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+		cmd.Env = append(cmd.Env, "DATAMON_CONTEXT="+os.Getenv("DATAMON_CONTEXT")) // TODO(fred): not sure this is used
+		cmd.Env = append(cmd.Env, "DATAMON_GLOBAL_CONFIG="+os.Getenv("DATAMON_GLOBAL_CONFIG"))
+	}
 	cmd.Env = append(cmd.Env, "HOME="+os.Getenv("HOME"))
 	cmd.Env = append(cmd.Env, "PATH="+os.Getenv("PATH"))
-	cmd.Env = append(cmd.Env, "GOOGLE_APPLICATION_CREDENTIALS="+os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"))
+
+	if !withPipe {
+		return cmd, nil
+	}
+
 	pipeOut, err := cmd.StdoutPipe()
 	require.NoError(t, err)
 
@@ -67,16 +75,15 @@ func testCommand(t testing.TB, target string, args ...string) (*exec.Cmd, io.Rea
 	return cmd, pipeR
 }
 
-func generateRepoName() string {
-	//#nosec
-	return "test-fuse-repo-" + strconv.Itoa(rand.Int())
+func generateRepoName(in string) string {
+	return "test-" + in + "-repo-" + internal.RandStringBytesMaskImprSrc(10)
 }
 
 func testBundleMount(t *testing.T, testType string, waiter func(*zap.Logger, io.Reader)) {
 	logger := testLogger(t)
 
 	logger.Info("test initialization")
-	repo := generateRepoName()
+	repo := generateRepoName("fuse")
 	cleanup := setupTests(t)
 	defer cleanup()
 	const testConcurrencyForUpload = "10"
@@ -119,9 +126,15 @@ func testBundleMount(t *testing.T, testType string, waiter func(*zap.Logger, io.
 	cmdParams = append(cmdParams, "--context", testContext())
 	logger.Info("datamon exec", zap.Strings("params", cmdParams))
 
-	cmd, pipe := testCommand(t, targetBinary, cmdParams...)
+	cmd, pipe := testCommand(t, true, true, targetBinary, cmdParams...)
 
 	require.NoError(t, cmd.Start())
+	var killed bool
+	defer func() {
+		if !killed {
+			_ = cmd.Process.Kill()
+		}
+	}()
 
 	logger.Info("waiting for mount to be ready")
 	waiter(logger, pipe)
@@ -137,6 +150,7 @@ func testBundleMount(t *testing.T, testType string, waiter func(*zap.Logger, io.
 	logger.Info("unmounting")
 	require.NoError(t, cmd.Process.Kill())
 	err = cmd.Wait()
+	killed = true
 	require.Equal(t, "signal: killed", err.Error(), "cmd exit with killed error")
 }
 
@@ -241,9 +255,25 @@ func TestBundleMountNoStreamNoDest(t *testing.T) {
 	testBundleMount(t, "nostream-nodest", testMountReady(t, `"mounting"`, 5*time.Second))
 }
 
+func captureOutputProgress(p io.Reader) (*bytes.Buffer, *sync.WaitGroup) {
+	var (
+		wg sync.WaitGroup
+		b  bytes.Buffer
+	)
+	wg.Add(1)
+	latch := make(chan struct{})
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		latch <- struct{}{}
+		_, _ = b.ReadFrom(p)
+	}(&wg)
+	<-latch
+	return &b, &wg
+}
+
 func TestBundleMutableMount(t *testing.T) {
 	logger := testLogger(t)
-	repo := generateRepoName()
+	repo := generateRepoName("fuse-mutable")
 	extraTestArgs := []string{"--loglevel", "info"} // set this to debug to get more tracing
 
 	logger.Info("test initialization")
@@ -280,9 +310,15 @@ func TestBundleMutableMount(t *testing.T) {
 	cmdParams = append(cmdParams, "--context", testContext())
 	logger.Info("datamon exec", zap.Strings("params", cmdParams))
 
-	cmd, pipe := testCommand(t, targetBinary, cmdParams...)
+	cmd, pipe := testCommand(t, true, true, targetBinary, cmdParams...)
 
 	require.NoError(t, cmd.Start())
+	var killed bool
+	defer func() {
+		if !killed {
+			_ = cmd.Process.Kill()
+		}
+	}()
 
 	testMountReady(t, `"mounting"`, 5*time.Second)(logger, pipe)
 
@@ -300,26 +336,19 @@ func TestBundleMutableMount(t *testing.T) {
 	require.NoError(t, cmd.Process.Signal(os.Interrupt))
 
 	logger.Info("capturing commit output")
-	var (
-		wg sync.WaitGroup
-		b  []byte
-	)
-	wg.Add(1)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		b, _ = ioutil.ReadAll(pipe)
-	}(&wg)
+	b, wg := captureOutputProgress(pipe)
 
 	logger.Debug("waiting for cmd to terminate")
 	require.NoError(t, cmd.Wait())
+	killed = true
 	_ = pipe.Close()
 	logger.Debug("waiting for pipe to end")
 	wg.Wait()
 
 	logger.Info("asserting created bundle")
-	rex := regexp.MustCompile(`(?m)^bundle:\s+([^\s]+)$`)
-	match := rex.FindSubmatch(b)
-	require.Truef(t, len(match) > 1, "couldn't find bundle ID in output, got this instead: %s", string(b))
+	rex := regexp.MustCompile(`(?m)^bundle:\s*([^\s]+)$`)
+	match := rex.FindSubmatch(b.Bytes())
+	require.Truef(t, len(match) > 1, "couldn't find bundle ID in output, got this instead: %s", b.String())
 	bundleID := string(match[1])
 
 	bundles, err = listBundles(t, repo)

--- a/cmd/datamon/cmd/cli_test.go
+++ b/cmd/datamon/cmd/cli_test.go
@@ -1418,6 +1418,8 @@ func dirPathStr(t *testing.T, file uploadTree) (path string) {
 	/* the strings.Split gets the root directory name.
 	 * would be cleaner to iterate on filepath.Split,
 	 * although even in this case `os.PathSeparator` appears necessary.
+	 *
+	 * TODO(fred): filepath.Abs(filepath.FromSlash(path.Join(sourceData strings.Split(file.path)[1])))
 	 */
 	path, err := filepath.Abs(filepath.Join(sourceData, strings.Split(file.path, string(os.PathSeparator))[1]))
 	if err != nil {

--- a/cmd/datamon/cmd/cli_workshop_test.go
+++ b/cmd/datamon/cmd/cli_workshop_test.go
@@ -1,0 +1,494 @@
+// +build fuse_cli
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	gcsStorage "cloud.google.com/go/storage"
+	"github.com/oneconcern/datamon/internal"
+	"github.com/oneconcern/datamon/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+type testFile struct {
+	data                        []byte
+	size                        int
+	listed, downloaded, mounted bool
+}
+
+// TestWorkshop goes through all the steps in our workshop.
+//
+// Test is run with spawned process on freshly built datamon binary, not test goroutine: no mocks, no tricks
+func TestWorkshop(t *testing.T) {
+	logger := testLogger(t)
+	logger.Info("test initialization")
+	repo := generateRepoName("workshop")
+	targetBinary := buildTestBinary(t)
+
+	// create config
+	cmd, _ := testCommand(t, false, false, targetBinary,
+		"config",
+		"set",
+		"--config", "workshop-config",
+		"--credential", os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"),
+	)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "could not create config: %s", string(output))
+	// TODO(fred): should separate assertion on stdout and stderr here
+	assert.Contains(t, string(output), "config file created in")
+
+	// obtain available contexts
+	logger.Info("listing contexts")
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"context",
+		"list",
+	)
+
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "could not list contexts, got: %s", string(output))
+	// TODO(fred): should separate assertion on stdout and stderr here
+	assert.Contains(t, string(output), "[dev]")
+
+	// create repo
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"repo",
+		"create",
+		"--repo", repo,
+		"--description", "workshop CI test repo",
+	)
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "got: %s", string(output))
+
+	defer deleteRepoMeta(t, repo)
+
+	// list repos
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"repo",
+		"list",
+	)
+	output, err = cmd.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(output), repo)
+
+	// repo detail
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"repo",
+		"get",
+		"--repo", repo,
+	)
+	output, err = cmd.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(output), repo)
+	assert.Contains(t, string(output), "workshop CI test repo")
+
+	// upload a bundle
+	pathToData, _ := ioutil.TempDir("", "bdle-workshop-")
+	defer os.RemoveAll(pathToData)
+	msg := internal.RandStringBytesMaskImprSrc(15)
+
+	files := makeTestWorkshopBundle(t, pathToData)
+
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"bundle",
+		"upload",
+		"--repo", repo,
+		"--message", msg,
+		"--path", pathToData,
+	)
+	output, err = cmd.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(output), "Uploaded bundle id:")
+
+	rex := regexp.MustCompile(`Uploaded bundle id:\s?([^\s]+)`)
+	match := rex.FindSubmatch(output)
+	require.Truef(t, len(match) > 1, "couldn't find bundle ID in output, got this instead: %s", string(output))
+	bundleID := string(match[1])
+
+	// list bundles
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"bundle",
+		"list",
+		"--repo", repo,
+	)
+	output, err = cmd.Output()
+	require.NoError(t, err)
+	assert.Contains(t, string(output), bundleID)
+	assert.Contains(t, string(output), msg)
+
+	// set label
+	label := internal.RandStringBytesMaskImprSrc(10)
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"label",
+		"set",
+		"--repo", repo,
+		"--bundle", bundleID,
+		"--label", label,
+	)
+	err = cmd.Run()
+	require.NoError(t, err)
+
+	// list labels
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"label",
+		"list",
+		"--repo", repo,
+	)
+	output, err = cmd.Output()
+	require.NoError(t, err)
+	rex1 := regexp.MustCompile(`(?m)` + regexp.QuoteMeta(label) + `\s*,\s*` + regexp.QuoteMeta(bundleID))
+	require.Truef(t, rex1.Match(output), "output not matching: %s", string(output))
+
+	// additional label
+	extraLabel := internal.RandStringBytesMaskImprSrc(10)
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"label",
+		"set",
+		"--repo", repo,
+		"--bundle", bundleID,
+		"--label", extraLabel,
+	)
+	err = cmd.Run()
+	require.NoError(t, err)
+
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"label",
+		"list",
+		"--repo", repo,
+	)
+	output, err = cmd.Output()
+	require.NoError(t, err)
+	require.True(t, rex1.Match(output))
+
+	rex2 := regexp.MustCompile(`(?m)` + regexp.QuoteMeta(extraLabel) + `\s*,\s*` + regexp.QuoteMeta(bundleID))
+	require.Truef(t, rex2.Match(output), "output not matching: %s", string(output))
+
+	// prefix based label search
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"label",
+		"list",
+		"--repo", repo,
+		"--prefix", extraLabel[:5],
+	)
+	output, err = cmd.Output()
+	require.NoError(t, err)
+	require.False(t, rex1.Match(output))
+	require.Truef(t, rex2.Match(output), "output not matching: %s", string(output))
+
+	// query files
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"bundle",
+		"list",
+		"files",
+		"--repo", repo,
+		"--bundle", bundleID,
+	)
+	output, err = cmd.Output()
+	require.NoError(t, err)
+
+	rex3 := regexp.MustCompile(`name:\s*([^\s,]+)\s*,\s*size:\s*([^\s,]+)`)
+	rexB := regexp.MustCompile("Using bundle")
+	scanner := bufio.NewScanner(bytes.NewBuffer(output))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if rexB.MatchString(line) {
+			continue
+		}
+		match := rex3.FindStringSubmatch(line)
+		require.True(t, len(match) > 2)
+		name := match[1]
+		sizeAsStr := match[2]
+		size, eri := strconv.Atoi(sizeAsStr)
+		require.NoError(t, eri)
+
+		require.Contains(t, files, name)
+		files[name].listed = true
+		assert.Equal(t, files[name].size, size)
+	}
+	for name, file := range files {
+		assert.Truef(t, file.listed, "expected file %s to be listed", name)
+	}
+
+	// mounting the bundle RO
+	pathBackingFs, _ := ioutil.TempDir("", "mmfs-")
+	pathToMount, _ := ioutil.TempDir("", "mmp-")
+	defer os.RemoveAll(pathBackingFs)
+	defer os.RemoveAll(pathToMount)
+
+	cmd, pipe := testCommand(t, true, false, targetBinary,
+		"bundle",
+		"mount",
+		"--repo", repo,
+		"--label", label,
+		"--mount", pathToMount,
+		"--destination", pathBackingFs,
+	)
+	require.NoError(t, cmd.Start())
+	var killed bool
+	defer func() {
+		if !killed {
+			_ = cmd.Process.Kill()
+		}
+	}()
+
+	logger.Info("waiting for mount to be ready")
+	testMountReady(t, `"mounting"`, 5*time.Second)(logger, pipe)
+
+	err = filepath.Walk(pathToMount, func(pth string, info os.FileInfo, _ error) error {
+		if info.IsDir() {
+			return nil
+		}
+		name := filepath.Base(pth)
+		require.Contains(t, files, name)
+		files[name].mounted = true
+		assert.Equal(t, files[name].size, int(info.Size()))
+		b, erf := ioutil.ReadFile(pth)
+		require.NoError(t, erf)
+		assert.EqualValues(t, files[name].data, b)
+		return nil
+	})
+	require.NoError(t, err)
+	for name, file := range files {
+		assert.Truef(t, file.mounted, "expected file %s to be mounted", name)
+	}
+
+	logger.Info("unmounting")
+	require.NoError(t, cmd.Process.Kill())
+	err = cmd.Wait()
+	killed = true
+	require.Equal(t, "signal: killed", err.Error(), "cmd exit with killed error")
+
+	// downloading the bundle
+	pathToDownload, _ := ioutil.TempDir("", "mmd-")
+	defer os.RemoveAll(pathToDownload)
+
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"bundle",
+		"download",
+		"--repo", repo,
+		"--label", label,
+		"--destination", pathToDownload,
+	)
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "unexpected error, got: %s", string(output))
+
+	err = filepath.Walk(pathToDownload, func(pth string, info os.FileInfo, _ error) error {
+		rel, _ := filepath.Rel(pathToDownload, pth)
+		if info.IsDir() || model.IsGeneratedFile(rel) {
+			return nil
+		}
+		name := filepath.Base(pth)
+		require.Contains(t, files, name)
+		files[name].downloaded = true
+		assert.Equal(t, files[name].size, int(info.Size()))
+		b, erf := ioutil.ReadFile(pth)
+		require.NoError(t, erf)
+		assert.EqualValues(t, files[name].data, b)
+		return nil
+	})
+	require.NoError(t, err)
+	for name, file := range files {
+		assert.Truef(t, file.downloaded, "expected file %s to be downloaded", name)
+	}
+
+	// downloading some files
+	pathToSomeDownload, _ := ioutil.TempDir("", "mmd-")
+	defer os.RemoveAll(pathToSomeDownload)
+
+	var picked string
+	for n := range files {
+		picked = n
+		break
+	}
+
+	cmd, _ = testCommand(t, false, false, targetBinary,
+		"bundle",
+		"download",
+		"--repo", repo,
+		"--label", label,
+		"--destination", pathToSomeDownload,
+		"--name-filter", picked[:8]+".+",
+	)
+	output, err = cmd.CombinedOutput()
+	require.NoErrorf(t, err, "unexpected error, got: %s", string(output))
+
+	err = filepath.Walk(pathToSomeDownload, func(pth string, info os.FileInfo, _ error) error {
+		rel, _ := filepath.Rel(pathToSomeDownload, pth)
+		if info.IsDir() || model.IsGeneratedFile(rel) {
+			return nil
+		}
+		name := filepath.Base(pth)
+		require.Equal(t, picked, name)
+		assert.Equal(t, files[name].size, int(info.Size()))
+		b, erf := ioutil.ReadFile(pth)
+		require.NoError(t, erf)
+		assert.EqualValues(t, files[name].data, b)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// no test here for web (see pkg/web)
+	// no test here for upgrade (see self_upgrade_test.go)
+}
+
+func makeTestWorkshopBundle(t testing.TB, pathToData string) map[string]*testFile {
+	files := make(map[string]*testFile, 10)
+	for i := 0; i < 9; i++ {
+		name := internal.RandStringBytesMaskImprSrc(10)
+		data := internal.RandBytesMaskImprSrc(100)
+		err := ioutil.WriteFile(filepath.Join(pathToData, name), data, 0644)
+		require.NoError(t, err)
+		files[name] = &testFile{data: data, size: 100}
+	}
+	name := internal.RandStringBytesMaskImprSrc(10)
+	data := []byte{} // empty file
+	err := ioutil.WriteFile(filepath.Join(pathToData, name), data, 0644)
+	require.NoError(t, err)
+	files[name] = &testFile{data: data, size: 0}
+	return files
+}
+
+func TestWorkshopBrewInstall(t *testing.T) {
+	if runtime.GOOS == "linux" { // TODO: don't know where brew installs things on OSX
+		home, _ := os.UserHomeDir()
+		cmdPath := strings.Join([]string{
+			filepath.Join("/", "home", "linuxbrew", ".linuxbrew", "bin"),
+			filepath.Join(home, ".linuxbrew", "bin"),
+			os.Getenv("PATH"),
+		}, ":")
+		os.Setenv("PATH", cmdPath)
+	}
+
+	// brew install (linux flavor)
+	cmd := exec.Command("brew", "--version")
+	if output, err := cmd.Output(); err != nil {
+		t.Logf("brew not installed. Skipping test")
+		t.SkipNow()
+	} else {
+		t.Logf("using brew: %s", string(output))
+	}
+
+	output, err := exec.Command("brew", "tap", "oneconcern/datamon").CombinedOutput()
+	require.NoErrorf(t, err, "could not run brew tap: %v:\n%s", err, string(output))
+
+	output, err = exec.Command("brew", "install", "datamon").CombinedOutput()
+	require.NoErrorf(t, err, "could not run brew install: %v:\n%s", err, string(output))
+
+	// version
+	datamon, err := exec.LookPath("datamon2")
+	require.NoErrorf(t, err, "datamon not found in path: %v", err)
+
+	output, err = exec.Command(datamon, "version").CombinedOutput()
+	require.NoErrorf(t, err, "could not run datamon: %s\n%s", err, string(output))
+}
+
+func deleteRepoMeta(t testing.TB, repo string) {
+	// delete the test repo on gs://datamon-workshop
+	var err error
+	defer func() {
+		if err != nil {
+			t.Logf("WARNING:could not access metadata bucket to clean up test with repo %s...: %v", repo, err)
+		}
+	}()
+	err = deleteMeta(t, "workshop-dev-meta", repo)
+	if err != nil {
+		t.Logf("WARNING: error encountered when cleaning up test with repo %s: %v", repo, err)
+	}
+	err = deleteVMeta(t, "workshop-dev-vmeta", repo)
+}
+
+func deleteMeta(t testing.TB, bucket, repo string) (err error) {
+	ctx := context.Background()
+	client, erc := gcsStorage.NewClient(ctx, option.WithScopes(gcsStorage.ScopeFullControl))
+	if erc != nil {
+		return erc
+	}
+
+	metaBucket := client.Bucket(bucket)
+
+	metaRepo := metaBucket.Object(model.GetArchivePathToRepoDescriptor(repo))
+	if metaRepo == nil {
+		err = fmt.Errorf("could not find path to repo in metadata")
+		return
+	}
+
+	name := metaRepo.ObjectName()
+	t.Logf("about to delete %s", name)
+	err = metaRepo.Delete(ctx)
+	if err != nil {
+		return
+	}
+
+	bundles := metaBucket.Objects(ctx, &gcsStorage.Query{Prefix: model.GetArchivePathPrefixToBundles(repo)})
+	if bundles == nil {
+		err = fmt.Errorf("could not find path to bundles for repo in metadata")
+		return
+	}
+
+	for {
+		bundleAttrs, eri := bundles.Next()
+		if eri == iterator.Done {
+			break
+		}
+		if eri != nil {
+			return eri
+		}
+		bundle := metaBucket.Object(bundleAttrs.Name)
+		name = bundle.ObjectName()
+		t.Logf("about to delete %s", name)
+		err = bundle.Delete(ctx)
+		if err != nil {
+			return
+		}
+	}
+	return err
+}
+
+func deleteVMeta(t testing.TB, bucket, repo string) (err error) {
+	ctx := context.Background()
+	client, erc := gcsStorage.NewClient(ctx, option.WithScopes(gcsStorage.ScopeFullControl))
+	if err != nil {
+		return erc
+	}
+
+	vmetaBucket := client.Bucket(bucket)
+	labels := vmetaBucket.Objects(ctx, &gcsStorage.Query{Prefix: model.GetArchivePathPrefixToLabels(repo)})
+	if labels == nil {
+		t.Logf("no label to clean in repo %s", repo)
+		return
+	}
+
+	for {
+		labelAttrs, eri := labels.Next()
+		if eri == iterator.Done {
+			break
+		}
+		if eri != nil {
+			return eri
+		}
+		label := vmetaBucket.Object(labelAttrs.Name)
+		name := label.ObjectName()
+		t.Logf("about to delete %s", name)
+		err = label.Delete(ctx)
+		if err != nil {
+			return
+		}
+	}
+	return err
+}

--- a/cmd/datamon/cmd/config_set.go
+++ b/cmd/datamon/cmd/config_set.go
@@ -41,7 +41,7 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 	Run: func(cmd *cobra.Command, args []string) {
 		_, err := paramsToContributor(datamonFlags)
 		if err != nil {
-			wrapFatalln("contributor datamonFlags present", err)
+			wrapFatalln("failed to resolve contributor", err)
 			return
 		}
 

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -200,7 +200,9 @@ func addWebNoBrowserFlag(cmd *cobra.Command) string {
 
 func addLabelNameFlag(cmd *cobra.Command) string {
 	labelName := "label"
-	cmd.Flags().StringVar(&datamonFlags.label.Name, labelName, "", "The human-readable name of a label")
+	if cmd != nil { // TODO(fred): quickfix - the actual remedy should be to avoid calling this with nil input
+		cmd.Flags().StringVar(&datamonFlags.label.Name, labelName, "", "The human-readable name of a label")
+	}
 	return labelName
 }
 

--- a/cmd/datamon/cmd/root.go
+++ b/cmd/datamon/cmd/root.go
@@ -107,6 +107,7 @@ func initConfig() {
 	}
 
 	if config.Credential != "" {
+		// TODO(fred): now handled in paramsToContributor. May be removed
 		_ = os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", config.Credential)
 	}
 


### PR DESCRIPTION
This unrolls the workshop entirely, including `brew install datamon` (with `linuxbrew`).

Not covered:
- web browser launch (covered by other tests)
- self upgrade (covered by other tests)
- context creation (covered by other tests)
- RW fuse mount (covered by other tests)

**NOTE on this for the future**: struggled with two pain points I wouldn't have expected at first:
1. non-interactive install of brew on CI has been a pain (trying  many hacks and stuff, eventually it works...)
2. some tests run os.Setenv(), which in turn pollute some other ones depending on the order of execution => need to rethink a bit our common launch pad mockery

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>