### PR TITLE
test(cafs): Faster cafs test suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20191207000613-e7e4b65ae663 // indirect
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	golang.org/x/tools v0.0.0-20200107184032-11e9d9cc0042 // indirect
 	google.golang.org/api v0.14.0

--- a/internal/rand/randomdata.go
+++ b/internal/rand/randomdata.go
@@ -1,0 +1,154 @@
+package rand
+
+import (
+	"bytes"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// Bytes returns a random slice of bytes
+func Bytes(n int) []byte {
+	return randBytes(n)
+}
+
+// String returns a random string
+func String(n int) string {
+	return randString(n)
+}
+
+// LetterBytes returns a random slice of bytes picked in the [0-9]|[a-z] range
+func LetterBytes(n int) []byte {
+	return randLetterBytes(n)
+}
+
+// LetterString returns a random string picked in the [0-9]|[a-z] range
+func LetterString(n int) string {
+	return randLetterString(n)
+}
+
+/*
+func origRandString(n int) string {
+	return string(origRandBytes(n))
+}
+
+func origRandBytes(n int) []byte {
+	// from https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
+	const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
+	const (
+		letterIdxBits = 6                    // 6 bits to represent a letter index
+		letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+		letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+	)
+	src := rand.NewSource(time.Now().UnixNano())
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+	return b
+}
+*/
+
+var (
+	onceSource  sync.Once
+	rgen        *rand.Rand
+	onceLetters sync.Once
+	randMutex   sync.Mutex
+)
+
+func seed() {
+	src := rand.NewSource(time.Now().UnixNano())
+	rgen = rand.New(src)
+}
+
+func randBytes(n int) []byte {
+	onceSource.Do(seed)
+	buf := make([]byte, n)
+	randMutex.Lock() // the mutex doesn't add any significant time - alternative to mutex: singleton w/ goroutine
+	_, _ = rgen.Read(buf)
+	randMutex.Unlock()
+	return buf
+}
+
+func randString(n int) string {
+	return string(randBytes(n)) // this is not optimal but the cost of this extra copy is only about 10%
+}
+
+var letters []byte
+
+func makeLetters() {
+	// adds "a" to pad over 256 locations (0-9 U a-z makes up to 252 only and we want to cover the range of uint8)
+	// do the "a" is slightly more frequent than other signs. The trade-off here is speed over exact randomness
+	letters = bytes.Repeat([]byte("abcdefghijklmnopqrstuvwxyz0123456789a"), 7)
+}
+
+func randLetterBytes(n int) []byte {
+	onceLetters.Do(makeLetters)
+	buf := randBytes(n)
+	for i, b := range buf {
+		buf[i] = letters[b]
+	}
+	return buf
+}
+
+func randLetterString(n int) string {
+	return string(randLetterBytes(n))
+}
+
+/*
+// a channel based version: it is actually a bit slower - channel overhead and copy offsets
+// any gain from buffering ahead a random stream.
+const (
+	randChunk  = 1024
+	randBuffer = 2048
+)
+
+var (
+	rchan    chan []byte
+	onceChan sync.Once
+)
+
+func bgseed() {
+	seed()
+	rchan = make(chan []byte, randBuffer)
+	go func(bgrand chan<- []byte) {
+		buf := make([]byte, randChunk)
+		for {
+			_, _ = rgen.Read(buf)
+			bgrand <- buf
+		}
+	}(rchan)
+}
+
+func chanRandBytes(n int) []byte {
+	onceChan.Do(bgseed)
+	buf := make([]byte, ((n/randChunk)+1)*randChunk)
+	for i := 0; i < len(buf); i += randChunk {
+		chunk := <-rchan
+		copy(buf[i:i+randChunk], chunk[0:])
+	}
+	return buf[0:n]
+}
+
+func chanRandString(n int) string {
+	return string(chanRandBytes(n))
+}
+
+func chanRandLetterBytes(n int) []byte {
+	onceLetters.Do(makeLetters)
+	buf := chanRandBytes(n)
+	for i, b := range buf {
+		buf[i] = letters[uint8(b)]
+	}
+	return buf
+}
+*/

--- a/internal/rand/randomdata_test.go
+++ b/internal/rand/randomdata_test.go
@@ -1,0 +1,84 @@
+package rand
+
+import "testing"
+
+func TestRandLetterBytes(t *testing.T) {
+	name := randLetterBytes(20)
+	t.Logf("%v", string(name))
+}
+
+/*
+func benchmarkRandLetterBytes1(b *testing.B, size int) {
+	for n := 0; n < b.N; n++ {
+		_ = origRandBytes(size)
+	}
+}
+
+func Benchmark1RandLetterBytes20(b *testing.B)      { benchmarkRandLetterBytes1(b, 20) }
+func Benchmark1RandLetterBytes100(b *testing.B)     { benchmarkRandLetterBytes1(b, 100) }
+func Benchmark1RandLetterBytes500(b *testing.B)     { benchmarkRandLetterBytes1(b, 500) }
+func Benchmark1RandLetterBytes1000(b *testing.B)    { benchmarkRandLetterBytes1(b, 1000) }
+func Benchmark1RandLetterBytes1000000(b *testing.B) { benchmarkRandLetterBytes1(b, 1000000) }
+*/
+
+func benchmarkRandBytes2(b *testing.B, size int) {
+	for n := 0; n < b.N; n++ {
+		_ = randBytes(size)
+	}
+}
+
+func Benchmark2RandBytes20(b *testing.B)      { benchmarkRandBytes2(b, 20) }
+func Benchmark2RandBytes100(b *testing.B)     { benchmarkRandBytes2(b, 100) }
+func Benchmark2RandBytes500(b *testing.B)     { benchmarkRandBytes2(b, 500) }
+func Benchmark2RandBytes1000(b *testing.B)    { benchmarkRandBytes2(b, 1000) }
+func Benchmark2RandBytes1000000(b *testing.B) { benchmarkRandBytes2(b, 1000000) }
+
+func benchmarkRandString2(b *testing.B, size int) {
+	for n := 0; n < b.N; n++ {
+		_ = randString(size)
+	}
+}
+
+func Benchmark2RandString20(b *testing.B)      { benchmarkRandString2(b, 20) }
+func Benchmark2RandString100(b *testing.B)     { benchmarkRandString2(b, 100) }
+func Benchmark2RandString500(b *testing.B)     { benchmarkRandString2(b, 500) }
+func Benchmark2RandString1000(b *testing.B)    { benchmarkRandString2(b, 1000) }
+func Benchmark2RandString1000000(b *testing.B) { benchmarkRandString2(b, 1000000) }
+
+func benchmarkRandLetterBytes2(b *testing.B, size int) {
+	for n := 0; n < b.N; n++ {
+		_ = randLetterBytes(size)
+	}
+}
+
+func Benchmark2RandLetterBytes20(b *testing.B)      { benchmarkRandLetterBytes2(b, 20) }
+func Benchmark2RandLetterBytes100(b *testing.B)     { benchmarkRandLetterBytes2(b, 100) }
+func Benchmark2RandLetterBytes500(b *testing.B)     { benchmarkRandLetterBytes2(b, 500) }
+func Benchmark2RandLetterBytes1000(b *testing.B)    { benchmarkRandLetterBytes2(b, 1000) }
+func Benchmark2RandLetterBytes1000000(b *testing.B) { benchmarkRandLetterBytes2(b, 1000000) }
+
+/*
+func benchmarkRandBytes3(b *testing.B, size int) {
+	for n := 0; n < b.N; n++ {
+		_ = chanRandBytes(size)
+	}
+}
+
+func Benchmark3RandBytes20(b *testing.B)      { benchmarkRandBytes3(b, 20) }
+func Benchmark3RandBytes100(b *testing.B)     { benchmarkRandBytes3(b, 100) }
+func Benchmark3RandBytes500(b *testing.B)     { benchmarkRandBytes3(b, 500) }
+func Benchmark3RandBytes1000(b *testing.B)    { benchmarkRandBytes3(b, 1000) }
+func Benchmark3RandBytes1000000(b *testing.B) { benchmarkRandBytes3(b, 1000000) }
+
+func benchmarkRandLetterBytes3(b *testing.B, size int) {
+	for n := 0; n < b.N; n++ {
+		_ = chanRandLetterBytes(size)
+	}
+}
+
+func Benchmark3RandLetterBytes20(b *testing.B)      { benchmarkRandLetterBytes3(b, 20) }
+func Benchmark3RandLetterBytes100(b *testing.B)     { benchmarkRandLetterBytes3(b, 100) }
+func Benchmark3RandLetterBytes500(b *testing.B)     { benchmarkRandLetterBytes3(b, 500) }
+func Benchmark3RandLetterBytes1000(b *testing.B)    { benchmarkRandLetterBytes3(b, 1000) }
+func Benchmark3RandLetterBytes1000000(b *testing.B) { benchmarkRandLetterBytes3(b, 1000000) }
+*/

--- a/pkg/cafs/cafs_test.go
+++ b/pkg/cafs/cafs_test.go
@@ -16,12 +16,11 @@ import (
 func assertReaderOriginal(t testing.TB, original string, rdr io.ReadCloser) {
 	defer rdr.Close()
 
-	b, err := ioutil.ReadAll(rdr)
+	actual, err := ioutil.ReadAll(rdr)
 	require.NoError(t, err)
 	require.NoError(t, rdr.Close())
 
 	expected := readTextFile(t, original)
-	actual := string(b)
 	require.Equal(t, len(expected), len(actual))
 	require.Equal(t, expected, actual)
 }
@@ -35,9 +34,7 @@ func TestCAFS_Get(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tf := range testFiles(destDir) {
-		rhash := readTextFile(t, tf.RootHash)
-		rkey, err := KeyFromString(rhash)
-		require.NoError(t, err)
+		rkey := keyFromFile(t, tf.RootHash)
 
 		rdr, err := fs.Get(context.Background(), rkey)
 		require.NoError(t, err)

--- a/pkg/cafs/fake_data_generator.go
+++ b/pkg/cafs/fake_data_generator.go
@@ -2,62 +2,87 @@ package cafs
 
 import (
 	"context"
-	"fmt"
 	"path"
 
-	"github.com/oneconcern/datamon/internal"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/oneconcern/datamon/internal/rand"
+	"github.com/oneconcern/datamon/pkg/errors"
 
 	"io/ioutil"
 	"os"
 	"path/filepath"
 )
 
-func GenerateFile(tgt string, size int, leafSize uint32) error {
-	err := os.MkdirAll(path.Dir(tgt), os.ModePerm)
+// GenerateFile is a test utility.
+//
+// It builds a file on the local file system with some random content
+func GenerateFile(target string, size int, leafSize uint32) (e error) {
+	err := os.MkdirAll(path.Dir(target), os.ModePerm)
 	if err != nil {
-		fmt.Printf("Unable to create file:%s, err:%s\n", tgt, err)
-		return err
-	}
-	f, err := os.Create(tgt)
-	if err != nil {
-		fmt.Printf("Unable to create file:%s, err:%s\n", tgt, err)
-		return err
-	}
-	if err = f.Sync(); err != nil {
-		fmt.Printf("Unable to sync file:%s, err:%s\n", tgt, err)
-		return err
+		return errors.New("unable to create dir").WrapMessage("%s", target).Wrap(err)
 	}
 
-	if size <= int(leafSize) { // small single chunk file
-		_, err = f.WriteString(internal.RandStringBytesMaskImprSrc(size))
+	f, err := os.Create(target)
+	if err != nil {
+		return errors.New("unable to create file").WrapMessage("%s", target).Wrap(err)
+	}
+
+	defer func() {
+		e = f.Close()
 		if err != nil {
-			return err
+			e = err
 		}
-		return f.Close()
+	}()
+
+	generator := rand.Bytes
+
+	if leafSize == 0 {
+		leafSize = DefaultLeafSize
+	}
+	leaf := int(leafSize)
+
+	if size <= leaf { // small single chunk file
+		_, err = f.Write(generator(size))
+		return
 	}
 
-	var parts = size / int(leafSize)
-	var i int
+	var (
+		parts = size / leaf
+		i     int
+		wg    errgroup.Group
+	)
+
 	for i = 0; i < parts; i++ {
-		_, err = f.WriteString(internal.RandStringBytesMaskImprSrc(int(leafSize)))
-		if err != nil {
-			return err
-		}
+		wg.Go(func(idx int) func() error {
+			return func() error {
+				_, erw := f.WriteAt(rand.Bytes(leaf), int64(idx*leaf))
+				return erw
+			}
+		}(i))
 	}
-	remaining := size - (parts * int(leafSize))
+	err = wg.Wait()
+	if err != nil {
+		return
+	}
+	_, err = f.Seek(0, 2)
+	if err != nil {
+		return
+	}
+	remaining := size - (parts * leaf)
 	if remaining > 0 {
-		_, err = f.WriteString(internal.RandStringBytesMaskImprSrc(remaining))
+		_, err = f.Write(generator(remaining))
 		if err != nil {
-			return err
+			return
 		}
 	}
-	if err = f.Sync(); err != nil {
-		fmt.Printf("Unable to sync file:%s, err:%s\n", tgt, err)
-		return err
-	}
-	return f.Close()
+	//nolint:nakedret
+	return
 }
 
+// GenerateCAFSFile is a test utility.
+//
+// It puts some local file into a cafs store, then archive the root key to retrieve the content
 func GenerateCAFSFile(src string, fs Fs, destDir string) error {
 	key, err := GenerateCAFSChunks(src, fs)
 	if err != nil {
@@ -66,11 +91,13 @@ func GenerateCAFSFile(src string, fs Fs, destDir string) error {
 	return ioutil.WriteFile(filepath.Join(destDir, "roots", filepath.Base(src)), []byte(key.String()), 0600)
 }
 
+// GenerateCAFSChunks is a test utility.
+//
+// It copies a source file to a cafs store.
 func GenerateCAFSChunks(src string, fs Fs) (*Key, error) {
 	sourceFile, err := os.Open(src)
 	if err != nil {
-		fmt.Printf("Failed to open file:%s, err:%s\n", src, err)
-		return nil, err
+		return nil, errors.New("failed to open file").WrapMessage("%s", src).Wrap(err)
 	}
 	defer sourceFile.Close()
 

--- a/pkg/cafs/fake_data_generator_test.go
+++ b/pkg/cafs/fake_data_generator_test.go
@@ -1,0 +1,37 @@
+package cafs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type generateFixture struct {
+	target   string
+	size     int
+	leafSize uint32
+}
+
+func TestGenerateFile(t *testing.T) {
+	tmp, erd := ioutil.TempDir("", "faker-")
+	require.NoError(t, erd)
+
+	defer func() {
+		_ = os.RemoveAll(tmp)
+	}()
+
+	for _, gen := range []generateFixture{
+		{target: "file1", size: 20},
+		{target: "file2", size: 2100, leafSize: 200},
+	} {
+		file := filepath.Join(tmp, gen.target)
+		assert.NoError(t, GenerateFile(file, gen.size, gen.leafSize))
+		info, err := os.Stat(file)
+		require.NoError(t, err)
+		assert.Equal(t, gen.size, int(info.Size()))
+	}
+}

--- a/pkg/cafs/hasher_test.go
+++ b/pkg/cafs/hasher_test.go
@@ -74,7 +74,7 @@ func TestLeafHashes_Multi(t *testing.T) {
 		t.Run(tf.Original+"-hashes-multi", func(t *testing.T) {
 			t.Parallel()
 
-			rhash := readTextFile(t, tf.RootHash)
+			rhash := string(readTextFile(t, tf.RootHash))
 			rrdr, err := blobs.Get(context.Background(), rhash)
 			require.NoError(t, err)
 			rkey, err := KeyFromString(rhash)

--- a/pkg/cafs/reader_test.go
+++ b/pkg/cafs/reader_test.go
@@ -16,7 +16,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"go.uber.org/zap"
 
-	"github.com/oneconcern/datamon/internal"
+	"github.com/oneconcern/datamon/internal/rand"
 
 	"github.com/oneconcern/datamon/pkg/dlogger"
 	"github.com/oneconcern/datamon/pkg/storage"
@@ -28,15 +28,15 @@ import (
 
 func keyFromFile(t testing.TB, pth string) Key {
 	rhash := readTextFile(t, pth)
-	rkey, err := KeyFromString(rhash)
+	rkey, err := KeyFromString(string(rhash))
 	require.NoError(t, err)
 	return rkey
 }
 
-func readTextFile(t testing.TB, pth string) string {
+func readTextFile(t testing.TB, pth string) []byte {
 	v, err := ioutil.ReadFile(pth)
 	require.NoError(t, err)
-	return string(v)
+	return v
 }
 
 func TestChunkReader_SmallOnly(t *testing.T) {
@@ -58,11 +58,10 @@ func verifyChunkReader(t testing.TB, blobs storage.Store, tf testFile) {
 	require.NoError(t, err)
 	defer rdr.Close()
 
-	b, err := ioutil.ReadAll(rdr)
+	actual, err := ioutil.ReadAll(rdr)
 	require.NoError(t, err)
 
 	expected := readTextFile(t, tf.Original)
-	actual := string(b)
 	require.Equal(t, len(expected), len(actual))
 	require.Equal(t, expected, actual)
 }
@@ -75,7 +74,7 @@ func verifyChunkReaderAt(t testing.TB, blobs storage.Store, tf testFile, opts ..
 	r, err := newReader(blobs, rkey, leafSize, opts...)
 	require.NoErrorf(t, err, "did not expect newReader to fail, but got: %v", err)
 
-	// assert that the reader is actually destroyable, when the gc will eventually reclaim it
+	// assert that the reader is actually destroyable, when the gc eventually reclaims it
 	// (terminates prefetching routines)
 	defer r.(*chunkReader).destroy()
 
@@ -135,7 +134,7 @@ func filterEOF(err error) error {
 	return err
 }
 
-func assertReadAtContent(t testing.TB, size int, name, expected string, received []byte, n int, offset int64) {
+func assertReadAtContent(t testing.TB, size int, name string, expected, received []byte, n int, offset int64) {
 	var count int
 	// truncate tested data to the first 2*leafSize bytes
 	if len(expected) > size {
@@ -331,8 +330,10 @@ func TestWriteTo(t *testing.T) {
 	testFakeStore := fakeStore{
 		chunks: make(map[string][]byte, 2),
 	}
-	testFakeStore.chunks[keyStr1] = internal.RandBytesMaskImprSrc(64 * 1024)
-	testFakeStore.chunks[keyStr2] = internal.RandBytesMaskImprSrc(64 * 1024)
+	const chunkSize = 64 * 1024
+
+	testFakeStore.chunks[keyStr1] = rand.Bytes(chunkSize)
+	testFakeStore.chunks[keyStr2] = rand.Bytes(chunkSize)
 	key, err := KeyFromString(rKeyStr)
 	require.NoError(t, err)
 	key1, err := KeyFromString(keyStr1)
@@ -340,7 +341,7 @@ func TestWriteTo(t *testing.T) {
 	key2, err := KeyFromString(keyStr2)
 	require.NoError(t, err)
 	keys := []Key{key1, key2}
-	reader, err := newReader(&testFakeStore, key, 64*1024,
+	reader, err := newReader(&testFakeStore, key, chunkSize,
 		ReaderPrefix(""),
 		TruncateLeaf(false),
 		Keys(keys),
@@ -349,22 +350,22 @@ func TestWriteTo(t *testing.T) {
 	rWriteTo, ok := reader.(io.WriterTo)
 	require.True(t, ok)
 	fakeWriterAt := &fakeWriteAt{
-		data: make([]byte, 2*64*1024),
+		data: make([]byte, 2*chunkSize),
 	}
 	written, err := rWriteTo.WriteTo(fakeWriterAt)
 	require.NoError(t, err)
-	require.Equal(t, written, int64(2*64*1024))
-	require.Equal(t, testFakeStore.chunks[keyStr1], fakeWriterAt.data[:64*1024])
-	require.Equal(t, testFakeStore.chunks[keyStr2], fakeWriterAt.data[64*1024:])
+	require.Equal(t, written, int64(2*chunkSize))
+	require.Equal(t, testFakeStore.chunks[keyStr1], fakeWriterAt.data[:chunkSize])
+	require.Equal(t, testFakeStore.chunks[keyStr2], fakeWriterAt.data[chunkSize:])
 	// Pass writer with write at. make sure data read from reader is written to writerAt
 	fakeWriter := &fakeWriter{
-		data: make([]byte, 2*64*1024),
+		data: make([]byte, 2*chunkSize),
 	}
 	written, err = rWriteTo.WriteTo(fakeWriter)
 	require.NoError(t, err)
-	require.Equal(t, written, int64(2*64*1024))
-	require.Equal(t, testFakeStore.chunks[keyStr1], fakeWriter.data[:64*1024])
-	require.Equal(t, testFakeStore.chunks[keyStr2], fakeWriter.data[64*1024:])
+	require.Equal(t, written, int64(2*chunkSize))
+	require.Equal(t, testFakeStore.chunks[keyStr1], fakeWriter.data[:chunkSize])
+	require.Equal(t, testFakeStore.chunks[keyStr2], fakeWriter.data[chunkSize:])
 	// TODO: Set truncation on and verify.
 }
 


### PR DESCRIPTION
* introduced new, faster, random data generator
* faster cafs tests with faster random generator, less string <-> []byte conversions

NOTE: I am also introducing here the use of "golang.org/x/sync/errgroup", which might help us simplify some of our goroutine patterns in the near future.

NOTE: on CI run, the cafs test suite goes from 42 sec down to 4s. Generalizing the new generator to other consuming packages shall bring testing time further down.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>