### PR TITLE
feat(ops): [RES-2173] Cleaned up circleci details

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ executors:
   docker_minio:
     working_directory: ~/project
     environment:
-      GOOGLE_PROJECT_ID: "onec-co"
       GOOGLE_COMPUTE_ZONE: us-west2-c
     docker:
       - image: circleci/golang
@@ -24,7 +23,6 @@ executors:
   docker_builder:
     working_directory: ~/project
     environment:
-      GOOGLE_PROJECT_ID: "onec-co"
       GOOGLE_COMPUTE_ZONE: us-west2-c
     docker:
       - image: circleci/golang
@@ -32,7 +30,6 @@ executors:
   fuse_tester:
     working_directory: ~/project
     environment:
-      GOOGLE_PROJECT_ID: "onec-co"
       GOOGLE_COMPUTE_ZONE: us-west2-c
       GOROOT: /usr/local/go
       GOPATH: /go
@@ -124,7 +121,7 @@ commands:
           command: |
             sudo apt-get update -y --quiet
             sudo apt-get install --quiet kubectl
-            gcloud container clusters get-credentials onec-dev
+            gcloud container clusters get-credentials ${CLUSTER}
 
   install_test_tools:
     steps:


### PR DESCRIPTION
**Description:**
Datamon being an Open Source Project we don’t want any One Concern details revealed to the public anywhere in the code base. And we noticed that on the Circle CI yaml file there are a couple of parameters that are revealed and should not be.

Got rid of:
* Google Project ID
* Cluster Name

