### PR TITLE
Diamonds #3: fix(localfs)

### DIFF
--- a/pkg/storage/localfs/store.go
+++ b/pkg/storage/localfs/store.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -18,17 +21,36 @@ import (
 )
 
 // New creates a new local file system backed storage model
-func New(fs afero.Fs) storage.Store {
+func New(fs afero.Fs, opts ...Option) storage.Store {
 	if fs == nil {
 		fs = afero.NewBasePathFs(afero.NewOsFs(), filepath.Join(".datamon", "objects"))
 	}
-	return &localFS{
-		fs: fs,
+	local := &localFS{
+		fs:   fs,
+		glob: make(map[string][]string),
+	}
+	for _, apply := range opts {
+		apply(local)
+	}
+	return local
+}
+
+// Option for the local FS store
+type Option func(*localFS)
+
+// WithLock prevents concurrent writes or concurrent read/writes on this local FS
+func WithLock(flag bool) Option {
+	return func(fs *localFS) {
+		fs.lock = flag
 	}
 }
 
 type localFS struct {
-	fs afero.Fs
+	fs        afero.Fs
+	glob      map[string][]string // current state of KeyPrefix matches
+	exclusive sync.Mutex          // mutex on glob access
+	lock      bool
+	rw        sync.RWMutex
 }
 
 func (l *localFS) Has(ctx context.Context, key string) (bool, error) {
@@ -63,12 +85,16 @@ func (r localReader) Read(p []byte) (n int, err error) {
 func toSentinelErrors(err error) error {
 	// return sentinel errors defined by the status package
 	if os.IsNotExist(err) {
-		return storagestatus.ErrNotExists
+		return storagestatus.ErrNotExists.Wrap(err)
 	}
 	return err
 }
 
 func (l *localFS) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	if l.lock {
+		l.rw.RLock()
+		defer l.rw.RUnlock()
+	}
 	t, err := l.fs.Open(key)
 	return localReader{
 		objectReader: t,
@@ -82,11 +108,16 @@ type readCloser struct {
 func (rc readCloser) Read(p []byte) (n int, err error) {
 	return rc.reader.Read(p)
 }
+
 func (rc readCloser) Close() error {
 	return nil
 }
 
 func (l *localFS) Put(ctx context.Context, key string, source io.Reader, exclusive bool) error {
+	if l.lock {
+		l.rw.Lock()
+		defer l.rw.Unlock()
+	}
 	// TODO: Change this implementation to use rename to put file into place.
 	dir := filepath.Dir(key)
 	if dir != "" {
@@ -94,7 +125,7 @@ func (l *localFS) Put(ctx context.Context, key string, source io.Reader, exclusi
 			return fmt.Errorf("ensuring directories for %q: %v", key, err)
 		}
 	}
-	flag := os.O_CREATE | os.O_WRONLY | os.O_SYNC | 0600
+	flag := os.O_CREATE | os.O_WRONLY | os.O_SYNC | os.O_TRUNC
 	if exclusive {
 		flag |= os.O_EXCL
 	}
@@ -123,6 +154,10 @@ func (l *localFS) Put(ctx context.Context, key string, source io.Reader, exclusi
 }
 
 func (l *localFS) Delete(ctx context.Context, key string) error {
+	if l.lock {
+		l.rw.Lock()
+		defer l.rw.Unlock()
+	}
 	if err := l.fs.Remove(key); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("removing %q: %v", key, err)
 	}
@@ -130,6 +165,10 @@ func (l *localFS) Delete(ctx context.Context, key string) error {
 }
 
 func (l *localFS) Keys(ctx context.Context) ([]string, error) {
+	if l.lock {
+		l.rw.RLock()
+		defer l.rw.RUnlock()
+	}
 	const root = "."
 	var res []string
 	e := afero.Walk(l.fs, root, func(path string, info os.FileInfo, err error) error {
@@ -139,11 +178,7 @@ func (l *localFS) Keys(ctx context.Context) ([]string, error) {
 		if path == root {
 			return nil
 		}
-		fileInfo, err := l.fs.Stat(path)
-		if err != nil {
-			return err
-		}
-		if fileInfo.IsDir() {
+		if info.IsDir() {
 			return nil
 		}
 		res = append(res, path)
@@ -155,9 +190,75 @@ func (l *localFS) Keys(ctx context.Context) ([]string, error) {
 	return res, nil
 }
 
-//TODO discuss the implementation with @Ivan & @Ritesh
-func (l *localFS) KeysPrefix(ctx context.Context, token, prefix, delimiter string, count int) ([]string, string, error) {
-	return nil, "", storagestatus.ErrNotImplemented
+// KeyPrefix provides a paginated key iterator using "pageToken" as the next starting point
+//
+// NOTE: this cursory implementation is at the moment only used by mocks in test. A more thorough approach
+// is required to make KeyPrefix a first class citizen for localfs.
+//
+// NOTE: "delimiter" is ignored (always set to "/").
+//
+// TODO(known limitations):
+//   * this implementation does not really scale up, but it is quite workable for our testcases using localfs.
+//   * this implementation is not meant for parallel use with mutable FS.
+func (l *localFS) KeysPrefix(_ context.Context, token, prefix, _ string, count int) ([]string, string, error) {
+	l.exclusive.Lock()
+	defer l.exclusive.Unlock()
+
+	prefix = path.Clean("/" + prefix)
+
+	// we cache the result for the duration of the fetch loop: during this period, localfs updates are not seen
+	search, ok := l.glob[prefix]
+	if !ok {
+		// NOTE: Glob is not workable, fall back to Walk
+		matches := make([]string, 0, 50)
+		err := afero.Walk(l.fs, path.Dir(prefix), func(pth string, info os.FileInfo, err error) error {
+			if info.IsDir() || err != nil {
+				return nil
+			}
+			if strings.HasPrefix(pth, prefix) {
+				matches = append(matches, strings.TrimPrefix(pth, "/"))
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, "", err
+		}
+		l.glob[prefix], search = matches, matches
+	}
+
+	var (
+		start, end int
+		next       string
+	)
+
+	if token == "" {
+		start = 0
+	} else {
+		found := false
+		for i, lookup := range search {
+			if token != lookup {
+				continue
+			}
+			found = true
+			start = i
+			break
+		}
+		if !found {
+			delete(l.glob, prefix)
+			return []string{}, "", nil
+		}
+	}
+
+	if len(search) > start+count {
+		next = search[start+count]
+		end = start + count
+	} else {
+		next = ""
+		end = len(search)
+		delete(l.glob, prefix)
+	}
+
+	return search[start:end], next, nil
 }
 
 func (l *localFS) Clear(ctx context.Context) error {

--- a/pkg/storage/localfs/store.go
+++ b/pkg/storage/localfs/store.go
@@ -154,10 +154,7 @@ func (l *localFS) Put(ctx context.Context, key string, source io.Reader, exclusi
 }
 
 func (l *localFS) Delete(ctx context.Context, key string) error {
-	if l.lock {
-		l.rw.Lock()
-		defer l.rw.Unlock()
-	}
+	// unlink is atomic: no need to lock the in-memory object for that
 	if err := l.fs.Remove(key); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("removing %q: %v", key, err)
 	}

--- a/pkg/storage/localfs/store_test.go
+++ b/pkg/storage/localfs/store_test.go
@@ -125,6 +125,8 @@ func fakeFile(t testing.TB, fs afero.Fs, file string) {
 	require.NoError(t, err)
 }
 
+const aSearch = "/a"
+
 func TestKeysPrefix(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	err := fs.MkdirAll("/a/b/c", 0777)
@@ -144,7 +146,7 @@ func TestKeysPrefix(t *testing.T) {
 	)
 
 	i := 0
-	search := "/a"
+	search := aSearch
 	for keys, next, err = store.KeysPrefix(context.Background(), "", search, "", 3); next != ""; keys, next, err = store.KeysPrefix(context.Background(), next, search, "", 3) {
 		require.NoError(t, err)
 		assert.Len(t, keys, 3)
@@ -214,8 +216,8 @@ func TestKeysPrefixWithDelimiter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// with invalid next
-	search = "/a"
-	keys, next, err = store.KeysPrefix(context.Background(), "", search, "", 5)
+	search = aSearch
+	_, next, err = store.KeysPrefix(context.Background(), "", search, "", 5)
 	require.NotEmpty(t, next)
 	assert.NoError(t, err)
 	keys, next, err = store.KeysPrefix(context.Background(), "nowhere", search, "", 5)
@@ -225,7 +227,7 @@ func TestKeysPrefixWithDelimiter(t *testing.T) {
 
 	// with delimiters and deduplication
 	i := 0
-	search = "/a"
+	search = aSearch
 	for keys, next, err = store.KeysPrefix(context.Background(), "", search, "-", 5); next != ""; keys, next, err = store.KeysPrefix(context.Background(), next, search, "-", 5) {
 		require.NoError(t, err)
 		assert.Lenf(t, keys, 5, "got keys %v", keys)


### PR DESCRIPTION
fix(localfs): fixed Put flags: added O_TRUNC (avoids file corruption when updating a file), removed 0600
fix(localfs): implemented KeysPrefix method (cursory implementation, primarily intended to use localfs as a mocked up Store)
fix(localfs): added the WithLock option to guard localfs against concurrent R/W and W/W options

**Motivation:**
I am building up some elaborate testcases for the diamonds feature, based on mocked localfs.
This brought up several issues with concurrent updates and required an implementation of KeysPrefix.

The new KeyPrefix is certainly not very scalable, but at least it
supports my testcases with core. I am not sure there is a better
way to go with afero.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>