### PR TITLE
chore(linting): fixed linting after golangci default behavior has changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ commands:
           command: |
             go get -u gotest.tools/gotestsum@latest
             go get -u github.com/matryer/moq@latest
-            go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.3 # temporarily pin linter, which breaks on CI with v1.23.6
+            go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
             go clean -modcache
 
   login_to_google:
@@ -219,7 +219,7 @@ jobs:
           command: |
             hack/go-generate.sh
             go mod download
-            golangci-lint run
+            golangci-lint run --new-from-rev master --timeout 10m
       - run:
           name: Lint shell scripts
           command: |

--- a/cmd/datamon/cmd/cli_workshop_test.go
+++ b/cmd/datamon/cmd/cli_workshop_test.go
@@ -398,13 +398,13 @@ func makeTestWorkshopBundle(t testing.TB, pathToData string) map[string]*testFil
 	for i := 0; i < 9; i++ {
 		name := rand.LetterString(10)
 		data := rand.Bytes(100)
-		err := ioutil.WriteFile(filepath.Join(pathToData, name), data, 0644)
+		err := ioutil.WriteFile(filepath.Join(pathToData, name), data, 0600)
 		require.NoError(t, err)
 		files[name] = &testFile{data: data, size: 100}
 	}
 	name := rand.LetterString(10)
 	data := []byte{} // empty file
-	err := ioutil.WriteFile(filepath.Join(pathToData, name), data, 0644)
+	err := ioutil.WriteFile(filepath.Join(pathToData, name), data, 0600)
 	require.NoError(t, err)
 	files[name] = &testFile{data: data, size: 0}
 	return files

--- a/cmd/datamon/cmd/config_set.go
+++ b/cmd/datamon/cmd/config_set.go
@@ -70,7 +70,7 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 			return
 		}
 
-		err = ioutil.WriteFile(file, o, 0666)
+		err = ioutil.WriteFile(file, o, 0600)
 		if err != nil {
 			wrapFatalln("error writing config file "+file, err)
 			return

--- a/cmd/datamon/cmd/self_upgrade_test.go
+++ b/cmd/datamon/cmd/self_upgrade_test.go
@@ -37,7 +37,7 @@ func TestSelfUpgrade(t *testing.T) {
 
 	opts.selfBinary = filepath.Join(dummyDir, "datamon2")
 
-	err = ioutil.WriteFile(opts.selfBinary, []byte(`dummy`), 0700)
+	err = ioutil.WriteFile(opts.selfBinary, []byte(`dummy`), 0700) //nolint: gosec
 	require.NoError(t, err)
 
 	require.NoError(t, doSelfUpgrade(opts))

--- a/pkg/cafs/reader_test.go
+++ b/pkg/cafs/reader_test.go
@@ -168,7 +168,7 @@ func assertReadAtContent(t testing.TB, size int, name string, expected, received
 			expected=%s
 			actual=%s`, name, len(expected), offset, n, diff,
 			expected,
-			spew.Sdump(expectedBytes), spew.Sdump(received[:n]))), 0644)
+			spew.Sdump(expectedBytes), spew.Sdump(received[:n]))), 0600)
 	}
 }
 

--- a/pkg/fuse/mocks/fs_test_utils.go
+++ b/pkg/fuse/mocks/fs_test_utils.go
@@ -141,7 +141,7 @@ func PopulateFS(t testing.TB, mountPath string, fixtureBuilders ...func() Upload
 			continue
 		}
 		data := rand.Bytes(uf.size)
-		require.NoError(t, ioutil.WriteFile(target, data, 0644))
+		require.NoError(t, ioutil.WriteFile(target, data, 0600))
 
 		testUploadTree[idx].data = data
 		//#nosec
@@ -184,7 +184,7 @@ func PopulateFSWithDirs(t testing.TB, mountPath string, withFile bool, fixtureBu
 		// => have to randomize for now
 		//data := []byte(`not empty`)
 		data := rand.Bytes(10)
-		require.NoError(t, ioutil.WriteFile(target, data, 0644))
+		require.NoError(t, ioutil.WriteFile(target, data, 0600))
 
 		normalizedPath, _ := filepath.Rel(mountPath, target)
 		extraFiles = append(extraFiles, &UploadFileTest{

--- a/pkg/sidecar/param/pub_api.go
+++ b/pkg/sidecar/param/pub_api.go
@@ -72,6 +72,7 @@ func (fuseParams *FUSEParams) FirstCutSidecarFmt(destPath string) error {
 	if err != nil {
 		return err
 	}
+	//nolint: gosec
 	err = ioutil.WriteFile(destPath, o,
 		// @gabe, pls verify, contasting 0660 and r-- on the same octets
 		0666)
@@ -119,6 +120,7 @@ func (pgParams *PGParams) FirstCutSidecarFmt(destPath string) error {
 	if err != nil {
 		return err
 	}
+	//nolint: gosec
 	err = ioutil.WriteFile(destPath, o,
 		// @gabe, pls verify, contasting 0660 and r-- on the same octets
 		0666)


### PR DESCRIPTION
The linter has changed some defaults regarding false positives with gosec.

* gosec warnings fixed with either reduced privileges (test programs) or //nolint directives (i.e. don't know if relevant to fix)
* changed linting strategy to be based on diff with master and not scanning the whole repo, possibly digging out old things not related to a PR's changes
* added timeout to linter (which defaults to 1m), as circleCI sometimes delivers very scarce resources to our containers

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>