### PR TITLE
refact(model): moved constructors and options for metadata models from core to model

### DIFF
--- a/cmd/datamon/cmd/bundle.go
+++ b/cmd/datamon/cmd/bundle.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	context2 "github.com/oneconcern/datamon/pkg/context"
+	"github.com/oneconcern/datamon/pkg/model"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/spf13/cobra"
@@ -72,10 +73,13 @@ func setLatestOrLabelledBundle(ctx context.Context, remote context2.Stores) erro
 		}
 		datamonFlags.bundle.ID = key
 	case datamonFlags.bundle.ID == "" && datamonFlags.label.Name != "":
-		label := core.NewLabel(nil,
-			core.LabelName(datamonFlags.label.Name),
-		)
-		bundle := core.NewBundle(core.NewBDescriptor(),
+		label := core.NewLabel(
+			core.LabelDescriptor(
+				model.NewLabelDescriptor(
+					model.LabelName(datamonFlags.label.Name),
+				),
+			))
+		bundle := core.NewBundle(
 			core.Repo(datamonFlags.repo.RepoName),
 			core.ContextStores(remote),
 		)

--- a/cmd/datamon/cmd/bundle_diff.go
+++ b/cmd/datamon/cmd/bundle_diff.go
@@ -59,7 +59,7 @@ var bundleDiffCmd = &cobra.Command{
 			return
 		}
 
-		localBundle := core.NewBundle(core.NewBDescriptor(),
+		localBundle := core.NewBundle(
 			core.ConsumableStore(destinationStore),
 		)
 
@@ -72,7 +72,7 @@ var bundleDiffCmd = &cobra.Command{
 		bundleOpts = append(bundleOpts,
 			core.ConcurrentFilelistDownloads(datamonFlags.bundle.ConcurrencyFactor/filelistDownloadsByConcurrencyFactor))
 
-		remoteBundle := core.NewBundle(core.NewBDescriptor(),
+		remoteBundle := core.NewBundle(
 			bundleOpts...,
 		)
 

--- a/cmd/datamon/cmd/bundle_download.go
+++ b/cmd/datamon/cmd/bundle_download.go
@@ -72,7 +72,7 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 		}
 		bundleOpts = append(bundleOpts, core.Logger(logger))
 
-		bundle := core.NewBundle(core.NewBDescriptor(),
+		bundle := core.NewBundle(
 			bundleOpts...,
 		)
 

--- a/cmd/datamon/cmd/bundle_download_file.go
+++ b/cmd/datamon/cmd/bundle_download_file.go
@@ -47,7 +47,7 @@ You may use the "--label" flag as an alternate way to specify a particular bundl
 		bundleOpts = append(bundleOpts, core.ConsumableStore(destinationStore))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
 
-		bundle := core.NewBundle(core.NewBDescriptor(),
+		bundle := core.NewBundle(
 			bundleOpts...,
 		)
 

--- a/cmd/datamon/cmd/bundle_get.go
+++ b/cmd/datamon/cmd/bundle_get.go
@@ -47,7 +47,7 @@ exits with ENOENT status otherwise.`,
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 
-		bundle := core.NewBundle(core.NewBDescriptor(),
+		bundle := core.NewBundle(
 			bundleOpts...,
 		)
 

--- a/cmd/datamon/cmd/bundle_list_file.go
+++ b/cmd/datamon/cmd/bundle_list_file.go
@@ -45,7 +45,7 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 		}
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
-		bundle := core.NewBundle(core.NewBDescriptor(),
+		bundle := core.NewBundle(
 			bundleOpts...,
 		)
 		err = core.PopulateFiles(context.Background(), bundle)

--- a/cmd/datamon/cmd/bundle_mount.go
+++ b/cmd/datamon/cmd/bundle_mount.go
@@ -108,7 +108,6 @@ var mountBundleCmd = &cobra.Command{
 			onDaemonError("determine bundle id", err)
 			return
 		}
-		bd := core.NewBDescriptor()
 		bundleOpts, err := optionInputs.bundleOpts(ctx)
 		if err != nil {
 			wrapFatalln("failed to initialize bundle options", err)
@@ -123,7 +122,7 @@ var mountBundleCmd = &cobra.Command{
 			return
 		}
 		bundleOpts = append(bundleOpts, core.Logger(logger))
-		bundle := core.NewBundle(bd, bundleOpts...)
+		bundle := core.NewBundle(bundleOpts...)
 		var fsOpts []fuse.Option
 		fsOpts = append(fsOpts, fuse.Streaming(datamonFlags.fs.Stream))
 		fsOpts = append(fsOpts, fuse.Logger(logger))

--- a/cmd/datamon/cmd/bundle_mutable_mount.go
+++ b/cmd/datamon/cmd/bundle_mutable_mount.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/fuse"
+	"github.com/oneconcern/datamon/pkg/model"
 	"github.com/spf13/cobra"
 )
 
@@ -38,15 +39,16 @@ The destination path is a temporary staging area for write operations.`,
 			return
 		}
 
-		bd := core.NewBDescriptor(
-			core.Message(datamonFlags.bundle.Message),
-			core.Contributor(contributor),
+		bd := model.NewBundleDescriptor(
+			model.Message(datamonFlags.bundle.Message),
+			model.BundleContributor(contributor),
 		)
 		bundleOpts, err := optionInputs.bundleOpts(ctx)
 		if err != nil {
 			onDaemonError("failed to initialize bundle options", err)
 			return
 		}
+		bundleOpts = append(bundleOpts, core.BundleDescriptor(bd))
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.ConsumableStore(consumableStore))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
@@ -57,7 +59,7 @@ The destination path is a temporary staging area for write operations.`,
 		}
 		bundleOpts = append(bundleOpts, core.Logger(logger))
 
-		bundle := core.NewBundle(bd, bundleOpts...)
+		bundle := core.NewBundle(bundleOpts...)
 
 		var fsOpts []fuse.Option
 		fsOpts = append(fsOpts, fuse.Logger(logger))
@@ -87,12 +89,13 @@ The destination path is a temporary staging area for write operations.`,
 		}
 		log.Printf("bundle: %v", bundle.BundleID)
 		if datamonFlags.label.Name != "" {
-			labelDescriptor := core.NewLabelDescriptor(
-				core.LabelContributor(contributor),
-			)
-			label := core.NewLabel(labelDescriptor,
-				core.LabelName(datamonFlags.label.Name),
-			)
+			label := core.NewLabel(
+				core.LabelDescriptor(
+					model.NewLabelDescriptor(
+						model.LabelContributor(contributor),
+						model.LabelName(datamonFlags.label.Name),
+					),
+				))
 			err = label.UploadDescriptor(ctx, bundle)
 			if err != nil {
 				wrapFatalln("upload label", err)

--- a/cmd/datamon/cmd/bundle_update.go
+++ b/cmd/datamon/cmd/bundle_update.go
@@ -69,7 +69,7 @@ var bundleUpdateCmd = &cobra.Command{
 			wrapFatalln("determine bundle id", err)
 			return
 		}
-		localBundle := core.NewBundle(core.NewBDescriptor(),
+		localBundle := core.NewBundle(
 			core.ConsumableStore(destinationStore),
 		)
 
@@ -79,7 +79,7 @@ var bundleUpdateCmd = &cobra.Command{
 		}
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
-		remoteBundle := core.NewBundle(core.NewBDescriptor(),
+		remoteBundle := core.NewBundle(
 			bundleOpts...,
 		)
 

--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/oneconcern/datamon/pkg/core"
+	"github.com/oneconcern/datamon/pkg/model"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -48,9 +49,9 @@ set label 'init'
 			wrapFatalln("create source store", err)
 			return
 		}
-		bd := core.NewBDescriptor(
-			core.Message(datamonFlags.bundle.Message),
-			core.Contributor(contributor),
+		bd := model.NewBundleDescriptor(
+			model.Message(datamonFlags.bundle.Message),
+			model.BundleContributor(contributor),
 		)
 
 		bundleOpts, err := optionInputs.bundleOpts(ctx)
@@ -58,6 +59,7 @@ set label 'init'
 			wrapFatalln("failed to initialize bundle options", err)
 			return
 		}
+		bundleOpts = append(bundleOpts, core.BundleDescriptor(bd))
 		bundleOpts = append(bundleOpts, core.ConsumableStore(sourceStore))
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.SkipMissing(datamonFlags.bundle.SkipOnError))
@@ -74,7 +76,7 @@ set label 'init'
 		if enableBundlePreserve {
 			bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
 		}
-		bundle := core.NewBundle(bd,
+		bundle := core.NewBundle(
 			bundleOpts...,
 		)
 
@@ -118,12 +120,13 @@ set label 'init'
 		}()
 
 		if datamonFlags.label.Name != "" {
-			labelDescriptor := core.NewLabelDescriptor(
-				core.LabelContributor(contributor),
-			)
-			label := core.NewLabel(labelDescriptor,
-				core.LabelName(datamonFlags.label.Name),
-			)
+			label := core.NewLabel(
+				core.LabelDescriptor(
+					model.NewLabelDescriptor(
+						model.LabelContributor(contributor),
+						model.LabelName(datamonFlags.label.Name),
+					),
+				))
 			err = label.UploadDescriptor(ctx, bundle)
 			if err != nil {
 				wrapFatalln("upload label", err)

--- a/cmd/datamon/cmd/label_get.go
+++ b/cmd/datamon/cmd/label_get.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oneconcern/datamon/pkg/core"
 	status "github.com/oneconcern/datamon/pkg/core/status"
 	"github.com/oneconcern/datamon/pkg/errors"
+	"github.com/oneconcern/datamon/pkg/model"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
@@ -28,13 +29,18 @@ exits with ENOENT status otherwise.`,
 			wrapFatalln("create remote stores", err)
 			return
 		}
-		bundle := core.NewBundle(core.NewBDescriptor(),
+		bundle := core.NewBundle(
 			core.Repo(datamonFlags.repo.RepoName),
 			core.ContextStores(remoteStores),
 		)
-		label := core.NewLabel(core.NewLabelDescriptor(),
-			core.LabelName(datamonFlags.label.Name),
-		)
+
+		label := core.NewLabel(
+			core.LabelDescriptor(
+				model.NewLabelDescriptor(
+					model.LabelName(datamonFlags.label.Name),
+				),
+			))
+
 		err = label.DownloadDescriptor(ctx, bundle, true)
 		if errors.Is(err, status.ErrNotFound) {
 			wrapFatalWithCodef(int(unix.ENOENT), "didn't find label %q", datamonFlags.label.Name)

--- a/cmd/datamon/cmd/label_set.go
+++ b/cmd/datamon/cmd/label_set.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/oneconcern/datamon/pkg/core"
+	"github.com/oneconcern/datamon/pkg/model"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +33,7 @@ Setting a label is analogous to the git command "git tag {label}".`,
 			return
 		}
 
-		bundle := core.NewBundle(core.NewBDescriptor(),
+		bundle := core.NewBundle(
 			core.Repo(datamonFlags.repo.RepoName),
 			core.ContextStores(remoteStores),
 			core.BundleID(datamonFlags.bundle.ID),
@@ -48,12 +49,13 @@ Setting a label is analogous to the git command "git tag {label}".`,
 			return
 		}
 
-		labelDescriptor := core.NewLabelDescriptor(
-			core.LabelContributor(contributor),
-		)
-		label := core.NewLabel(labelDescriptor,
-			core.LabelName(datamonFlags.label.Name),
-		)
+		label := core.NewLabel(
+			core.LabelDescriptor(
+				model.NewLabelDescriptor(
+					model.LabelContributor(contributor),
+					model.LabelName(datamonFlags.label.Name),
+				),
+			))
 
 		err = label.UploadDescriptor(ctx, bundle)
 		if err != nil {

--- a/cmd/metrics/cmd/upload.go
+++ b/cmd/metrics/cmd/upload.go
@@ -163,9 +163,9 @@ var uploadCmd = &cobra.Command{
 			Name:  "contributors-name-" + contributorsTag,
 			Email: "contributors-email-" + contributorsTag,
 		}}
-		bd := core.NewBDescriptor(
-			core.Message("metrics bundle upload"),
-			core.Contributors(contributors),
+		bd := model.NewBundleDescriptor(
+			model.Message("metrics bundle upload"),
+			model.BundleContributors(contributors),
 		)
 		repoTag := internal.RandStringBytesMaskImprSrc(15)
 
@@ -182,7 +182,8 @@ var uploadCmd = &cobra.Command{
 			log.Fatalln(err)
 		}
 
-		bundle := core.NewBundle(bd,
+		bundle := core.NewBundle(
+			core.BundleDescriptor(bd),
 			core.Repo(repoName),
 			core.ContextStores(dmc),
 			core.ConsumableStore(sourceStore),

--- a/pkg/core/bundle.go
+++ b/pkg/core/bundle.go
@@ -5,15 +5,12 @@ package core
 import (
 	"context"
 	"fmt"
-	"time"
 
 	context2 "github.com/oneconcern/datamon/pkg/context"
 
 	"github.com/oneconcern/datamon/pkg/dlogger"
 
 	"go.uber.org/zap"
-
-	"github.com/oneconcern/datamon/pkg/cafs"
 
 	"github.com/segmentio/ksuid"
 
@@ -59,29 +56,6 @@ func (b *Bundle) InitializeBundleID() error {
 // GetBundleEntries retrieves all entries in a bundle
 func (b *Bundle) GetBundleEntries() []model.BundleEntry {
 	return b.BundleEntries
-}
-
-func defaultBundleDescriptor() *model.BundleDescriptor {
-	return &model.BundleDescriptor{
-		LeafSize:               cafs.DefaultLeafSize, // For now, fixed leaf size
-		ID:                     "",
-		Message:                "",
-		Parents:                nil,
-		Timestamp:              time.Now(),
-		Contributors:           nil,
-		BundleEntriesFileCount: 0,
-		Version:                model.CurrentBundleVersion,
-		Deduplication:          cafs.DeduplicationBlake,
-	}
-}
-
-// NewBDescriptor builds a new default bundle descriptor
-func NewBDescriptor(descriptorOps ...BundleDescriptorOption) *model.BundleDescriptor {
-	bd := defaultBundleDescriptor()
-	for _, apply := range descriptorOps {
-		apply(bd)
-	}
-	return bd
 }
 
 // BlobStore defines the blob storage (part of the context) for a bundle
@@ -144,6 +118,7 @@ func getReadLogStore(stores context2.Stores) storage.Store {
 
 func defaultBundle() *Bundle {
 	return &Bundle{
+		BundleDescriptor:            *model.NewBundleDescriptor(),
 		RepoID:                      "",
 		BundleID:                    "",
 		ConsumableStore:             nil,
@@ -156,12 +131,10 @@ func defaultBundle() *Bundle {
 }
 
 // NewBundle creates a new bundle
-func NewBundle(bd *model.BundleDescriptor, bundleOps ...BundleOption) *Bundle {
+func NewBundle(opts ...BundleOption) *Bundle {
 	b := defaultBundle()
-	b.BundleDescriptor = *bd
-
-	for _, bApply := range bundleOps {
-		bApply(b)
+	for _, apply := range opts {
+		apply(b)
 	}
 	return b
 }

--- a/pkg/core/bundle_options.go
+++ b/pkg/core/bundle_options.go
@@ -10,39 +10,12 @@ import (
 // BundleOption is a functor to build a bundle with some options
 type BundleOption func(*Bundle)
 
-// BundleDescriptorOption is a functor to build a bundle descriptor with some options
-type BundleDescriptorOption func(descriptor *model.BundleDescriptor)
-
-// Message defines the message of the bundle descriptor
-func Message(m string) BundleDescriptorOption {
-	return func(b *model.BundleDescriptor) {
-		b.Message = m
-	}
-}
-
-// Contributors defines the list of contributors for a bundle descriptor
-func Contributors(c []model.Contributor) BundleDescriptorOption {
-	return func(b *model.BundleDescriptor) {
-		b.Contributors = c
-	}
-}
-
-// Contributor defines a single contributor for a bundle descriptor
-func Contributor(c model.Contributor) BundleDescriptorOption {
-	return Contributors([]model.Contributor{c})
-}
-
-// Parents defines the parents for a bundle descriptor
-func Parents(p []string) BundleDescriptorOption {
-	return func(b *model.BundleDescriptor) {
-		b.Parents = p
-	}
-}
-
-// Deduplication defines the deduplication scheme for a bundle descriptor
-func Deduplication(d string) BundleDescriptorOption {
-	return func(b *model.BundleDescriptor) {
-		b.Deduplication = d
+// BundleDescriptor sets the descriptor for this bundle
+func BundleDescriptor(r *model.BundleDescriptor) BundleOption {
+	return func(b *Bundle) {
+		if r != nil {
+			b.BundleDescriptor = *r
+		}
 	}
 }
 

--- a/pkg/core/bundle_test.go
+++ b/pkg/core/bundle_test.go
@@ -49,8 +49,7 @@ func testBundleEnv() mocks.TestEnv {
 // fakeBundle builds a fake bundle for the testing environment, with fake
 // context and consumable store located in DestinationDir.
 func fakeBundle(ev mocks.TestEnv) *Bundle {
-	bd := NewBDescriptor()
-	return NewBundle(bd,
+	return NewBundle(
 		Repo(ev.Repo),
 		BundleID(ev.BundleID),
 		ContextStores(mocks.FakeContext(ev.MetaDir, ev.BlobDir)),
@@ -88,9 +87,8 @@ func TestBundle(t *testing.T) {
 	mocks.ValidatePublish(t, bundle.ConsumableStore, bundleEntriesFileCount, ev)
 
 	// bundle id is set on upload
-	bd := NewBDescriptor()
 	consumableStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), ev.DestinationDir))
-	archiveBundle2 := NewBundle(bd,
+	archiveBundle2 := NewBundle(
 		Repo(ev.Repo),
 		ConsumableStore(consumableStore),
 		ContextStores(mocks.FakeContext(ev.ReArchiveMetaDir, ev.ReArchiveBlobDir)),
@@ -114,8 +112,7 @@ func paramedTestPublishMetadata(t *testing.T, publish bool, ev mocks.TestEnv) {
 	require.NoError(t, CreateRepo(mocks.FakeRepoDescriptor(ev.Repo), mocks.FakeContext(ev.MetaDir, "")))
 
 	consumableStore := localfs.New(afero.NewBasePathFs(afero.NewOsFs(), ev.DestinationDir))
-	bd := NewBDescriptor()
-	bundle := NewBundle(bd,
+	bundle := NewBundle(
 		Repo(ev.Repo),
 		BundleID(ev.BundleID),
 		ConsumableStore(consumableStore),

--- a/pkg/core/bundle_unpack.go
+++ b/pkg/core/bundle_unpack.go
@@ -562,7 +562,7 @@ func unpackDataFiles(ctx context.Context, bundle *Bundle,
 				return err
 			}
 		}
-		publishMetadataBundle := NewBundle(NewBDescriptor(),
+		publishMetadataBundle := NewBundle(
 			Repo(bundle.RepoID),
 			ContextStores(bundle.contextStores),
 			ConsumableStore(bundleDest.ConsumableStore),

--- a/pkg/core/label_list.go
+++ b/pkg/core/label_list.go
@@ -259,9 +259,9 @@ func getLabelAsync(repo string, stores context2.Stores, input <-chan string, out
 			output <- labelEvent{err: err}
 			continue
 		}
-		bundle := NewBundle(NewBDescriptor(), Repo(repo), ContextStores(stores))
+		bundle := NewBundle(Repo(repo), ContextStores(stores))
 		labelName := apc.LabelName
-		label := NewLabel(nil, LabelName(labelName))
+		label := NewLabel(LabelDescriptor(model.NewLabelDescriptor(model.LabelName(labelName))))
 		if err = label.DownloadDescriptor(context.Background(), bundle, false); err != nil {
 			output <- labelEvent{err: err}
 			continue

--- a/pkg/core/label_options.go
+++ b/pkg/core/label_options.go
@@ -1,0 +1,15 @@
+package core
+
+import "github.com/oneconcern/datamon/pkg/model"
+
+// LabelOption is a functor to build labels
+type LabelOption func(*Label)
+
+// LabelDescriptor sets the descriptor for this label
+func LabelDescriptor(r *model.LabelDescriptor) LabelOption {
+	return func(l *Label) {
+		if r != nil {
+			l.Descriptor = *r
+		}
+	}
+}

--- a/pkg/fuse/mocks/fs_test_utils.go
+++ b/pkg/fuse/mocks/fs_test_utils.go
@@ -27,8 +27,7 @@ import (
 
 // FakeBundle produce some fake bundle structure for this test environment
 func FakeBundle(ev mocks.TestEnv) *core.Bundle {
-	bd := core.NewBDescriptor()
-	return core.NewBundle(bd,
+	return core.NewBundle(
 		core.Repo(ev.Repo),
 		core.BundleID(ev.BundleID),
 		core.ContextStores(mocks.FakeContext(ev.MetaDir, ev.BlobDir)),
@@ -39,8 +38,10 @@ func FakeBundle(ev mocks.TestEnv) *core.Bundle {
 
 // EmptyBundle produces an initialized bundle with proper staging and context, but no bundle ID yet
 func EmptyBundle(ev mocks.TestEnv) *core.Bundle {
-	bd := core.NewBDescriptor(core.Message("test bundle"))
-	bundle := core.NewBundle(bd,
+	bundle := core.NewBundle(
+		core.BundleDescriptor(
+			model.NewBundleDescriptor(model.Message("test bundle")),
+		),
 		core.Repo(ev.Repo),
 		core.ConsumableStore(localfs.New(afero.NewBasePathFs(afero.NewOsFs(), ev.PathToStaging))),
 		core.ContextStores(mocks.FakeContext(ev.MetaDir, ev.BlobDir)),

--- a/pkg/model/bundle.go
+++ b/pkg/model/bundle.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/oneconcern/datamon/pkg/cafs"
 )
 
 const (
@@ -31,6 +33,24 @@ type BundleDescriptor struct {
 	Deduplication          string        `json:"deduplication,omitempty" yaml:"deduplication,omitempty"` // Type of deduplication used
 	RunStage               string        `json:"runstage,omitempty" yaml:"runstage,omitempty"`           // Path to the run stage
 	_                      struct{}
+}
+
+func defaultBundleDescriptor() *BundleDescriptor {
+	return &BundleDescriptor{
+		LeafSize:      cafs.DefaultLeafSize, // For now, fixed leaf size
+		Timestamp:     GetBundleTimeStamp(),
+		Version:       CurrentBundleVersion,
+		Deduplication: cafs.DeduplicationBlake,
+	}
+}
+
+// NewBundleDescriptor builds a new default bundle descriptor
+func NewBundleDescriptor(opts ...BundleDescriptorOption) *BundleDescriptor {
+	bd := defaultBundleDescriptor()
+	for _, apply := range opts {
+		apply(bd)
+	}
+	return bd
 }
 
 // BundleDescriptors is a sortable slice of BundleDescriptor
@@ -185,9 +205,9 @@ func GetBundleTimeStamp() time.Time {
 	return time.Now().UTC()
 }
 
-// IsGeneratedFile indicate if some file comes from auto-generation (e.g. .datamon files)
+// IsGeneratedFile indicates if some file comes from auto-generation (e.g. .datamon files)
 func IsGeneratedFile(file string) bool {
-	// TODO: Need to find a way for AeroFs to convert to abs patch while honoring the fake root
+	// TODO: Need to find a way for afero.Fs to convert to abs patch while honoring the fake root
 	//path, err := filepath.Abs(file)
 	return genFileRe.MatchString(file)
 }

--- a/pkg/model/bundle_options.go
+++ b/pkg/model/bundle_options.go
@@ -1,0 +1,37 @@
+package model
+
+// BundleDescriptorOption is a functor to build a bundle descriptor with some options
+type BundleDescriptorOption func(descriptor *BundleDescriptor)
+
+// Message defines the message of the bundle descriptor
+func Message(m string) BundleDescriptorOption {
+	return func(b *BundleDescriptor) {
+		b.Message = m
+	}
+}
+
+// BundleContributors defines the list of contributors for a bundle descriptor
+func BundleContributors(c []Contributor) BundleDescriptorOption {
+	return func(b *BundleDescriptor) {
+		b.Contributors = c
+	}
+}
+
+// BundleContributor defines a single contributor for a bundle descriptor
+func BundleContributor(c Contributor) BundleDescriptorOption {
+	return BundleContributors([]Contributor{c})
+}
+
+// Parents defines the parents for a bundle descriptor
+func Parents(p []string) BundleDescriptorOption {
+	return func(b *BundleDescriptor) {
+		b.Parents = p
+	}
+}
+
+// Deduplication defines the deduplication scheme for a bundle descriptor
+func Deduplication(d string) BundleDescriptorOption {
+	return func(b *BundleDescriptor) {
+		b.Deduplication = d
+	}
+}

--- a/pkg/model/label.go
+++ b/pkg/model/label.go
@@ -18,6 +18,21 @@ type LabelDescriptor struct {
 	_            struct{}
 }
 
+func defaultLabelDescriptor() *LabelDescriptor {
+	return &LabelDescriptor{
+		Timestamp: GetBundleTimeStamp(),
+	}
+}
+
+// NewLabelDescriptor builds a new label descriptor
+func NewLabelDescriptor(opts ...LabelDescriptorOption) *LabelDescriptor {
+	ld := defaultLabelDescriptor()
+	for _, apply := range opts {
+		apply(ld)
+	}
+	return ld
+}
+
 // LabelDescriptors is a sortable slice of LabelDescriptor
 type LabelDescriptors []LabelDescriptor
 

--- a/pkg/model/label_options.go
+++ b/pkg/model/label_options.go
@@ -1,0 +1,23 @@
+package model
+
+// LabelDescriptorOption is a functor to build label descriptors
+type LabelDescriptorOption func(descriptor *LabelDescriptor)
+
+// LabelContributors sets a list of contributors for the label
+func LabelContributors(c []Contributor) LabelDescriptorOption {
+	return func(ld *LabelDescriptor) {
+		ld.Contributors = c
+	}
+}
+
+// LabelContributor sets a single contributor for the label
+func LabelContributor(c Contributor) LabelDescriptorOption {
+	return LabelContributors([]Contributor{c})
+}
+
+// LabelName sets a name for the label
+func LabelName(name string) LabelDescriptorOption {
+	return func(ld *LabelDescriptor) {
+		ld.Name = name
+	}
+}

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -140,7 +140,7 @@ func listBundlesDefault(repoName string, stores context2.Stores) []model.BundleD
 }
 
 func listBundleFilesDefault(repoName string, bundleID string, stores context2.Stores) []model.BundleEntry {
-	bundle := core.NewBundle(core.NewBDescriptor(),
+	bundle := core.NewBundle(
 		core.Repo(repoName),
 		core.ContextStores(stores),
 		core.BundleID(bundleID),


### PR DESCRIPTION

* Principle: move constructors and option functors to the package that declares the type
* The main use case for core.NewBundle() being core.NewBundle(core.NewBDescriptor(), replaced
  this by default and added an option to override the descriptor.

NOTE: this point has been discussed in one of the diamond PR's (commented by  @ransomw1c ), in which I have anticipated this layout for the new core objects (i.e. establishing a clearer divide between core and model).

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>