### PR TITLE
feat: datamon metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,28 @@ executors:
     machine:
       image: ubuntu-1604:201903-01
 
+  metrics_tester:
+    working_directory: ~/project
+    environment:
+      GOOGLE_COMPUTE_ZONE: us-west2-c
+    docker:
+      - image: circleci/golang
+      - image: minio/minio
+        environment:
+          MINIO_ACCESS_KEY: access-key
+          MINIO_SECRET_KEY: secret-key-thing
+          MINIO_BROWSER: "off"
+          MINIO_DOMAIN: s3.local
+          MINIO_HTTP_TRACE: /tmp/minio.log
+        command:
+          - server
+          - data
+      - image: influxdb:1.7-alpine
+        environment:
+          INFLUXDB_DB: datamon
+        command:
+          - influxd
+
 commands:
   install_base:
     steps:
@@ -179,7 +201,8 @@ commands:
           name: Prepare golang tests
           command: |
             mkdir -p /tmp/test-results/cafs /tmp/test-results/noncafs /tmp/test-results/fuse \
-                     /tmp/test-coverage/cafs /tmp/test-coverage/noncafs /tmp/test-coverage/fuse
+                     /tmp/test-coverage/cafs /tmp/test-coverage/noncafs /tmp/test-coverage/fuse \
+                     /tmp/test-results/metrics /tmp/test-coverage/metrics
             hack/go-generate.sh
             go mod download
 
@@ -241,6 +264,37 @@ jobs:
           paths:
             - noncafs
             - cafs
+      - store_test_results:
+          path: /tmp/test-results
+
+  go_test_metrics:
+    executor: metrics_tester
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /home/circleci/extra/appcredentials.json
+      GO111MODULE: 'on'
+    steps:
+      - install_base
+      - checkout
+      - get_cache
+      - install_test_tools
+      - login_to_google
+      - prepare_tests
+      - run:
+         name: Create influxdb test db
+         command: |
+           curl --get http://localhost:8086/query --data-urlencode "q=CREATE DATABASE test"
+      - run:
+          name: Run golang tests with metrics (1)
+          command: |
+            gotestsum --junitfile /tmp/test-results/metrics/go-test-report-metrics.xml --format short-with-failures -- \
+              -tags influxdbintegration \
+              -race -cover -covermode atomic -coverprofile /tmp/test-coverage/metrics/c_metrics.out \
+              ./cmd/datamon/cmd ./pkg/metrics
+      - put_cache
+      - persist_to_workspace:
+          root: /tmp/test-coverage
+          paths:
+            - metrics
       - store_test_results:
           path: /tmp/test-results
 
@@ -444,12 +498,21 @@ workflows:
             branches:
               only: /.*/
 
+      - go_test_metrics:
+          context: "OC Common"
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+
       - test_coverage:
           context: "OC Common"
           requires:
             - go_lint
             - go_test
             - go_test_fuse
+            - go_test_metrics
           filters:
             tags:
               only: /.*/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
   build-tags:
     - fuse_cli
     - fsintegration
+    - influxdbintegration
   disable:
     - maligned
     - lll

--- a/cmd/datamon/cmd/bundle.go
+++ b/cmd/datamon/cmd/bundle.go
@@ -74,6 +74,7 @@ func setLatestOrLabelledBundle(ctx context.Context, remote context2.Stores) erro
 		datamonFlags.bundle.ID = key
 	case datamonFlags.bundle.ID == "" && datamonFlags.label.Name != "":
 		label := core.NewLabel(
+			core.LabelWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 			core.LabelDescriptor(
 				model.NewLabelDescriptor(
 					model.LabelName(datamonFlags.label.Name),
@@ -82,6 +83,7 @@ func setLatestOrLabelledBundle(ctx context.Context, remote context2.Stores) erro
 		bundle := core.NewBundle(
 			core.Repo(datamonFlags.repo.RepoName),
 			core.ContextStores(remote),
+			core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
 		if err := label.DownloadDescriptor(ctx, bundle, true); err != nil {
 			return err

--- a/cmd/datamon/cmd/bundle_diff.go
+++ b/cmd/datamon/cmd/bundle_diff.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"text/template"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/storage/localfs"
@@ -36,6 +37,11 @@ var bundleDiffCmd = &cobra.Command{
 	Long: "Diff a downloaded bundle with a remote bundle.  " +
 		"--destination is a location previously passed to the `bundle download` command.",
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "bundle diff", err)
+		}(time.Now())
 
 		ctx := context.Background()
 
@@ -61,6 +67,7 @@ var bundleDiffCmd = &cobra.Command{
 
 		localBundle := core.NewBundle(
 			core.ConsumableStore(destinationStore),
+			core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
 
 		bundleOpts, err := optionInputs.bundleOpts(ctx)
@@ -69,6 +76,7 @@ var bundleDiffCmd = &cobra.Command{
 		}
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
+		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 		bundleOpts = append(bundleOpts,
 			core.ConcurrentFilelistDownloads(datamonFlags.bundle.ConcurrencyFactor/filelistDownloadsByConcurrencyFactor))
 

--- a/cmd/datamon/cmd/bundle_download.go
+++ b/cmd/datamon/cmd/bundle_download.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/spf13/cobra"
@@ -35,8 +36,13 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 ...
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx := context.Background()
+		var err error
 
+		defer func(t0 time.Time) {
+			cliUsage(t0, "bundle download", err)
+		}(time.Now())
+
+		ctx := context.Background()
 		optionInputs := newCliOptionInputs(config, &datamonFlags)
 		remoteStores, err := optionInputs.datamonContext(ctx)
 		if err != nil {
@@ -71,6 +77,7 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 			return
 		}
 		bundleOpts = append(bundleOpts, core.Logger(logger))
+		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 
 		bundle := core.NewBundle(
 			bundleOpts...,

--- a/cmd/datamon/cmd/bundle_download_file.go
+++ b/cmd/datamon/cmd/bundle_download_file.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/spf13/cobra"
@@ -17,6 +18,11 @@ You may use the "--label" flag as an alternate way to specify a particular bundl
 `,
 	Example: `% datamon bundle download file --file datamon/cmd/repo_list.go --repo ritesh-test-repo --bundle 1ISwIzeAR6m3aOVltAsj1kfQaml --destination /tmp`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "bundle download file", err)
+		}(time.Now())
 
 		ctx := context.Background()
 
@@ -46,6 +52,7 @@ You may use the "--label" flag as an alternate way to specify a particular bundl
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.ConsumableStore(destinationStore))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
+		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 
 		bundle := core.NewBundle(
 			bundleOpts...,

--- a/cmd/datamon/cmd/bundle_get.go
+++ b/cmd/datamon/cmd/bundle_get.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	status "github.com/oneconcern/datamon/pkg/core/status"
@@ -21,6 +22,12 @@ var GetBundleCommand = &cobra.Command{
 Prints corresponding bundle metadata if the bundle exists,
 exits with ENOENT status otherwise.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "bundle get", err)
+		}(time.Now())
+
 		ctx := context.Background()
 		datamonFlagsPtr := &datamonFlags
 		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
@@ -46,6 +53,7 @@ exits with ENOENT status otherwise.`,
 		}
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
+		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 
 		bundle := core.NewBundle(
 			bundleOpts...,

--- a/cmd/datamon/cmd/bundle_list.go
+++ b/cmd/datamon/cmd/bundle_list.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/model"
@@ -32,6 +33,12 @@ This is analogous to the "git log" command. The bundle ID works like a git commi
 	Example: `% datamon bundle list --repo ritesh-test-repo
 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT , Updating test bundle`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "bundle list", err)
+		}(time.Now())
+
 		ctx := context.Background()
 		datamonFlagsPtr := &datamonFlags
 		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
@@ -42,7 +49,9 @@ This is analogous to the "git log" command. The bundle ID works like a git commi
 		}
 		err = core.ListBundlesApply(datamonFlags.repo.RepoName, remoteStores, applyBundleTemplate,
 			core.ConcurrentList(datamonFlags.core.ConcurrencyFactor),
-			core.BatchSize(datamonFlags.core.BatchSize))
+			core.BatchSize(datamonFlags.core.BatchSize),
+			core.WithMetrics(datamonFlags.root.metrics.IsEnabled()),
+		)
 		if err != nil {
 			wrapFatalln("concurrent list bundles", err)
 			return

--- a/cmd/datamon/cmd/bundle_list_file.go
+++ b/cmd/datamon/cmd/bundle_list_file.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"text/template"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 
@@ -26,6 +27,12 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995dbb989e6091328e6be3d9e3161ad22d9ad0fbfb71410f9e4730f6ac4482cc592c0bc6011585bd9b0f00b11463
 ...`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "bundle list files", err)
+		}(time.Now())
+
 		ctx := context.Background()
 		datamonFlagsPtr := &datamonFlags
 		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
@@ -45,6 +52,7 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 		}
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
+		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 		bundle := core.NewBundle(
 			bundleOpts...,
 		)

--- a/cmd/datamon/cmd/bundle_update.go
+++ b/cmd/datamon/cmd/bundle_update.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"context"
 	"path/filepath"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 
@@ -18,6 +19,12 @@ var bundleUpdateCmd = &cobra.Command{
 	Long: "Update a downloaded bundle with a remote bundle.  " +
 		"--destination is a location previously passed to the `bundle download` command.",
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "bundle update", err)
+		}(time.Now())
+
 		ctx := context.Background()
 		optionInputs := newCliOptionInputs(config, &datamonFlags)
 		remoteStores, err := optionInputs.datamonContext(ctx)
@@ -71,14 +78,15 @@ var bundleUpdateCmd = &cobra.Command{
 		}
 		localBundle := core.NewBundle(
 			core.ConsumableStore(destinationStore),
+			core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
-
 		bundleOpts, err := optionInputs.bundleOpts(ctx)
 		if err != nil {
 			wrapFatalln("failed to initialize bundle options", err)
 		}
 		bundleOpts = append(bundleOpts, core.Repo(datamonFlags.repo.RepoName))
 		bundleOpts = append(bundleOpts, core.BundleID(datamonFlags.bundle.ID))
+		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 		remoteBundle := core.NewBundle(
 			bundleOpts...,
 		)

--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"text/template"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/model"
@@ -36,6 +37,12 @@ Uploaded bundle id:1INzQ5TV4vAAfU2PbRFgPfnzEwR
 set label 'init'
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "bundle upload", err)
+		}(time.Now())
+
 		ctx := context.Background()
 
 		optionInputs := newCliOptionInputs(config, &datamonFlags)
@@ -71,6 +78,7 @@ set label 'init'
 			return
 		}
 		bundleOpts = append(bundleOpts, core.Logger(logger))
+		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 
 		// feature guard
 		if enableBundlePreserve {
@@ -121,6 +129,7 @@ set label 'init'
 
 		if datamonFlags.label.Name != "" {
 			label := core.NewLabel(
+				core.LabelWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 				core.LabelDescriptor(
 					model.NewLabelDescriptor(
 						model.LabelContributor(contributor),

--- a/cmd/datamon/cmd/config.go
+++ b/cmd/datamon/cmd/config.go
@@ -55,6 +55,7 @@ type CLIConfig struct {
 	Context    string `json:"context" yaml:"context"`       // Current context for datamon
 	logger     *zap.Logger
 	onceLogger sync.Once
+	Metrics    metricsFlags `json:"metrics,omitempty" yaml:"metrics,omitempty"`
 }
 
 // MarshalConfig produces a CLI config as a YAML document

--- a/cmd/datamon/cmd/config_set.go
+++ b/cmd/datamon/cmd/config_set.go
@@ -50,6 +50,7 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 			Config:     datamonFlags.core.Config,
 			Context:    datamonFlags.context.Descriptor.Name,
 			Credential: datamonFlags.root.credFile,
+			Metrics:    datamonFlags.root.metrics,
 		}
 
 		file := configFileLocation(true)

--- a/cmd/datamon/cmd/context_create.go
+++ b/cmd/datamon/cmd/context_create.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	context2 "context"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/context"
 	"github.com/oneconcern/datamon/pkg/storage/gcs"
@@ -19,6 +20,12 @@ var ContextCreateCommand = &cobra.Command{
 	Short: "Create a context",
 	Long:  "Create a context for Datamon",
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "context create", err)
+		}(time.Now())
+
 		createContext()
 	},
 }

--- a/cmd/datamon/cmd/context_get.go
+++ b/cmd/datamon/cmd/context_get.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"time"
 
 	context2 "github.com/oneconcern/datamon/pkg/context"
 	status "github.com/oneconcern/datamon/pkg/core/status"
@@ -24,6 +25,12 @@ var ContextGetCommand = &cobra.Command{
 	Short: "Get a context info",
 	Long:  "Get a Datamon context's info",
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "context get", err)
+		}(time.Now())
+
 		getContext()
 	},
 }

--- a/cmd/datamon/cmd/context_list.go
+++ b/cmd/datamon/cmd/context_list.go
@@ -6,6 +6,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +18,12 @@ var ContextListCommand = &cobra.Command{
 	Short: "List available contexts",
 	Long:  "List all available contexts in a remote configuration",
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "context list", err)
+		}(time.Now())
+
 		listContexts()
 	},
 }

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -65,6 +65,7 @@ type flagsT struct {
 		logLevel string
 		cpuProf  bool
 		upgrade  bool
+		metrics  metricsFlags
 	}
 	doc struct {
 		docTarget string
@@ -325,6 +326,20 @@ func addVerifyHashFlag(cmd *cobra.Command) string {
 func addTemplateFlag(cmd *cobra.Command) string {
 	c := "format"
 	cmd.PersistentFlags().StringVar(&datamonFlags.core.Template, c, "", `Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields`)
+	return c
+}
+
+func addMetricsFlag(cmd *cobra.Command) string {
+	c := "metrics"
+	defaultMetrics := false // TODO(fred): once our concern about metrics backend security is addressed, move back the default to true
+	datamonFlags.root.metrics.Enabled = &defaultMetrics
+	cmd.PersistentFlags().BoolVar(datamonFlags.root.metrics.Enabled, c, defaultMetrics, `Toggle telemetry and metrics collection`)
+	return c
+}
+
+func addMetricsURLFlag(cmd *cobra.Command) string {
+	c := "metrics-url"
+	cmd.PersistentFlags().StringVar(&datamonFlags.root.metrics.URL, c, "", `Fully qualified URL to an influxdb metrics collector, with user and password`)
 	return c
 }
 

--- a/cmd/datamon/cmd/influxdb_test.go
+++ b/cmd/datamon/cmd/influxdb_test.go
@@ -1,0 +1,8 @@
+// +build influxdbintegration
+
+package cmd
+
+func testMetricsEnabled() *bool {
+	b := true
+	return &b
+}

--- a/cmd/datamon/cmd/label_get.go
+++ b/cmd/datamon/cmd/label_get.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	status "github.com/oneconcern/datamon/pkg/core/status"
@@ -21,6 +22,12 @@ var GetLabelCommand = &cobra.Command{
 Prints corresponding bundle information if the label exists,
 exits with ENOENT status otherwise.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "label get", err)
+		}(time.Now())
+
 		ctx := context.Background()
 		datamonFlagsPtr := &datamonFlags
 		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
@@ -32,9 +39,11 @@ exits with ENOENT status otherwise.`,
 		bundle := core.NewBundle(
 			core.Repo(datamonFlags.repo.RepoName),
 			core.ContextStores(remoteStores),
+			core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
 
 		label := core.NewLabel(
+			core.LabelWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 			core.LabelDescriptor(
 				model.NewLabelDescriptor(
 					model.LabelName(datamonFlags.label.Name),

--- a/cmd/datamon/cmd/label_list.go
+++ b/cmd/datamon/cmd/label_list.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/model"
@@ -30,6 +31,12 @@ This is analogous to the "git tag --list" command.`,
 	Example: `% datamon label list --repo ritesh-test-repo
 init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "label list", err)
+		}(time.Now())
+
 		ctx := context.Background()
 
 		datamonFlagsPtr := &datamonFlags
@@ -41,7 +48,9 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT`,
 		}
 		err = core.ListLabelsApply(datamonFlags.repo.RepoName, remoteStores, datamonFlags.label.Prefix, applyLabelTemplate,
 			core.ConcurrentList(datamonFlags.core.ConcurrencyFactor),
-			core.BatchSize(datamonFlags.core.BatchSize))
+			core.BatchSize(datamonFlags.core.BatchSize),
+			core.WithMetrics(datamonFlags.root.metrics.IsEnabled()),
+		)
 
 		if err != nil {
 			wrapFatalln("download label list", err)

--- a/cmd/datamon/cmd/label_set.go
+++ b/cmd/datamon/cmd/label_set.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/model"
@@ -19,6 +20,12 @@ Setting a label is analogous to the git command "git tag {label}".`,
 	Example: `% datamon label set --repo ritesh-test-repo --label anotherlabel --bundle 1ISwIzeAR6m3aOVltAsj1kfQaml
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "label set", err)
+		}(time.Now())
+
 		ctx := context.Background()
 
 		optionInputs := newCliOptionInputs(config, &datamonFlags)
@@ -37,6 +44,7 @@ Setting a label is analogous to the git command "git tag {label}".`,
 			core.Repo(datamonFlags.repo.RepoName),
 			core.ContextStores(remoteStores),
 			core.BundleID(datamonFlags.bundle.ID),
+			core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
 
 		bundleExists, err := bundle.Exists(ctx)
@@ -50,6 +58,7 @@ Setting a label is analogous to the git command "git tag {label}".`,
 		}
 
 		label := core.NewLabel(
+			core.LabelWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 			core.LabelDescriptor(
 				model.NewLabelDescriptor(
 					model.LabelContributor(contributor),

--- a/cmd/datamon/cmd/metrics.go
+++ b/cmd/datamon/cmd/metrics.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/oneconcern/datamon/pkg/metrics"
+)
+
+type metricsFlags struct {
+	Enabled *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"` // pointer because we want to distinguish unset from false
+	URL     string `json:"url,omitempty" yaml:"url,omitempty"`
+	m       *M
+}
+
+func (m metricsFlags) IsEnabled() bool {
+	return m.Enabled != nil && *m.Enabled
+}
+
+// M describes metrics for the cmd package
+type M struct {
+	Usage metrics.UsageMetrics `group:"telemetry" description:"usage stats for datamon CLI"`
+
+	// more metrics here
+}
+
+// cliUsage records a usage metric in the CLI context in a single go.
+// This is intended to be used in some defer statement.
+//
+// Metrics are flushed as soon as the command is done.
+func cliUsage(t0 time.Time, command string, err error) {
+	if datamonFlags.root.metrics.IsEnabled() {
+		datamonFlags.root.metrics.m.Usage.UsedAll(t0, command)(err)
+		metrics.Flush()
+	}
+}

--- a/cmd/datamon/cmd/mocks_test.go
+++ b/cmd/datamon/cmd/mocks_test.go
@@ -181,6 +181,9 @@ func runCmd(t *testing.T, cmd []string, intentMsg string, expectError bool, as .
 	datamonFlags.context.Descriptor.VMetadata = bucketVMeta
 	datamonFlags.core.Config = config
 
+	// test with metrics, depending on build flag
+	datamonFlags.root.metrics.Enabled = testMetricsEnabled()
+
 	if len(as) == 0 {
 		authorizer = AuthMock{name: "tests", email: "datamon@oneconcern.com"}
 	} else {

--- a/cmd/datamon/cmd/noinfluxdb_test.go
+++ b/cmd/datamon/cmd/noinfluxdb_test.go
@@ -1,0 +1,8 @@
+// +build !influxdbintegration
+
+package cmd
+
+func testMetricsEnabled() *bool {
+	b := false
+	return &b
+}

--- a/cmd/datamon/cmd/repo_create.go
+++ b/cmd/datamon/cmd/repo_create.go
@@ -22,6 +22,12 @@ Allowed characters Unicode characters, digits and hyphen.
 This is analogous to the "git init ..." command.`,
 	Example: `% datamon repo create  --description "Ritesh's repo for testing" --repo ritesh-datamon-test-repo`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "repo create", err)
+		}(time.Now())
+
 		ctx := context.Background()
 		optionInputs := newCliOptionInputs(config, &datamonFlags)
 		contributor, err := optionInputs.contributor()

--- a/cmd/datamon/cmd/repo_get.go
+++ b/cmd/datamon/cmd/repo_get.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	status "github.com/oneconcern/datamon/pkg/core/status"
@@ -20,6 +21,12 @@ var GetRepoCommand = &cobra.Command{
 Prints corresponding repo information if the name exists,
 exits with ENOENT status otherwise.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "repo get", err)
+		}(time.Now())
+
 		ctx := context.Background()
 		datamonFlagsPtr := &datamonFlags
 		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)

--- a/cmd/datamon/cmd/repo_list.go
+++ b/cmd/datamon/cmd/repo_list.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/oneconcern/datamon/pkg/core"
 	"github.com/oneconcern/datamon/pkg/model"
@@ -26,6 +27,12 @@ var repoList = &cobra.Command{
 	Example: `% datamon repo list --context ctx2
 fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01:18.181535 +0100 CET`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "repo list", err)
+		}(time.Now())
+
 		ctx := context.Background()
 		datamonFlagsPtr := &datamonFlags
 		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)
@@ -36,7 +43,9 @@ fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01
 		}
 		err = core.ListReposApply(remoteStores, applyRepoTemplate,
 			core.ConcurrentList(datamonFlags.core.ConcurrencyFactor),
-			core.BatchSize(datamonFlags.core.BatchSize))
+			core.BatchSize(datamonFlags.core.BatchSize),
+			core.WithMetrics(datamonFlags.root.metrics.IsEnabled()),
+		)
 		if err != nil {
 			wrapFatalln("download repo list", err)
 			return

--- a/cmd/datamon/cmd/self_upgrade.go
+++ b/cmd/datamon/cmd/self_upgrade.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"text/template"
+	"time"
 
 	"syscall"
 
@@ -146,6 +147,12 @@ var selfUpgradeCmd = &cobra.Command{
 	Short: "Upgrades datamon to the latest release",
 	Long:  `Checks for the latest release on github repo then upgrades. By default upgrade is skipped if the current datamon is not a released version`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+
+		defer func(t0 time.Time) {
+			cliUsage(t0, "upgrade", err)
+		}(time.Now())
+
 		datamonFlags.upgrade.verbose = datamonFlags.root.logLevel == "debug"
 		if datamonFlags.upgrade.checkOnly {
 			if err := doCheckVersion(); err != nil {

--- a/cmd/datamon/cmd/web.go
+++ b/cmd/datamon/cmd/web.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/oneconcern/datamon/pkg/metrics"
 	"github.com/oneconcern/datamon/pkg/web"
 
 	"github.com/pkg/browser"
@@ -17,6 +18,12 @@ var webSrv = &cobra.Command{
 	Short: "Webserver",
 	Long:  "A webserver process to browse datamon data",
 	Run: func(cmd *cobra.Command, args []string) {
+		if datamonFlags.root.metrics.IsEnabled() {
+			// do not record timings or failures for long running or daemonized commands, do not wait for completion to report
+			datamonFlags.root.metrics.m.Usage.Inc("web")
+			metrics.Flush()
+		}
+
 		infoLogger.Println("begin webserver")
 		datamonFlagsPtr := &datamonFlags
 		optionInputs := newCliOptionInputs(config, datamonFlagsPtr)

--- a/docs/usage/datamon.md
+++ b/docs/usage/datamon.md
@@ -18,12 +18,14 @@ your data buckets are organized in repositories of versioned and tagged bundles 
 ### Options
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --force             Forces upgrade even if the current version is not a released version
-  -h, --help              help for datamon
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --force                Forces upgrade even if the current version is not a released version
+  -h, --help                 help for datamon
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle.md
+++ b/docs/usage/datamon_bundle.md
@@ -24,10 +24,12 @@ together.
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_diff.md
+++ b/docs/usage/datamon_bundle_diff.md
@@ -26,11 +26,13 @@ datamon bundle diff [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_download.md
+++ b/docs/usage/datamon_bundle_download.md
@@ -45,11 +45,13 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_download_file.md
+++ b/docs/usage/datamon_bundle_download_file.md
@@ -36,11 +36,13 @@ datamon bundle download file [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_get.md
+++ b/docs/usage/datamon_bundle_get.md
@@ -27,11 +27,13 @@ datamon bundle get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_list.md
+++ b/docs/usage/datamon_bundle_list.md
@@ -33,11 +33,13 @@ datamon bundle list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_list_files.md
+++ b/docs/usage/datamon_bundle_list_files.md
@@ -38,11 +38,13 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_mount.md
+++ b/docs/usage/datamon_bundle_mount.md
@@ -33,11 +33,13 @@ datamon bundle mount [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_mount_new.md
+++ b/docs/usage/datamon_bundle_mount_new.md
@@ -28,11 +28,13 @@ datamon bundle mount new [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_update.md
+++ b/docs/usage/datamon_bundle_update.md
@@ -26,11 +26,13 @@ datamon bundle update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_upload.md
+++ b/docs/usage/datamon_bundle_upload.md
@@ -42,11 +42,13 @@ set label 'init'
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_config.md
+++ b/docs/usage/datamon_config.md
@@ -23,10 +23,12 @@ You may force a specific local config file using the $DATAMON_CONFIG environment
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_config_set.md
+++ b/docs/usage/datamon_config_set.md
@@ -52,10 +52,12 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context.md
+++ b/docs/usage/datamon_context.md
@@ -18,10 +18,12 @@ Commands to manage contexts. A context is an instance of Datamon with set of rep
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_create.md
+++ b/docs/usage/datamon_context_create.md
@@ -26,11 +26,13 @@ datamon context create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_get.md
+++ b/docs/usage/datamon_context_get.md
@@ -21,11 +21,13 @@ datamon context get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_list.md
+++ b/docs/usage/datamon_context_list.md
@@ -21,11 +21,13 @@ datamon context list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label.md
+++ b/docs/usage/datamon_label.md
@@ -34,10 +34,12 @@ production
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label_get.md
+++ b/docs/usage/datamon_label_get.md
@@ -25,11 +25,13 @@ datamon label get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label_list.md
+++ b/docs/usage/datamon_label_list.md
@@ -34,11 +34,13 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label_set.md
+++ b/docs/usage/datamon_label_set.md
@@ -33,11 +33,13 @@ datamon label set [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo.md
+++ b/docs/usage/datamon_repo.md
@@ -24,10 +24,12 @@ They are versioned and managed via bundles.
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo_create.md
+++ b/docs/usage/datamon_repo_create.md
@@ -34,11 +34,13 @@ datamon repo create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo_get.md
+++ b/docs/usage/datamon_repo_get.md
@@ -24,11 +24,13 @@ datamon repo get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo_list.md
+++ b/docs/usage/datamon_repo_list.md
@@ -30,11 +30,13 @@ fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --format string     Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_upgrade.md
+++ b/docs/usage/datamon_upgrade.md
@@ -24,10 +24,12 @@ datamon upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_usage.md
+++ b/docs/usage/datamon_usage.md
@@ -22,10 +22,12 @@ datamon usage [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_version.md
+++ b/docs/usage/datamon_version.md
@@ -27,10 +27,12 @@ datamon version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_web.md
+++ b/docs/usage/datamon_web.md
@@ -23,10 +23,12 @@ datamon web [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string     Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string    Set the context for datamon (default "dev")
-      --loglevel string   The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --upgrade           Upgrades the current version then carries on with the specified command
+      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string       Set the context for datamon (default "dev")
+      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics              Toggle telemetry and metrics collection
+      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
+      --upgrade              Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-immutable-radix v1.0.0
 	github.com/hashicorp/golang-lru v0.5.3
+	github.com/influxdata/influxdb v1.7.9
 	github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f
 	github.com/jacobsa/fuse v0.0.0-20200128091008-ae5da07e4c80
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
@@ -38,6 +39,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.5.0
 	github.com/stretchr/testify v1.4.0
+	go.opencensus.io v0.22.2
 	go.uber.org/goleak v0.10.1-0.20191111212139-7380c5a9fa84
 	go.uber.org/zap v1.13.0
 	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
+github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -190,6 +192,8 @@ github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7V
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/influxdb v1.7.9 h1:uSeBTNO4rBkbp1Be5FKRsAmglM9nlx25TzVQRQt1An4=
+github.com/influxdata/influxdb v1.7.9/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f h1:X+tnaqoCcBgAwSTJtoYW6p0qKiuPyMfofEHEFUf2kdU=
 github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
 github.com/jacobsa/fuse v0.0.0-20200128091008-ae5da07e4c80 h1:K9lTj2neg5ay8TiLL9TU3VZi9+9if/EzYRO02lrYNAQ=
@@ -344,6 +348,8 @@ go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.opencensus.io v0.22.2 h1:75k/FF0Q2YM8QYo07VPddOLBslDt1MZOdEslOHvmzAs=
+go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=

--- a/pkg/cafs/cafs_options.go
+++ b/pkg/cafs/cafs_options.go
@@ -107,3 +107,10 @@ func KeysCacheSize(keys int) Option {
 		}
 	}
 }
+
+// WithMetrics enables metrics collection on this cafs
+func WithMetrics(enabled bool) Option {
+	return func(w *defaultFs) {
+		w.EnableMetrics(enabled)
+	}
+}

--- a/pkg/cafs/metrics.go
+++ b/pkg/cafs/metrics.go
@@ -1,0 +1,85 @@
+package cafs
+
+import (
+	"strconv"
+
+	"github.com/oneconcern/datamon/pkg/metrics"
+	"go.opencensus.io/stats"
+)
+
+// M describes metrics for the cafs package
+type M struct {
+	Volume struct {
+		Blobs cafsMetrics       `group:"blobs" description:"metrics about cafs chunks (blobs)"`
+		IO    metrics.IOMetrics `group:"io" description:"metrics about cafs IO operations"`
+		Cache cacheUsage        `group:"cache" description:"metrics about cafs ReadAt cache (fuse mount)"`
+	} `group:"volumetry" description:""`
+	Usage metrics.UsageMetrics `group:"telemetry" description:"usage stats for the cafs package"`
+
+	// more metrics here
+}
+
+type cafsMetrics struct {
+	BlobsCount     *stats.Int64Measure `metric:"blobs" extraviews:"sum" tags:"kind,operation" description:"number of cafs chunks (blobs), including duplicates"`
+	DuplicateCount *stats.Int64Measure `metric:"duplicateBlobs" extraviews:"sum" tags:"kind,operation" description:"number of deduplicated cafs chunks (blobs)"`
+	RootsCount     *stats.Int64Measure `metric:"roots" extraviews:"sum" tags:"kind,operation" description:"number of root keys"`
+	BlobSize       *stats.Int64Measure `metric:"blobsSize" unit:"sumbytes" tags:"kind,operation" description:"cumulated size of cafs chunks (blobs)"`
+}
+
+func (*cafsMetrics) tags(operation string) map[string]string {
+	return map[string]string{"kind": "io", "operation": operation}
+}
+
+func (m *cafsMetrics) IncBlob(operation string) {
+	metrics.Inc(m.BlobsCount, m.tags(operation))
+}
+
+func (m *cafsMetrics) IncDuplicate(operation string) {
+	metrics.Inc(m.DuplicateCount, m.tags(operation))
+}
+
+func (m *cafsMetrics) Size(size int64, operation string) {
+	metrics.Int64(m.BlobSize, size, m.tags(operation))
+}
+
+func (m *cafsMetrics) IntRoot(keys int, operation string) {
+	metrics.Int64(m.RootsCount, int64(keys), m.tags(operation))
+}
+
+type cacheUsage struct {
+	CacheBuffers     *stats.Int64Measure `metric:"buffers" description:"cache size in buffers the size of a leaf" tags:"leafsize"`
+	FreeListHWM      *stats.Int64Measure `metric:"freelistHWM" description:"free list highwater mark" tags:"leafsize"`
+	AllocatedBuffers *stats.Int64Measure `metric:"allocated" description:"number of allocated buffers" tags:"leafsize"`
+	FreeBuffers      *stats.Int64Measure `metric:"free" description:"number of free buffers" tags:"leafsize"`
+	TotalRequested   *stats.Int64Measure `metric:"totalRequested" unit:"bytes" description:"size of the I/O request" tags:"leafsize,operation"`
+	TotalRead        *stats.Int64Measure `metric:"totalRead" unit:"bytes" description:"size of the I/O response" tags:"leafsize,operation"`
+	RequestedLeaves  *stats.Int64Measure `metric:"leavesRequested" description:"number of leaves requested to complete the operation" tags:"leafsize,operation"`
+	FetchedLeaves    *stats.Int64Measure `metric:"leavesFetched" description:"number of leaves actually fetched to complete the operation" tags:"leafsize,operation"`
+	WastedLeaves     *stats.Int64Measure `metric:"leavesWasted" description:"number of leaves fetched and wasted because of fast cache recycling" tags:"leafsize,operation"`
+	CacheHits        *stats.Int64Measure `metric:"cacheHits" tags:"leafsize,operation"`
+	CacheMisses      *stats.Int64Measure `metric:"cacheMisses" tags:"leafsize,operation"`
+}
+
+func (u *cacheUsage) tags(leafsize uint32, operation string) map[string]string {
+	if operation == "" {
+		return map[string]string{"leafsize": strconv.FormatUint(uint64(leafsize), 10)}
+	}
+	return map[string]string{"leafsize": strconv.FormatUint(uint64(leafsize), 10), "operation": operation}
+}
+
+func (u *cacheUsage) Sizing(buffers, freelistHWM int, leafsize uint32) {
+	tags := u.tags(leafsize, "")
+	metrics.Int64(u.CacheBuffers, int64(buffers), tags)
+	metrics.Int64(u.FreeListHWM, int64(freelistHWM), tags)
+}
+
+func (u *cacheUsage) Capture(bytesToRead, readBytes int, requested, fetched, wasted, cacheHits, cacheMisses uint64, leafsize uint32, operation string) {
+	tags := u.tags(leafsize, operation)
+	metrics.Int64(u.TotalRequested, int64(bytesToRead), tags)
+	metrics.Int64(u.TotalRead, int64(readBytes), tags)
+	metrics.Int64(u.RequestedLeaves, int64(readBytes), tags)
+	metrics.Int64(u.FetchedLeaves, int64(fetched), tags)
+	metrics.Int64(u.WastedLeaves, int64(wasted), tags)
+	metrics.Int64(u.CacheHits, int64(cacheHits), tags)
+	metrics.Int64(u.CacheMisses, int64(cacheMisses), tags)
+}

--- a/pkg/cafs/reader_options.go
+++ b/pkg/cafs/reader_options.go
@@ -98,3 +98,12 @@ func ReaderPather(fn func(Key) string) ReaderOption {
 		}
 	}
 }
+
+// ReaderWithMetrics enables metrics collection on this reader
+func ReaderWithMetrics(enabled bool) ReaderOption {
+	return func(reader *chunkReader) {
+		if enabled {
+			reader.EnableMetrics(enabled)
+		}
+	}
+}

--- a/pkg/cafs/writer_options.go
+++ b/pkg/cafs/writer_options.go
@@ -39,3 +39,12 @@ func WriterPather(fn func(Key) string) WriterOption {
 		}
 	}
 }
+
+// WriterWithMetrics enables metrics collection on this writer
+func WriterWithMetrics(enabled bool) WriterOption {
+	return func(writer *fsWriter) {
+		if enabled {
+			writer.EnableMetrics(enabled)
+		}
+	}
+}

--- a/pkg/core/bundle_list_test.go
+++ b/pkg/core/bundle_list_test.go
@@ -257,7 +257,9 @@ func mockedContextStores(scenario string) context2.Stores {
 
 func testListBundles(t *testing.T, concurrency int, i int) {
 	initBatchKeysFixture.Do(buildKeysBatchFixture(t))
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t,
+		// opencensus stats collection goroutine
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 
 	for _, toPin := range bundleTestCases() {
 		testcase := toPin

--- a/pkg/core/bundle_options.go
+++ b/pkg/core/bundle_options.go
@@ -81,3 +81,10 @@ func ConcurrentFilelistDownloads(concurrentFilelistDownloads int) BundleOption {
 		b.concurrentFilelistDownloads = concurrentFilelistDownloads
 	}
 }
+
+// BundleWithMetrics toggles metrics on a core Bundle object
+func BundleWithMetrics(enabled bool) BundleOption {
+	return func(b *Bundle) {
+		b.EnableMetrics(enabled)
+	}
+}

--- a/pkg/core/bundle_unpack.go
+++ b/pkg/core/bundle_unpack.go
@@ -323,6 +323,10 @@ func downloadBundleEntrySyncMaybeOverwrite(ctx context.Context, bundleEntry mode
 	overwrite bool) error {
 	bundle.l.Info("starting bundle entry download",
 		zap.String("name", bundleEntry.NameWithPath))
+
+	if bundle.MetricsEnabled() {
+		bundle.m.Volume.Bundles.Inc("download")
+	}
 	key, err := cafs.KeyFromString(bundleEntry.Hash)
 	if err != nil {
 		return err
@@ -524,6 +528,7 @@ func unpackDataFiles(ctx context.Context, bundle *Bundle,
 		cafs.ReaderConcurrentChunkWrites(bundle.concurrentFileDownloads/fileDownloadsPerConcurrentChunks),
 		cafs.VerifyHash(true),
 		cafs.Logger(bundle.l),
+		cafs.WithMetrics(bundle.MetricsEnabled()),
 	)
 	if err != nil {
 		return err
@@ -567,6 +572,7 @@ func unpackDataFiles(ctx context.Context, bundle *Bundle,
 			ContextStores(bundle.contextStores),
 			ConsumableStore(bundleDest.ConsumableStore),
 			BundleID(bundle.BundleID),
+			BundleWithMetrics(bundle.MetricsEnabled()),
 		)
 		err = PublishMetadata(ctx, publishMetadataBundle)
 		if err != nil {
@@ -584,6 +590,7 @@ func unpackDataFile(ctx context.Context, bundle *Bundle, file string) error {
 		cafs.Backend(bundle.BlobStore()),
 		cafs.Logger(bundle.l),
 		cafs.ReaderConcurrentChunkWrites(bundle.concurrentFileDownloads/fileDownloadsPerConcurrentChunks),
+		cafs.WithMetrics(bundle.MetricsEnabled()),
 	)
 	if err != nil {
 		return err

--- a/pkg/core/label_list_test.go
+++ b/pkg/core/label_list_test.go
@@ -104,7 +104,9 @@ func mockedLabelContextStores(scenario string) context2.Stores {
 
 func testListLabels(t *testing.T, concurrency int, i int) {
 	initLabelBatchFixture.Do(buildLabelBatchFixture(t))
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t,
+		// opencensus stats collection goroutine
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 	for _, toPin := range labelTestCases() {
 		testcase := toPin
 

--- a/pkg/core/label_options.go
+++ b/pkg/core/label_options.go
@@ -13,3 +13,10 @@ func LabelDescriptor(r *model.LabelDescriptor) LabelOption {
 		}
 	}
 }
+
+// LabelWithMetrics toggles metrics for this label
+func LabelWithMetrics(enabled bool) LabelOption {
+	return func(l *Label) {
+		l.EnableMetrics(enabled)
+	}
+}

--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -1,0 +1,15 @@
+package core
+
+import (
+	"github.com/oneconcern/datamon/pkg/metrics"
+)
+
+// M describes metrics for the core package
+type M struct {
+	Volume struct {
+		Bundles metrics.FilesMetrics `group:"bundles" description:"metrics about datasets (bundles)"`
+	} `group:"volumetry" description:""`
+	Usage metrics.UsageMetrics `group:"telemetry" description:"usage stats for the core package"`
+
+	// more metrics here
+}

--- a/pkg/core/options.go
+++ b/pkg/core/options.go
@@ -1,6 +1,10 @@
 package core
 
-import "runtime"
+import (
+	"runtime"
+
+	"github.com/oneconcern/datamon/pkg/metrics"
+)
 
 // Option sets options for listing core objects
 type Option func(*Settings)
@@ -12,6 +16,9 @@ type Settings struct {
 	doneChannel      chan struct{}
 	profilingEnabled bool
 	memProfDir       string
+
+	metrics.Enable
+	//m *M // TODO(fred): enable metrics for list operations
 }
 
 const (
@@ -59,6 +66,13 @@ func WithMemProf(memProfDir string) Option {
 		if memProfDir != "" {
 			s.memProfDir = memProfDir
 		}
+	}
+}
+
+// WithMetrics toggles metrics for the core package and its dependencies (e.g. cafs)
+func WithMetrics(enabled bool) Option {
+	return func(s *Settings) {
+		s.EnableMetrics(enabled)
 	}
 }
 

--- a/pkg/core/repo_create.go
+++ b/pkg/core/repo_create.go
@@ -15,6 +15,7 @@ import (
 
 // CreateRepo persists a repository with a repo descriptor and some context's stores
 func CreateRepo(repo model.RepoDescriptor, stores context2.Stores) error {
+	// TODO(fred): refact options etc to expose a consistent interface, plus support metrics
 	store := GetRepoStore(stores) // TODO: Integrate with WAL.
 	err := model.ValidateRepo(repo)
 	if err != nil {

--- a/pkg/core/repo_list_test.go
+++ b/pkg/core/repo_list_test.go
@@ -86,7 +86,9 @@ func mockedRepoContextStores(scenario string) context2.Stores {
 
 func testListRepos(t *testing.T, concurrency int, i int) {
 	initRepoBatchFixture.Do(buildRepoBatchFixture(t))
-	defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t,
+		// opencensus stats collection goroutine
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
 	for _, toPin := range repoTestCases() {
 		testcase := toPin
 

--- a/pkg/fuse/fs_options.go
+++ b/pkg/fuse/fs_options.go
@@ -60,6 +60,18 @@ func VerifyHash(enabled bool) Option {
 	}
 }
 
+// WithMetrics toggles metrics on the fuse package
+func WithMetrics(enabled bool) Option {
+	return func(mfs fuseutil.FileSystem) {
+		switch fs := mfs.(type) {
+		case *readOnlyFsInternal:
+			fs.EnableMetrics(enabled)
+		case *fsMutable:
+			fs.EnableMetrics(enabled)
+		}
+	}
+}
+
 // MountOption enables options when mounting the file system
 //
 // TODO plumb additional mount options

--- a/pkg/fuse/fs_rw_ops.go
+++ b/pkg/fuse/fs_rw_ops.go
@@ -135,8 +135,8 @@ func (fs *fsMutable) deleteNSEntry(p fuseops.InodeID, c string) error {
 }
 
 func (fs *fsMutable) LookUpInode(ctx context.Context, op *fuseops.LookUpInodeOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	nodeStore, lookupTree := fs.atomicGetReferences()
 
@@ -163,8 +163,8 @@ func (fs *fsMutable) LookUpInode(ctx context.Context, op *fuseops.LookUpInodeOp)
 }
 
 func (fs *fsMutable) GetInodeAttributes(ctx context.Context, op *fuseops.GetInodeAttributesOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	nodeStore, _ := fs.atomicGetReferences()
 
@@ -185,8 +185,8 @@ func (fs *fsMutable) GetInodeAttributes(ctx context.Context, op *fuseops.GetInod
 }
 
 func (fs *fsMutable) SetInodeAttributes(ctx context.Context, op *fuseops.SetInodeAttributesOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	if op.Mode != nil { // File permissions not supported
 		fs.l.Debug("setting permissions mode is not supported", zap.Uint32("mode", uint32(*op.Mode)))
@@ -245,8 +245,8 @@ func (fs *fsMutable) SetInodeAttributes(ctx context.Context, op *fuseops.SetInod
 func (fs *fsMutable) ForgetInode(
 	ctx context.Context,
 	op *fuseops.ForgetInodeOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	// Check reference count for iNode and remove from iNodeStore
 	// Get the node.
@@ -340,8 +340,8 @@ func (fs *fsMutable) CreateFile(
 // If newpath exists but the operation fails for some reason, rename() guarantees to leave an instance of newpath in place.
 // oldpath can specify a directory.  In this case, newpath must either not exist, or it must specify an empty directory.
 func (fs *fsMutable) Rename(ctx context.Context, op *fuseops.RenameOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	fs.lock.Lock()
 	defer fs.lock.Unlock()
@@ -384,8 +384,8 @@ func (fs *fsMutable) Rename(ctx context.Context, op *fuseops.RenameOp) (err erro
 func (fs *fsMutable) RmDir(
 	ctx context.Context,
 	op *fuseops.RmDirOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	fs.lock.Lock()
 	defer fs.lock.Unlock()
@@ -396,8 +396,8 @@ func (fs *fsMutable) RmDir(
 func (fs *fsMutable) Unlink(
 	ctx context.Context,
 	op *fuseops.UnlinkOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	fs.lock.Lock()
 	defer fs.lock.Unlock()
@@ -409,8 +409,8 @@ func (fs *fsMutable) Unlink(
 func (fs *fsMutable) OpenDir(
 	ctx context.Context,
 	op *fuseops.OpenDirOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	return
 }
@@ -418,8 +418,8 @@ func (fs *fsMutable) OpenDir(
 func (fs *fsMutable) ReadDir(
 	ctx context.Context,
 	op *fuseops.ReadDirOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	offset := int(op.Offset)
 	iNode := op.Inode
@@ -457,24 +457,31 @@ func (fs *fsMutable) ReadDir(
 func (fs *fsMutable) ReleaseDirHandle(
 	ctx context.Context,
 	op *fuseops.ReleaseDirHandleOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 	return
 }
 
 func (fs *fsMutable) OpenFile(
 	ctx context.Context,
 	op *fuseops.OpenFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 	return
 }
 
 func (fs *fsMutable) ReadFile(
 	ctx context.Context,
 	op *fuseops.ReadFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer func() {
+		fs.opEnd(t0, op, err)
+		if fs.MetricsEnabled() {
+			fs.m.Volume.Files.Inc("read")
+			fs.m.Volume.Files.Size(int64(op.BytesRead), "read")
+			fs.m.Volume.IO.IORecord(t0, "read")(int64(op.BytesRead), err)
+		}
+	}()
 
 	file, err := fs.localCache.OpenFile(getPathToBackingFile(op.Inode), os.O_RDONLY|os.O_SYNC, fileDefaultMode)
 	if err != nil {
@@ -494,8 +501,16 @@ func (fs *fsMutable) ReadFile(
 func (fs *fsMutable) WriteFile(
 	ctx context.Context,
 	op *fuseops.WriteFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	var n int
+	t0 := fs.opStart(op)
+	defer func() {
+		fs.opEnd(t0, op, err)
+		if fs.MetricsEnabled() {
+			fs.m.Volume.Files.Inc("write")
+			fs.m.Volume.Files.Size(int64(n), "write")
+			fs.m.Volume.IO.IORecord(t0, "write")(int64(n), err)
+		}
+	}()
 
 	file, err := fs.localCache.OpenFile(getPathToBackingFile(op.Inode), os.O_WRONLY|os.O_SYNC, fileDefaultMode)
 	if err != nil {
@@ -505,10 +520,11 @@ func (fs *fsMutable) WriteFile(
 	defer fs.lockBackingFiles.Unlock()
 
 	fs.backingFiles[op.Inode] = &file
-	_, err = file.WriteAt(op.Data, op.Offset)
+	n, err = file.WriteAt(op.Data, op.Offset)
 	if err != nil {
 		return jfuse.EIO
 	}
+
 	ne, found := fs.iNodeStore.Get(formKey(op.Inode))
 	if !found {
 		panic("Invalid state inode: not found" + fmt.Sprint(uint64(op.Inode)))
@@ -518,14 +534,14 @@ func (fs *fsMutable) WriteFile(
 	s, _ := file.Stat()
 	nodeEntry.attr.Size = uint64(s.Size())
 	nodeEntry.lock.Unlock()
-	return
+	return err
 }
 
 func (fs *fsMutable) SyncFile(
 	ctx context.Context,
 	op *fuseops.SyncFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	fs.lockBackingFiles.RLock()
 	defer fs.lockBackingFiles.RUnlock()
@@ -543,8 +559,8 @@ func (fs *fsMutable) SyncFile(
 func (fs *fsMutable) FlushFile(
 	ctx context.Context,
 	op *fuseops.FlushFileOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	fs.lockBackingFiles.RLock()
 	defer fs.lockBackingFiles.RUnlock()
@@ -563,8 +579,8 @@ func (fs *fsMutable) FlushFile(
 func (fs *fsMutable) ReleaseFileHandle(
 	ctx context.Context,
 	op *fuseops.ReleaseFileHandleOp) (err error) {
-	fs.opStart(op)
-	defer fs.opEnd(op, err)
+	t0 := fs.opStart(op)
+	defer fs.opEnd(t0, op, err)
 
 	return
 }
@@ -970,12 +986,19 @@ func (fs *fsMutable) commitImpl(caFs cafs.Fs) error {
 	return nil
 }
 
-func (fs *fsMutable) Commit() error {
+func (fs *fsMutable) Commit() (err error) {
+	defer func(t0 time.Time) {
+		if fs.MetricsEnabled() {
+			fs.m.Usage.UsedAll(t0, "commit")(err)
+		}
+	}(time.Now())
+
 	caFs, err := cafs.New(
 		cafs.LeafSize(fs.bundle.BundleDescriptor.LeafSize),
 		cafs.Backend(fs.bundle.BlobStore()),
 		cafs.LeafTruncation(fs.bundle.BundleDescriptor.Version < 1),
 		cafs.Logger(fs.l),
+		cafs.WithMetrics(fs.MetricsEnabled()),
 	)
 	if err != nil {
 		return err

--- a/pkg/fuse/metrics.go
+++ b/pkg/fuse/metrics.go
@@ -1,0 +1,16 @@
+package fuse
+
+import (
+	"github.com/oneconcern/datamon/pkg/metrics"
+)
+
+// M describes metrics for the fuse package
+type M struct {
+	Volume struct {
+		Files metrics.FilesMetrics `group:"files" description:"metrics about fuse files (mount)"`
+		IO    metrics.IOMetrics    `group:"io" description:"metrics about fuse IO operations"`
+	} `group:"volumetry" description:""`
+	Usage metrics.UsageMetrics `group:"telemetry" description:"usage stats for the fuse package"`
+
+	// more metrics here
+}

--- a/pkg/metrics/agent/doc.go
+++ b/pkg/metrics/agent/doc.go
@@ -1,0 +1,9 @@
+// Package agent provides an in-process opencensus agent
+// to scrape exported metrics and push them to some remote
+// open census collector.
+//
+// The in-process agent is intended for local use of datamon.
+//
+// For kubernetes deployments running datamon, it is best to
+// deploy a standalone opencensus agent container (as sidecar or daemonset).
+package agent

--- a/pkg/metrics/api.go
+++ b/pkg/metrics/api.go
@@ -1,0 +1,139 @@
+package metrics
+
+import (
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+// Init global settings for metrics collection, such as global tags and exporter setup.
+//
+// Init is used by any top-level package (such as CLI driver or SDK), to define global
+// settings such as exporter and global tags.
+//
+// Init may be called multiple times: only the first time matters.
+//
+// Metrics and views may be registered at init time or later on.
+func Init(opts ...Option) {
+	initOnce.Do(func() {
+		mp = newSettings(opts...)
+	})
+}
+
+// Flush all collected metrics to backend
+func Flush() {
+	mp.Flush()
+}
+
+// EnsureMetrics allows for lazy registration of metrics definitions.
+//
+// It may safely be called several times, and only the first registration
+// for a given unique location will be retained.
+//
+// When running several times, it ensures that all subsequent calls on the same location
+// specify the same metrics type, otherwise it panics.
+func EnsureMetrics(location string, m interface{}) interface{} {
+	return mp.EnsureMetrics(location, m)
+}
+
+// Inc increments a counter-like metric
+func Inc(counter *stats.Int64Measure, tags ...map[string]string) {
+	_ = stats.RecordWithTags(mp.contexter(), mergeTags(tags), counter.M(1))
+}
+
+// Int64 sets a value to a measurement
+func Int64(measure *stats.Int64Measure, value int64, tags ...map[string]string) {
+	_ = stats.RecordWithTags(mp.contexter(), mergeTags(tags), measure.M(value))
+}
+
+// Float64 sets a value to a measurement
+func Float64(measure *stats.Float64Measure, value float64, tags ...map[string]string) {
+	_ = stats.RecordWithTags(mp.contexter(), mergeTags(tags), measure.M(value))
+}
+
+// Since feeds a millisecs timing measurement from some start time
+func Since(start time.Time, measure *stats.Float64Measure, tags ...map[string]string) {
+	ms := float64(time.Since(start).Nanoseconds()) / 1e6
+	_ = stats.RecordWithTags(mp.contexter(), mergeTags(tags), measure.M(ms))
+}
+
+// Duration feeds a millisecs timing measurement from some start to end timings
+func Duration(start, end time.Time, measure *stats.Float64Measure, tags ...map[string]string) {
+	ms := float64(end.Sub(start).Nanoseconds()) / 1e6
+	_ = stats.RecordWithTags(mp.contexter(), mergeTags(tags), measure.M(ms))
+}
+
+// mergeTags adds some dynamically defined tags to a single measurement
+func mergeTags(extras []map[string]string) []tag.Mutator {
+	mutators := make([]tag.Mutator, 0, 10)
+	for _, extra := range extras {
+		for k, v := range extra {
+			mutators = append(mutators, tag.Upsert(tag.MustNewKey(k), v))
+		}
+	}
+	return mutators
+}
+
+// Enable equips any type with some capabilities to collect metrics in a very concise way.
+//
+// Sample usage:
+//
+//   type myType struct{
+//     ...
+//     metrics.Enable
+//     m *myMetrics // m points to the globally registered metrics collector
+//   }
+//
+//   ...
+//
+//   // MyTypeUsage describes a tree of metrics to be recorded on myType
+//   type MyTypeUsage struct {
+//     Volumetry struct {
+//       Metadata  FilesMetrics `group:"metadata" description:"some file metrics issued by myType"`
+//       TestCount *stats.Int64Measure   `metric:"testCount" description:"number of tests" extraviews:"sum"`
+//     } `group:"volumetry" description:"volumetry measurements that pertain to myType"`
+//   }
+//
+//   func (u *MyTypeUsage) Reads() {
+//     metrics.Inc(u.Volumetry.Metadata.Read)
+//   }
+//
+//   func (u *MyTypeUsage) Tests(p int) {
+//     metrics.Int64(u.Volumetry.TestCount, intt64(p))
+//   }
+//
+//   ...
+//
+//   func NewMyType() *myType {
+//     ...
+//     t := &MyType{}
+//     t.m := t.EnsureMetrics("MyType", &myMetrics{})
+//     t.EnableMetrics(true)
+//     return t
+//   }
+type Enable struct {
+	metricsEnabled bool
+}
+
+// MetricsEnabled tells whether metrics are enabled or not
+func (e Enable) MetricsEnabled() bool {
+	return e.metricsEnabled
+}
+
+// EnableMetrics toggles metrics collection
+func (e *Enable) EnableMetrics(enabled bool) {
+	e.metricsEnabled = enabled
+}
+
+// EnsureMetrics registers a type describing metrics to the global metrics collection.
+// The name argument constructs a new path in the metrics tree.
+//
+// EnsureMetrics may be called several times, only the first registration will apply.
+//
+// EnsureMetrics may be called lazily: metrics collection will start only after the first registration.
+//
+// NOTE: EnsureMetrics will panic if not called with a pointer to a struct.
+func (e *Enable) EnsureMetrics(name string, m interface{}) interface{} {
+	return EnsureMetrics(name, m)
+}

--- a/pkg/metrics/doc.go
+++ b/pkg/metrics/doc.go
@@ -1,0 +1,3 @@
+// Package metrics provides some instrumentation utilities
+// to equip other datamon packages with telemetry and metrics.
+package metrics

--- a/pkg/metrics/exporters/influxdb/doc.go
+++ b/pkg/metrics/exporters/influxdb/doc.go
@@ -1,0 +1,2 @@
+// Package influxdb exposes an opencensus exporter for influxdb
+package influxdb

--- a/pkg/metrics/exporters/influxdb/exporter.go
+++ b/pkg/metrics/exporters/influxdb/exporter.go
@@ -1,0 +1,138 @@
+package influxdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var _ view.Exporter = &Exporter{}
+
+func defaultExporter() *Exporter {
+	sink, _ := NewStore()
+	return &Exporter{
+		errorHandler: func(_ error) {},
+		store:        sink,
+	}
+}
+
+// NewExporter creates a new Influxdb exporter.
+//
+// Use options to configure:
+//   * an influxdd.Store instance, configured with the desired settings
+//   * an error handler. If set to nil, a no-op handler is set by default
+//   * a map of custom tags for written records (may be nil)
+func NewExporter(opts ...Option) *Exporter {
+	e := defaultExporter()
+	for _, apply := range opts {
+		apply(e)
+	}
+	return e
+}
+
+const (
+	// tags to represent opencensus information as influxdb tags
+	descriptionTag = "description" // view description
+	unitTag        = "unit"        // measurement unit
+	groupingTag    = "grouping"    // view aggregation/filtering tag
+	aggregationTag = "aggregation" // view aggregation type (count, sum, last, distribution)
+
+	// opencensus information represented as inluxdb fields
+	startField       = "start"             // start of the view aggregation period
+	observationField = "observationPeriod" // duration of the view aggregation period
+	valueField       = "value"
+	minField         = "min" // statistics on distribution aggregations
+	maxField         = "max"
+	meanField        = "mean"
+	countField       = "count"
+	bucketsField     = "buckets" // buckets on distribution aggregations
+)
+
+// Exporter is an opencensus exporter for Influxdb
+type Exporter struct {
+	store        Store
+	errorHandler func(error)
+	customTags   map[string]string
+}
+
+// ExportView sends collected metrics to the backend sink
+func (e *Exporter) ExportView(viewData *view.Data) {
+	points := make([]MetricPoint, 0, len(viewData.Rows))
+	for i, row := range viewData.Rows {
+		fields := make(map[string]interface{}, len(viewData.Rows))
+		tags := make(map[string]string, len(e.customTags)+len(row.Tags)+2)
+
+		// view metadata
+		fields[startField] = viewData.Start
+		fields[observationField] = viewData.End.Sub(viewData.Start)
+		if viewData.View.Description != "" {
+			tags[descriptionTag] = viewData.View.Description
+		}
+		tags[unitTag] = viewData.View.Measure.Unit()
+
+		// view aggregation keys
+		if i < len(viewData.View.TagKeys) {
+			tags[groupingTag] = strings.ToLower(viewData.View.TagKeys[i].Name())
+		}
+
+		// view fields
+		switch d := row.Data.(type) {
+		case *view.CountData:
+			fields[valueField] = float64(d.Value)
+			tags[aggregationTag] = "count"
+		case *view.DistributionData:
+			fields[minField] = d.Min
+			fields[maxField] = d.Max
+			fields[meanField] = d.Mean
+			fields[countField] = d.Count
+			fields[bucketsField] = d.CountPerBucket
+			tags[aggregationTag] = "distribution"
+		case *view.LastValueData:
+			fields[valueField] = d.Value
+			tags[aggregationTag] = "last"
+		case *view.SumData:
+			fields[valueField] = d.Value
+			tags[aggregationTag] = "sum"
+		default:
+			e.errorHandler(fmt.Errorf("unknown AggregationData type: %T", row.Data))
+			return
+		}
+
+		appendAndReplace(tags, e.customTags)
+		appendAndReplace(tags, convertTags(row.Tags))
+
+		points = append(points, MetricPoint{
+			Measurement: viewData.View.Name,
+			Tags:        tags,
+			Fields:      fields,
+			Timestamp:   viewData.End,
+		})
+	}
+
+	if err := e.store.WriteBatch(context.Background(), points); err != nil {
+		e.errorHandler(err)
+	}
+}
+
+// appendAndReplace appends all the data from the 'src' to the
+// 'dst' map. If both have the same key, the one from 'src' is taken.
+func appendAndReplace(dst, src map[string]string) {
+	if dst == nil {
+		dst = make(map[string]string, len(src))
+	}
+
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+func convertTags(tags []tag.Tag) map[string]string {
+	res := make(map[string]string)
+	for _, tag := range tags {
+		res[tag.Key.Name()] = tag.Value
+	}
+	return res
+}

--- a/pkg/metrics/exporters/influxdb/options.go
+++ b/pkg/metrics/exporters/influxdb/options.go
@@ -1,0 +1,142 @@
+package influxdb
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Option configures an exporter
+type Option func(*Exporter)
+
+// WithStore sets the influxdb store for this exporter
+func WithStore(s Store) Option {
+	return func(e *Exporter) {
+		if s != nil {
+			e.store = s
+		}
+	}
+}
+
+// WithErrorHandler sets an error handler for this exporter
+func WithErrorHandler(h func(error)) Option {
+	return func(e *Exporter) {
+		if h != nil {
+			e.errorHandler = h
+		}
+	}
+}
+
+// WithTags sets or	adds some tags to every record posted to the store
+func WithTags(tags map[string]string) Option {
+	return func(e *Exporter) {
+		if len(tags) > 0 {
+			if len(e.customTags) == 0 {
+				e.customTags = tags
+				return
+			}
+			for k, v := range tags {
+				e.customTags[k] = v
+			}
+		}
+	}
+}
+
+// StoreOption configures an influxdb client
+type StoreOption func(*influxDB)
+
+// WithDatabase sets the database to use
+func WithDatabase(db string) StoreOption {
+	return func(s *influxDB) {
+		if db != "" {
+			s.database = db
+		}
+	}
+}
+
+// WithAddr sets the influxdb server URL
+func WithAddr(addr string) StoreOption {
+	return func(s *influxDB) {
+		if addr != "" {
+			s.config.Addr = addr
+		}
+	}
+}
+
+// WithUser sets the database user to connect to an influxdb database
+func WithUser(user string) StoreOption {
+	return func(s *influxDB) {
+		s.config.Username = user
+	}
+}
+
+// WithPassword sets the database password to connect to an influxdb database
+func WithPassword(pwd string) StoreOption {
+	return func(s *influxDB) {
+		s.config.Password = pwd
+	}
+}
+
+// WithInsecureSkipVerify toggles TLS server certificate check by the client
+func WithInsecureSkipVerify(skip bool) StoreOption {
+	return func(s *influxDB) {
+		s.config.InsecureSkipVerify = skip
+	}
+}
+
+// WithTimeout sets write timeouts for the client
+func WithTimeout(d time.Duration) StoreOption {
+	return func(s *influxDB) {
+		s.config.Timeout = d
+	}
+}
+
+// WithTLSConfig sets TLS configuration for an https client
+func WithTLSConfig(config *tls.Config) StoreOption {
+	return func(s *influxDB) {
+		s.config.TLSConfig = config
+	}
+}
+
+// WithProxy configures a proxy for the http client
+func WithProxy(proxy func(*http.Request) (*url.URL, error)) StoreOption {
+	return func(s *influxDB) {
+		s.config.Proxy = proxy
+	}
+}
+
+// WithMapper specifies a name mapping function, which translates a measurement name and a set of tags into another
+// one. This allows for converting measurement names into tags and reduce the number of time series handled by influxdb.
+func WithMapper(mapper func(string, map[string]string) (string, map[string]string)) StoreOption {
+	return func(s *influxDB) {
+		s.mapper = mapper
+	}
+}
+
+// WithNameAsTag is a helper which specifies a simple mapper converting a measurement name into a
+// "metric" tag and the time series name is predefined.
+func WithNameAsTag(timeseries string) StoreOption {
+	return func(s *influxDB) {
+		s.mapper = func(name string, tags map[string]string) (string, map[string]string) {
+			tags["metric"] = name
+			return timeseries, tags
+		}
+	}
+}
+
+// WithURL combines user, password and host address in one single URI notation (e.g. http://user:password@host:port)
+func WithURL(r string) StoreOption {
+	return func(s *influxDB) {
+		if r != "" {
+			u, _ := url.Parse(r)
+			if u.User != nil {
+				s.config.Username = u.User.Username()
+				if pwd, ok := u.User.Password(); ok {
+					s.config.Password = pwd
+				}
+			}
+			s.config.Addr = u.Scheme + "://" + u.Host
+		}
+	}
+}

--- a/pkg/metrics/exporters/influxdb/store.go
+++ b/pkg/metrics/exporters/influxdb/store.go
@@ -1,0 +1,151 @@
+package influxdb
+
+import (
+	"context"
+	"time"
+
+	influxdb "github.com/influxdata/influxdb/client/v2"
+)
+
+// MetricPoint represents a single row in a batch of measurements
+type MetricPoint struct {
+	Measurement string
+	Tags        map[string]string
+	Fields      map[string]interface{}
+	Timestamp   time.Time
+}
+
+// Store provides an access to an influxdb database for reading and writing metrics
+type Store interface {
+	Database() string
+	GetClient() influxdb.Client
+	Ping(context.Context, time.Duration) error
+	ReadMetrics(context.Context, string) (*influxdb.Response, error)
+	WriteMetrics(context.Context, string, map[string]string, map[string]interface{}) error
+	WriteBatch(context.Context, []MetricPoint) error
+}
+
+var _ Store = &influxDB{}
+
+type influxDB struct {
+	config   influxdb.HTTPConfig
+	client   influxdb.Client
+	database string
+	mapper   func(string, map[string]string) (string, map[string]string)
+}
+
+func defaultInfluxDB() *influxDB {
+	return &influxDB{
+		config: influxdb.HTTPConfig{
+			Addr:               "http://localhost:8086",
+			Username:           "admin",
+			InsecureSkipVerify: true,
+		},
+		database: "test",
+	}
+}
+
+// NewStore builds an instance of Store with some options
+func NewStore(opts ...StoreOption) (Store, error) {
+	db := defaultInfluxDB()
+	for _, apply := range opts {
+		apply(db)
+	}
+	c, err := influxdb.NewHTTPClient(db.config)
+	if err != nil {
+		return nil, err
+	}
+	db.client = c
+	return db, nil
+}
+
+func (db *influxDB) GetClient() influxdb.Client {
+	return db.client
+}
+
+func (db *influxDB) Database() string {
+	return db.database
+}
+
+func (db *influxDB) Ping(_ context.Context, timeout time.Duration) error {
+	_, _, err := db.client.Ping(timeout)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *influxDB) WriteMetrics(_ context.Context, measurement string, tags map[string]string, fields map[string]interface{}) error {
+	bp, err := influxdb.NewBatchPoints(influxdb.BatchPointsConfig{
+		Database:  db.database,
+		Precision: "s",
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if db.mapper != nil {
+		measurement, tags = db.mapper(measurement, tags)
+	}
+
+	point, err1 := influxdb.NewPoint(
+		measurement,
+		tags,
+		fields,
+		time.Now(),
+	)
+	if err1 != nil {
+		return err1
+	}
+
+	bp.AddPoint(point)
+
+	err = db.client.Write(bp)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *influxDB) ReadMetrics(_ context.Context, query string) (*influxdb.Response, error) {
+	q := influxdb.Query{
+		Command:  query,
+		Database: db.database,
+	}
+	resp, err := db.client.Query(q)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error() != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (db *influxDB) WriteBatch(_ context.Context, points []MetricPoint) error {
+	bp, err := influxdb.NewBatchPoints(influxdb.BatchPointsConfig{
+		Database:  db.database,
+		Precision: "s",
+	})
+	if err != nil {
+		return err
+	}
+	for _, point := range points {
+		if db.mapper != nil {
+			point.Measurement, point.Tags = db.mapper(point.Measurement, point.Tags)
+		}
+
+		pt, erp := influxdb.NewPoint(point.Measurement, point.Tags, point.Fields, point.Timestamp)
+		if erp != nil {
+			return erp
+		}
+		bp.AddPoint(pt)
+
+	}
+	err = db.client.Write(bp)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/metrics/exporters/influxdb/store_test.go
+++ b/pkg/metrics/exporters/influxdb/store_test.go
@@ -1,0 +1,34 @@
+// +build influxdbintegration
+
+package influxdb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	influxdb "github.com/influxdata/influxdb/client/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient(t *testing.T) {
+	store, err := NewStore()
+	require.NoError(t, err)
+
+	require.NoError(t, store.Ping(context.Background(), 1*time.Second))
+
+	client := store.GetClient()
+
+	bp, err := influxdb.NewBatchPoints(influxdb.BatchPointsConfig{
+		Database:  store.Database(),
+		Precision: "s",
+	})
+	require.NoError(t, err)
+
+	pt, err := influxdb.NewPoint("myview", map[string]string{"mytag": "myvalue"}, map[string]interface{}{"counter": int64(34)})
+	require.NoError(t, err)
+
+	bp.AddPoint(pt)
+
+	require.NoError(t, client.Write(bp))
+}

--- a/pkg/metrics/exporters/mock/mock_exporter.go
+++ b/pkg/metrics/exporters/mock/mock_exporter.go
@@ -1,0 +1,26 @@
+package mocks
+
+import (
+	"go.opencensus.io/stats/view"
+	"go.uber.org/zap"
+)
+
+// NewExporter builds a new mock opencensus exporter
+func NewExporter() *Exporter {
+	l, _ := zap.NewDevelopment()
+	return &Exporter{
+		l: l,
+	}
+}
+
+var _ view.Exporter = &Exporter{}
+
+// Exporter is a mocked up opencensus exporter
+type Exporter struct {
+	l *zap.Logger
+}
+
+// ExportView logs the view data for test purpose
+func (e *Exporter) ExportView(viewData *view.Data) {
+	e.l.Debug("MockExporter", zap.Any("data", viewData))
+}

--- a/pkg/metrics/fixture_test.go
+++ b/pkg/metrics/fixture_test.go
@@ -1,0 +1,21 @@
+package metrics
+
+import "go.opencensus.io/stats"
+
+type exampleMetrics struct {
+	Telemetry struct {
+		UsageCounts   []FilesMetrics        `group:"usage" description:""`    // ignored
+		FailureCounts []*stats.Int64Measure `group:"failures" description:""` // ignored
+		TestCount     *stats.Int64Measure   `metric:"testCount" description:"number of tests"`
+	} `group:"telemetry" description:""`
+	Volumetry struct {
+		Metadata FilesMetrics `group:"metadata" description:""`
+	} `group:"volumetry" description:""`
+	Network struct {
+		Requests IOMetrics
+	} `group:"network" description:""`
+}
+
+func (e *exampleMetrics) IncTest() {
+	Inc(e.Telemetry.TestCount, map[string]string{"kind": "test"})
+}

--- a/pkg/metrics/influxdb_test.go
+++ b/pkg/metrics/influxdb_test.go
@@ -1,0 +1,14 @@
+// +build influxdbintegration
+
+package metrics
+
+import (
+	"github.com/oneconcern/datamon/pkg/metrics/exporters/influxdb"
+
+	"go.opencensus.io/stats/view"
+)
+
+// testExporter adapts metrics sink parameters according to build tag
+func testExporter(tags map[string]string) view.Exporter {
+	return DefaultExporter(influxdb.WithTags(tags))
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,330 @@
+package metrics
+
+import (
+	"context"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/oneconcern/datamon/pkg/metrics/exporters/influxdb"
+
+	"github.com/docker/go-units"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+const (
+	// KB stands for kilo bytes (1024 bytes)
+	KB = units.KiB
+
+	// MB stands for mega bytes (1024 kilo bytes)
+	MB = units.MiB
+
+	// GB stands for giga bytes (1024 mega bytes)
+	GB = units.GiB
+
+	unitCount    = "count"
+	unitSumBytes = "sumbytes"
+	unitBps      = "bps"
+)
+
+var (
+	// global settings for metrics
+	mp       *settings
+	initOnce sync.Once
+)
+
+type settings struct {
+	basePath  string
+	contexter func() context.Context
+	exporter  view.Exporter
+
+	allMetrics []stats.Measure
+	allViews   []*view.View
+
+	// a map of all registered modules
+	modules   map[string]interface{}
+	exclusive sync.Mutex
+}
+
+// defaultSettings define an exporter to a local influxDB backend store
+func defaultSettings() *settings {
+	return &settings{
+		modules:   make(map[string]interface{}),
+		contexter: context.Background,
+	}
+}
+
+func defaultStore() influxdb.Store {
+	sink, _ := influxdb.NewStore(
+		influxdb.WithDatabase("datamon"),
+		influxdb.WithNameAsTag("metrics"), // use metric name as an influxdb tag, with unique time series "metrics"
+	)
+	return sink
+}
+
+// DefaultExporter returns a metrics exporter for an influxdb backend, with db "datamon" and time series "metrics"
+func DefaultExporter(opts ...influxdb.Option) view.Exporter {
+	return flusher(influxdb.NewExporter(
+		append([]influxdb.Option{
+			influxdb.WithStore(defaultStore()),
+			influxdb.WithTags(map[string]string{"service": "datamon"}),
+		}, opts...)...,
+	))
+}
+
+func newSettings(opts ...Option) *settings {
+	s := defaultSettings()
+	for _, apply := range opts {
+		apply(s)
+	}
+
+	if s.exporter == nil {
+		s.exporter = DefaultExporter()
+	}
+
+	s.RegisterExporter()
+	return s
+}
+
+func (s *settings) EnsureMetrics(location string, m interface{}) interface{} {
+	s.exclusive.Lock()
+	defer s.exclusive.Unlock()
+	location = path.Join(s.basePath, location)
+
+	if existing, ok := s.modules[location]; ok {
+		if !equalType(existing, m) {
+			panic("trying to re-register existing metrics module with a different type")
+		}
+		return existing
+	}
+	scanStruct(location, s.addMetric, m)
+	s.modules[location] = m
+	return m
+}
+
+// Flush collects all remaining data for registered views and exports them
+func (s *settings) Flush() {
+	for _, v := range s.allViews {
+		rows, err := view.RetrieveData(v.Name)
+		if err != nil {
+			continue // ignore errors when pushing metrics
+		}
+		data := &view.Data{
+			View:  v,
+			Start: time.Now(), // cannot figure out last snapshot time from the background worker
+			End:   time.Now(),
+			Rows:  rows,
+		}
+		s.exporter.ExportView(data)
+	}
+}
+
+// registerExporter registers the current set exporter to the opencensus library
+func (s *settings) RegisterExporter() {
+	if s.exporter != nil {
+		view.RegisterExporter(s.exporter)
+	}
+}
+
+// addMetric creates a metric with some views, according to the decoded struct tags.
+//
+// Every metric is created with a default view according to its unit type:
+//   - counters (unit=unitCount or "") get a count view
+//   - bytes get a bytes size distribution view
+//   - timings get a duration distribution view
+//   - throughputs (bps) get a throughput distribution view
+//   - sumbytes get a cumulated bytes size sum view
+//
+// Supported extra views can be defined in struct tags, e.g. views:"sum,lastvalue,count"
+func (s *settings) addMetric(m interface{}, metric, group string, tags map[string]string) interface{} {
+	name := path.Join(group, metric)
+	description := tags["description"]
+	unit := tags["unit"]
+
+	if description == "" {
+		description = describeFromTags(name, tags)
+	}
+	// define default view
+	u, dist := unitAndDist(unit)
+
+	var measure stats.Measure
+	switch m.(type) {
+	case *stats.Int64Measure:
+		measure = stats.Int64(name, description, u)
+	case *stats.Float64Measure:
+		measure = stats.Float64(name, description, u)
+	default:
+		return nil
+	}
+
+	s.allMetrics = append(s.allMetrics, measure)
+
+	// capturing tags in views
+	groupingTag := tags["groupings"]
+	groupings := strings.Split(groupingTag, ",")
+	keys := make([]tag.Key, 0, len(groupings))
+	for _, g := range groupings {
+		if g != "" {
+			keys = append(keys, tag.MustNewKey(g))
+		}
+	}
+
+	viewOnMetric := &view.View{
+		Name:        name,
+		Description: describeViewFromDist(description, dist),
+		Measure:     measure,
+		Aggregation: dist,
+		TagKeys:     keys,
+	}
+	s.allViews = append(s.allViews, viewOnMetric)
+	_ = view.Register(viewOnMetric)
+
+	extraViews := tags["views"]
+	if extraViews != "" {
+		// add extra views
+		extras := strings.Split(extraViews, ",")
+		for _, extra := range extras {
+			extraView := &view.View{
+				Measure: measure,
+				TagKeys: keys,
+			}
+			switch extra {
+			case unitCount:
+				extraView.Aggregation = view.Count()
+			case "sum":
+				extraView.Aggregation = view.Sum()
+			case "lastvalue":
+				extraView.Aggregation = view.LastValue()
+			}
+			if extraView.Aggregation != nil {
+				extraView.Name = describeViewFromDist(name, extraView.Aggregation)
+				extraView.Description = describeViewFromDist(description, extraView.Aggregation)
+				s.allViews = append(s.allViews, extraView)
+				_ = view.Register(extraView)
+			}
+		}
+	}
+	return measure
+}
+
+func durationDistribution() *view.Aggregation {
+	// buckets in milliseconds
+	return view.Distribution(
+		10, 50,
+		100, 300, 500, 700, 900,
+		1000, 1300, 1500, 1700, 1900,
+		2000, 3000, 5000, 7000, 9000,
+		10000, 30000, 50000, 70000, 90000,
+		100000,
+	)
+}
+
+func bytesDistribution() *view.Aggregation {
+	// buckets in bytes
+	return view.Distribution(
+		500,
+		1*KB, 5*KB, 10*KB, 50*KB,
+		100*KB, 500*KB, 1*GB,
+		1.5*GB, /* cut-off at default cafs leaf size */
+		5*GB, 10*GB, 50*GB,
+		100*GB, 500*GB, 1000*GB,
+	)
+}
+
+func throughputDistribution() *view.Aggregation {
+	return view.Distribution(
+		1*KB, 5*KB, 50*KB, 100*KB, // for small files
+		1*MB,
+		10*MB,
+		20*MB,
+		50*MB,
+		100*MB,
+		150*MB,
+	)
+}
+
+func unitAndDist(unit string) (string, *view.Aggregation) {
+	switch unit {
+	case "milliseconds":
+		return stats.UnitMilliseconds, durationDistribution()
+	case "bytes":
+		return stats.UnitBytes, bytesDistribution()
+	case unitSumBytes:
+		return stats.UnitBytes, view.Sum()
+	case "bytespersec", unitBps:
+		return unitBps, throughputDistribution()
+	case unitCount:
+		fallthrough
+	default:
+		return stats.UnitDimensionless, view.Count()
+	}
+}
+
+func describeFromTags(name string, tags map[string]string) string {
+	unit := tags["unit"]
+	switch unit {
+	case unitSumBytes:
+		name += " cumulated bytes"
+	case "", unitCount:
+		name += " counter"
+	default:
+		name += " in " + unit
+	}
+	return name
+}
+
+func describeViewFromDist(desc string, in *view.Aggregation) string {
+	if in == nil {
+		return desc
+	}
+	switch in.Type {
+	case view.AggTypeCount:
+		return desc + " [count]"
+	case view.AggTypeSum:
+		return desc + " [cumulated]"
+	case view.AggTypeDistribution:
+		return desc + " [distribution]"
+	case view.AggTypeLastValue:
+		return desc + " [last]"
+	case view.AggTypeNone:
+		fallthrough
+	default:
+		return desc
+	}
+}
+
+// FlushExporter is a view exporter that knows how to flush metrics.
+//
+// This basically means that we may export views concurrently with the default
+// background exporter.
+type FlushExporter interface {
+	view.Exporter
+	Flush(*view.Data)
+}
+
+// flusher makes a FlushExporter of view.Exporter
+func flusher(e view.Exporter) FlushExporter {
+	return &simpleFlusher{
+		e: e,
+	}
+}
+
+type simpleFlusher struct {
+	e view.Exporter
+	m sync.RWMutex
+}
+
+func (f *simpleFlusher) ExportView(viewData *view.Data) {
+	f.m.RLock() // we don't want to lock out the view background worker, which may parallelize things however it sees fit
+	f.e.ExportView(viewData)
+	f.m.RUnlock()
+}
+
+func (f *simpleFlusher) Flush(viewData *view.Data) {
+	f.m.Lock()
+	f.e.ExportView(viewData)
+	f.m.Unlock()
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,89 @@
+package metrics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func fixtureRequires(t testing.TB, m *exampleMetrics) {
+	require.NotNil(t, m.Telemetry.TestCount)
+	require.NotNil(t, m.Volumetry.Metadata.FileCount)
+	require.NotNil(t, m.Network.Requests.Count)
+}
+
+func exerciseAPI(t testing.TB, m *exampleMetrics) {
+	Inc(m.Telemetry.TestCount)
+	Inc(m.Volumetry.Metadata.FileCount)
+	Int64(m.Network.Requests.Count, 10)
+}
+
+func TestMetrics(t *testing.T) {
+	testMetrics := &exampleMetrics{}
+	Init(
+		WithExporter(testExporter(map[string]string{"testing": "testingvalue"})),
+	)
+	_ = EnsureMetrics("example", testMetrics)
+
+	fixtureRequires(t, testMetrics)
+
+	exerciseAPI(t, testMetrics)
+}
+
+func TestRegister(t *testing.T) {
+	testMetrics := &exampleMetrics{}
+	Init(
+		WithExporter(testExporter(map[string]string{"registerTesting": "testingvalue"})),
+	)
+
+	// lazy registration
+	x := EnsureMetrics("registerExample", testMetrics)
+	fixtureRequires(t, testMetrics)
+	exerciseAPI(t, testMetrics)
+
+	// retry registration
+	y := EnsureMetrics("registerExample", testMetrics)
+	require.Equal(t, x, y)
+}
+
+func TestModules(t *testing.T) {
+	s := newSettings(
+		WithBasePath("root"),
+		WithExporter(testExporter(map[string]string{"author": "fred", "run": "test"})),
+	)
+	testMetrics := &exampleMetrics{}
+	_ = s.EnsureMetrics("moduleTesting", testMetrics)
+
+	require.Len(t, s.modules, 1)
+	assert.Len(t, s.allMetrics, 8)
+	assert.Len(t, s.allViews, 11)
+
+	fixtureRequires(t, testMetrics)
+	mp = s
+
+	// helper object level API
+	t0 := time.Now()
+
+	testMetrics.IncTest()
+
+	testMetrics.Network.Requests.IO(time.Now(), "read")
+	testMetrics.Network.Requests.Size(100, "write")
+	testMetrics.Network.Requests.Failed("delete")
+	testMetrics.Network.Requests.Throughput(t0, time.Now(), 100, "read")
+	testMetrics.Network.Requests.Throughput(t0, t0, 100, "nop")
+	testMetrics.Network.Requests.Throughput(t0, t0, 0, "nop")
+
+	testMetrics.Network.Requests.IORecord(t0, "nop")(0, nil)
+	testMetrics.Network.Requests.IORecord(t0, "read")(100, nil)
+	testMetrics.Network.Requests.IORecord(t0, "error")(0, fmt.Errorf("failure"))
+	testMetrics.Network.Requests.IORecord(t0, "write")(100, nil)
+
+	testMetrics.Volumetry.Metadata.Inc("read")
+	testMetrics.Volumetry.Metadata.Size(100, "write")
+	testMetrics.Volumetry.Metadata.Size(0, "download")
+
+	s.Flush()
+}

--- a/pkg/metrics/noinfluxdb_test.go
+++ b/pkg/metrics/noinfluxdb_test.go
@@ -1,0 +1,14 @@
+// +build !influxdbintegration
+
+package metrics
+
+import (
+	mock "github.com/oneconcern/datamon/pkg/metrics/exporters/mock"
+
+	"go.opencensus.io/stats/view"
+)
+
+// testExporter adapts metrics sink parameters according to build tag
+func testExporter(_ map[string]string) view.Exporter {
+	return mock.NewExporter()
+}

--- a/pkg/metrics/options.go
+++ b/pkg/metrics/options.go
@@ -1,0 +1,35 @@
+package metrics
+
+import (
+	"context"
+
+	"go.opencensus.io/stats/view"
+)
+
+// Option defines some options to the metrics initialization
+type Option func(*settings)
+
+// WithBasePath defines the root for the registered metrics tree
+func WithBasePath(location string) Option {
+	return func(m *settings) {
+		m.basePath = location
+	}
+}
+
+// WithContexter sets a context generation function. The default contexter is context.Background
+func WithContexter(c func() context.Context) Option {
+	return func(m *settings) {
+		if c != nil {
+			m.contexter = c
+		}
+	}
+}
+
+// WithExporter configures the exporter to convey metrics to some backend collector
+func WithExporter(exporter view.Exporter) Option {
+	return func(m *settings) {
+		if exporter != nil {
+			m.exporter = flusher(exporter)
+		}
+	}
+}

--- a/pkg/metrics/shared.go
+++ b/pkg/metrics/shared.go
@@ -1,0 +1,190 @@
+package metrics
+
+import (
+	"time"
+
+	"go.opencensus.io/stats"
+)
+
+// FilesMetrics is common set of metrics reporting about file activity
+type FilesMetrics struct {
+	FileCount *stats.Int64Measure `metric:"fileCount" description:"number of files" extraviews:"sum" tags:"kind,operation"`
+	FileSize  *stats.Int64Measure `metric:"fileSize" unit:"bytes" description:"size of files" extraviews:"sum" tags:"kind,operation"`
+}
+
+func (f *FilesMetrics) tags(operation string) map[string]string {
+	return map[string]string{"kind": "dataset", "operation": operation}
+}
+
+// Inc increments the counter for files
+func (f *FilesMetrics) Inc(operation string) {
+	Inc(f.FileCount, f.tags(operation))
+}
+
+// Size measures the size of a file
+func (f *FilesMetrics) Size(size int64, operation string) {
+	Int64(f.FileSize, size, f.tags(operation))
+}
+
+// IOMetrics is a common set of metrics reporting about IO activity
+type IOMetrics struct {
+	Count        *stats.Int64Measure   `metric:"ioCount" description:"number of IO requests" tags:"kind,operation"`
+	Timing       *stats.Float64Measure `metric:"timing" unit:"milliseconds" description:"response time in milliseconds" tags:"kind,operation"`
+	Failures     *stats.Int64Measure   `metric:"ioFailures" description:"number of failed IOs" tags:"kind,operation"`
+	IOSize       *stats.Int64Measure   `metric:"ioSize" unit:"bytes" description:"IO chunk size in bytes" extraviews:"sum" tags:"kind,operation"`
+	IOThroughput *stats.Float64Measure `metric:"throughput" unit:"bytespersec" description:"distribution of throughput of an unitary operation in bytes per second" tags:"kind,operation"`
+}
+
+func (n *IOMetrics) tags(operation string) map[string]string {
+	return map[string]string{"kind": "io", "operation": operation}
+}
+
+// IO records some metrics for an IO operation.
+//
+// Example:
+//   var myIOMetrics = &IOMetrics{}
+//
+//   func (m *myType) MyInstrumentedFunc() {
+//     var size int, err error
+//
+//     defer myIOMetrics.IO(time.Now(), "read")
+//     ...
+//     size,err := doSomeWork()
+//     if err != nil {
+//       myIOMetrics.Failed("read")
+//       return err
+//     }
+//     myIOMetrics.IOSize(size, "read")
+//   }
+func (n *IOMetrics) IO(start time.Time, operation string) {
+	now := time.Now()
+	Duration(start, now, n.Timing, n.tags(operation))
+	Inc(n.Count)
+}
+
+// Size records the size of some IO operation. Zero sizes are not recorded.
+func (n *IOMetrics) Size(size int64, operation string) {
+	if size == 0 {
+		return
+	}
+	Int64(n.IOSize, size, n.tags(operation))
+}
+
+// Failed records a failure on some IO operation
+func (n *IOMetrics) Failed(operation string) {
+	Inc(n.Failures, n.tags(operation))
+}
+
+// Throughput records a throuput on a successful, non-empty, IO operation. Expressed in bytes per second.
+func (n *IOMetrics) Throughput(start, end time.Time, size int64, operation string) {
+	if size == 0 {
+		return
+	}
+	elapsed := end.Sub(start)
+	if elapsed == 0 {
+		return
+	}
+	rate := float64(size) / (float64(elapsed) / 1e9)
+	Float64(n.IOThroughput, rate, n.tags(operation))
+}
+
+// IORecord records all metrics for an IO operation in one go.
+//
+// It provides an alternative way to record size and error in a single
+// deferred call.
+//
+// Example with deferred error capture:
+//   var myIOMetrics = &IOMetrics{}
+//
+//   func (m *myType) MyInstrumentedFunc() {
+//     var size int, err error
+//
+//     defer func(start time.Time) {
+//       myIOMetrics.IORecord(start, "read")(size, err)
+//     }(time.Now())
+//     ...
+//     size, err = doSomeWork()
+//     if err != nil {
+//       return
+//     }
+//   }
+func (n *IOMetrics) IORecord(start time.Time, operation string) func(int64, error) {
+	return func(size int64, err error) {
+		now := time.Now()
+		Duration(start, now, n.Timing, n.tags(operation))
+		Inc(n.Count, n.tags(operation))
+		n.Size(size, operation)
+		if err != nil {
+			Inc(n.Failures, n.tags(operation))
+			return
+		}
+		n.Throughput(start, now, size, operation)
+	}
+}
+
+// UsageMetrics is a common set of metrics reporting about usage
+type UsageMetrics struct {
+	Count    *stats.Int64Measure   `metric:"usageCount" description:"number of calls" tags:"kind,method"`
+	Failures *stats.Int64Measure   `metric:"usageFailures" description:"number of failed calls" tags:"kind,method"`
+	Timing   *stats.Float64Measure `metric:"timing" unit:"milliseconds" description:"duration of a call" tags:"kind,method"`
+}
+
+func (u *UsageMetrics) tags(method string) map[string]string {
+	return map[string]string{"kind": "usage", "method": method}
+}
+
+// Inc records the usage of some method, without timings or failure reporting
+func (u *UsageMetrics) Inc(method string) {
+	Inc(u.Count, u.tags(method))
+}
+
+// Used records usage of some instrumented entry point.
+//
+// Example:
+//   var myUsageMetrics = &UsageMetrics{}
+//
+//   func (m *myType) MyInstrumentedFunc() {
+//     defer myUsageMetrics.Used(time.Now(), "MyInstrumentedFunc")
+//     ...
+//     err := doSomeWork()
+//     if err != nil {
+//       myUsageMetrics.Failed()
+//       ...
+//     }
+//   }
+func (u *UsageMetrics) Used(start time.Time, method string) {
+	Since(start, u.Timing, u.tags(method))
+	Inc(u.Count, u.tags(method))
+}
+
+// UsedAll records usage of some instrumented entry point with failures, in one go.
+//
+// Example:
+//   var myUsageMetrics = &UsageMetrics{}
+//   var err error
+//
+//   func (m *myType) MyInstrumentedFunc() {
+//     defer func(start time.Time) {
+//       myUsageMetrics.UsedAll(start, "MyInstrumentedFunc")(err)
+//     }(time.Now())
+//     ...
+//     err = doSomeWork()
+//     if err != nil {
+//       return
+//     }
+//   }
+func (u *UsageMetrics) UsedAll(start time.Time, method string) func(error) {
+	return func(err error) {
+		Since(start, u.Timing, u.tags(method))
+		Inc(u.Count, u.tags(method))
+		if err != nil {
+			Inc(u.Failures, u.tags(method))
+			return
+		}
+	}
+}
+
+// Failed records a failure on some instrumented entry point
+func (u *UsageMetrics) Failed(method string) {
+	Inc(u.Failures, u.tags(method))
+}

--- a/pkg/metrics/struct_tags.go
+++ b/pkg/metrics/struct_tags.go
@@ -1,0 +1,141 @@
+package metrics
+
+import (
+	"fmt"
+	"path"
+	"reflect"
+)
+
+type metricAdder func(interface{}, string, string, map[string]string) interface{}
+
+func equalType(a, b interface{}) bool {
+	hadThis := reflect.TypeOf(a)
+	nowThis := reflect.TypeOf(b)
+	return hadThis == nowThis
+}
+
+func scanStruct(parent string, adder metricAdder, m interface{}) {
+	rv := reflect.ValueOf(m)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() || rv.Elem().Type().Kind() != reflect.Struct {
+		panic(fmt.Sprintf("scanStruct requires a pointer to a struct, got: %T", m))
+	}
+	scanTags(parent, adder, m)
+}
+
+func scanTags(parent string, adder metricAdder, m interface{}) {
+	container := reflect.ValueOf(m)
+	if shouldSkip(container) || !isStruct(container) {
+		return
+	}
+
+	receiver, derefType := pointerTo(container) // always a pointer
+	pointedStruct := reflect.Indirect(receiver) // always a struct
+	structChanged := false
+
+	for i := 0; i < derefType.NumField(); i++ {
+		field := derefType.Field(i)
+		pointedField := pointedStruct.Field(i)
+
+		if !pointedField.CanInterface() {
+			continue
+		}
+		var child interface{}
+		if pointedField.Type().Kind() == reflect.Ptr {
+			child = pointedField.Interface()
+		} else {
+			child = pointedField.Addr().Interface()
+		}
+
+		tags := fieldTags(field)
+		metric := tags["metric"]
+		group := tags["group"]
+
+		if metric == "" {
+			scanTags(path.Join(parent, group), adder, child)
+			continue
+		}
+
+		if skipMetric(pointedField) {
+			continue
+		}
+
+		allocated := adder(child, metric, path.Join(parent, group), tags)
+		if allocated != nil {
+			pointedField.Set(reflect.ValueOf(allocated))
+			structChanged = true
+		}
+	}
+
+	if !structChanged {
+		return
+	}
+
+	if container.CanSet() {
+		container.Set(receiver)
+	} else if container.CanAddr() && container.Addr().CanSet() {
+		container.Addr().Set(receiver)
+	}
+}
+
+func pointerTo(container reflect.Value) (reflect.Value, reflect.Type) {
+	var receiver reflect.Value
+	deref := derefType(container)
+	if container.Type().Kind() == reflect.Ptr {
+		if container.IsNil() {
+			receiver = reflect.New(deref)
+		} else {
+			receiver = container
+		}
+	} else {
+		receiver = reflect.New(deref)
+	}
+	return receiver, deref
+}
+
+func skipMetric(field reflect.Value) bool {
+	return field.Type().Kind() != reflect.Ptr || !field.CanSet()
+}
+
+// fieldTags decodes field tags that decorate the struct.
+// Supported tags are:
+//  * metric: the metric name
+//  * group: builds an additional path to the metric (e.g.  root/path/mymetrics/{metric})
+//  * description: adds this description to the metric and the associated views
+//  * extraviews:[aggregator, ...]: builds additional views with alternate aggregators
+func fieldTags(field reflect.StructField) map[string]string {
+	tags := make(map[string]string, 5)
+	if metric, ok := field.Tag.Lookup("metric"); ok {
+		tags["metric"] = metric
+	}
+	if unit, ok := field.Tag.Lookup("unit"); ok {
+		tags["unit"] = unit
+	}
+	if group, ok := field.Tag.Lookup("group"); ok {
+		tags["group"] = group
+	}
+	if description, ok := field.Tag.Lookup("description"); ok {
+		tags["description"] = description
+	}
+	if views, ok := field.Tag.Lookup("extraviews"); ok {
+		tags["views"] = views
+	}
+	if groupings, ok := field.Tag.Lookup("tags"); ok {
+		tags["groupings"] = groupings
+	}
+	return tags
+}
+
+func isStruct(v reflect.Value) bool {
+	return (v.Type().Kind() == reflect.Ptr && v.Type().Elem().Kind() == reflect.Struct) || (v.Type().Kind() == reflect.Struct)
+}
+
+func derefType(v reflect.Value) reflect.Type {
+	if v.Type().Kind() == reflect.Ptr {
+		return v.Type().Elem()
+	}
+	return v.Type()
+}
+
+func shouldSkip(v reflect.Value) bool {
+	return !v.IsValid() || v.Type().Kind() == reflect.Map || v.Type().Kind() == reflect.Map
+}

--- a/pkg/metrics/struct_tags_test.go
+++ b/pkg/metrics/struct_tags_test.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats"
+)
+
+func TestStructTags(t *testing.T) {
+	s := newSettings()
+	m := &exampleMetrics{}
+
+	scanStruct("parent", s.addMetric, m)
+
+	assert.Nil(t, m.Telemetry.UsageCounts)   // ignored slice
+	assert.Nil(t, m.Telemetry.FailureCounts) // ignored slice
+
+	assert.NotNil(t, m.Telemetry.TestCount)
+	assert.NotNil(t, m.Volumetry.Metadata.FileCount)
+	assert.NotNil(t, m.Volumetry.Metadata.FileSize)
+	assert.NotNil(t, m.Network.Requests.Count)
+	assert.NotNil(t, m.Network.Requests.Timing)
+	assert.NotNil(t, m.Network.Requests.Failures)
+	assert.NotNil(t, m.Network.Requests.IOSize)
+
+	require.NotNil(t, m.Network.Requests.IOThroughput)
+	assert.IsType(t, &stats.Float64Measure{}, m.Network.Requests.IOThroughput)
+	assert.Len(t, s.allMetrics, 8)
+	assert.Len(t, s.allViews, 11)
+}


### PR DESCRIPTION
* new package metrics to enable metrics reporting in any structure, seeking for the most concise and least intrusive coding of metrics
* examplified the use of pkg/metrics in cafs
* added influxdb backend for opencensus (heavily inspired from Jake's work with oneconcern/watchog)

TODO:
* enable CLI flags for this: --metrics true, [some metric parameters]
* enable CLI config file to store metric backend parameters
* setup CI tests with standalone influxdb container
* instrument pkg/core (dataset stats), pkg/cmd (telemetry), storage

**TODO (with @bluelion): define secure setup for desktop user access to metrics sink**

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>