### PR TITLE
init workshop web test

### DIFF
--- a/cmd/datamon/cmd/cli_fuse_test.go
+++ b/cmd/datamon/cmd/cli_fuse_test.go
@@ -206,7 +206,7 @@ func testMountCmdParams(t testing.TB, testType, repo, pathToMount, pathBackingFs
 	}
 }
 
-func testMountReady(t testing.TB, token string, defaultWait time.Duration) func(*zap.Logger, io.Reader) {
+func testWaitForReader(t testing.TB, token string, defaultWait time.Duration) func(*zap.Logger, io.Reader) {
 	return func(l *zap.Logger, output io.Reader) {
 		// awaits expected ready message
 		// TODO(fred): we may use that to time out on waiting if needed
@@ -245,15 +245,15 @@ func testMountReady(t testing.TB, token string, defaultWait time.Duration) func(
 }
 
 func TestBundleMount(t *testing.T) {
-	testBundleMount(t, "stream-dest", testMountReady(t, `"mounting"`, 5*time.Second))
+	testBundleMount(t, "stream-dest", testWaitForReader(t, `"mounting"`, 5*time.Second))
 }
 
 func TestBundleMountNoStream(t *testing.T) {
-	testBundleMount(t, "nostream-dest", testMountReady(t, `"mounting"`, 5*time.Second))
+	testBundleMount(t, "nostream-dest", testWaitForReader(t, `"mounting"`, 5*time.Second))
 }
 
 func TestBundleMountNoStreamNoDest(t *testing.T) {
-	testBundleMount(t, "nostream-nodest", testMountReady(t, `"mounting"`, 5*time.Second))
+	testBundleMount(t, "nostream-nodest", testWaitForReader(t, `"mounting"`, 5*time.Second))
 }
 
 func captureOutputProgress(p io.Reader) (*bytes.Buffer, *sync.WaitGroup) {
@@ -321,7 +321,7 @@ func TestBundleMutableMount(t *testing.T) {
 		}
 	}()
 
-	testMountReady(t, `"mounting"`, 5*time.Second)(logger, pipe)
+	testWaitForReader(t, `"mounting"`, 5*time.Second)(logger, pipe)
 
 	logger.Info("copying files to the mount")
 	// copy files to mount


### PR DESCRIPTION
update the `WorkshopTest` to include a smoke test of the `web` command at the same level of abstraction (driving the cli as a binary rather than using Cobra's api) as the remainder of that test.

`routes_test.go` remains the place for more detailed specification- and documentation-by-test of the `web` package.