### PR TITLE
chore(storage): smallish refactoring series, part 1

### DIFF
--- a/pkg/storage/gcs/store.go
+++ b/pkg/storage/gcs/store.go
@@ -173,7 +173,7 @@ func (rc readCloser) Close() error {
 	return nil
 }
 
-func (g *gcs) Put(ctx context.Context, objectName string, reader io.Reader, newObject storage.NewKey) (err error) {
+func (g *gcs) Put(ctx context.Context, objectName string, reader io.Reader, newObject bool) (err error) {
 	g.l.Debug("Start Put", zap.String("objectName", objectName))
 	defer func() {
 		g.l.Debug("End Put", zap.String("objectName", objectName), zap.Error(err))

--- a/pkg/storage/instrumented.go
+++ b/pkg/storage/instrumented.go
@@ -64,7 +64,7 @@ func (i *instrumentedStore) Get(ctx context.Context, key string) (io.ReadCloser,
 	return i.store.Get(ctx, key)
 }
 
-func (i *instrumentedStore) Put(ctx context.Context, key string, rdr io.Reader, c NewKey) error {
+func (i *instrumentedStore) Put(ctx context.Context, key string, rdr io.Reader, c bool) error {
 	span := i.spanFromContext(ctx, i.opName("Put"))
 	defer span.Finish()
 

--- a/pkg/storage/localfs/store.go
+++ b/pkg/storage/localfs/store.go
@@ -86,7 +86,7 @@ func (rc readCloser) Close() error {
 	return nil
 }
 
-func (l *localFS) Put(ctx context.Context, key string, source io.Reader, exclusive storage.NewKey) error {
+func (l *localFS) Put(ctx context.Context, key string, source io.Reader, exclusive bool) error {
 	// TODO: Change this implementation to use rename to put file into place.
 	dir := filepath.Dir(key)
 	if dir != "" {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -10,16 +10,17 @@ import (
 
 //go:generate moq -out ./mockstorage/store.go -pkg mockstorage . Store
 
-const MaxObjectSizeInMemory = 2 * 1024 * 1024 * 1024 // 2 gigs
-
 const (
 	// Adding these to make code more readable when looking at Put Call
+
+	// NoOverWrite does not accept clobbering of objects in store
 	NoOverWrite = true
-	OverWrite   = false
+
+	// OverWrite accepts clobbering of objects in store
+	OverWrite = false
 )
 
-type NewKey = bool
-
+// Attributes supported by object on this store
 type Attributes struct {
 	Created time.Time
 	Updated time.Time
@@ -37,7 +38,7 @@ type Store interface {
 	GetAttr(context.Context, string) (Attributes, error)
 	GetAt(context.Context, string) (io.ReaderAt, error)
 	Touch(context.Context, string) error
-	Put(context.Context, string, io.Reader, NewKey) error
+	Put(context.Context, string, io.Reader, bool) error
 	Delete(context.Context, string) error
 	Clear(context.Context) error
 

--- a/pkg/wal/wal_test.go
+++ b/pkg/wal/wal_test.go
@@ -379,7 +379,7 @@ func (m *mockMutableStoreTestAdd) Touch(_ context.Context, path string) error {
 	return nil
 }
 
-func (m *mockMutableStoreTestAdd) Put(_ context.Context, key string, reader io.Reader, overwrite storage.NewKey) error {
+func (m *mockMutableStoreTestAdd) Put(_ context.Context, key string, reader io.Reader, overwrite bool) error {
 	if m.failPut {
 		return fmt.Errorf(putError)
 	}
@@ -652,7 +652,7 @@ func (m *mockMutableStoreTestListEntries) Touch(_ context.Context, path string) 
 	panic("implement me")
 }
 
-func (m *mockMutableStoreTestListEntries) Put(_ context.Context, _ string, _ io.Reader, _ storage.NewKey) error {
+func (m *mockMutableStoreTestListEntries) Put(_ context.Context, _ string, _ io.Reader, _ bool) error {
 	panic("implement me")
 }
 


### PR DESCRIPTION
Removed aliased type to bool.

Go aliased types (i.e. type A = B) are a syntactic sugar only.
This is different from type redefinitions (i.e. type A B), which create a new type for the compiler.

The original intent was to construct some kind of enumerated type, for a... boolean.

I chose to remove all this and just go back to plain bool.

* contributes #374

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>