### PR TITLE
storage.Store versions

### DIFF
--- a/hack/build_artifacts.sh
+++ b/hack/build_artifacts.sh
@@ -1,0 +1,44 @@
+#! /bin/zsh
+
+setopt ERR_EXIT
+setopt PIPE_FAIL
+
+perhaps_module_dirs=(pkg/)
+
+for perhaps_module_dir in $perhaps_module_dirs; do
+    find $perhaps_module_dir -type d |while read pkg_dir; do
+        if find $pkg_dir -maxdepth 1 \
+                |grep -q '_test.go$'; then
+            print -- "building $pkg_dir test binary"
+            (cd $pkg_dir \
+                 && go test -c)
+        fi
+    done
+done
+
+# ./deploy ???
+perhaps_main_root_dirs=(cmd/ internal/ hack/ pkg/)
+
+typeset -a mains
+
+for perhaps_main_root_dir in $perhaps_main_root_dirs; do
+    find $perhaps_main_root_dir -type d \
+        |while read perhaps_main_dir; do
+        (cd $perhaps_main_dir \
+             && find $ -type f \
+                 |while read perhaps_main; do
+                 if cat $perhaps_main \
+                         |grep -q '^package\s*main'; then
+                     mains=($mains $perhaps_main)
+                 fi
+                 if [[ $#mains -eq 1 ]]; then
+                     print -- "attempting $$perhaps_main build"
+                     go build
+                 else
+                     if [[ $#mains -eq 0 ]]; then continue; fi
+                     print -- "unsure how to build multiple mains" \
+                           "in same directory $perhaps_main_dir build"
+                 fi
+             done)
+    done
+done

--- a/pkg/storage/gcs/options.go
+++ b/pkg/storage/gcs/options.go
@@ -1,6 +1,9 @@
 package gcs
 
-import "go.uber.org/zap"
+import (
+	"github.com/oneconcern/datamon/pkg/storage"
+	"go.uber.org/zap"
+)
 
 // Option is a functor to pass optional parameters to the gcs store
 type Option func(*gcs)
@@ -11,5 +14,11 @@ func Logger(logger *zap.Logger) Option {
 		if logger != nil {
 			g.l = logger
 		}
+	}
+}
+
+func WithVersion(version storage.Version) Option {
+	return func(g *gcs) {
+		g.s.Version = version
 	}
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -5,6 +5,7 @@ package storage
 import (
 	"context"
 	"io"
+	"strconv"
 	"time"
 )
 
@@ -33,27 +34,91 @@ type Attributes struct {
 // Implementations of this interface are assumed to be fairly simple.
 type Store interface {
 	String() string
+	// Has this object in the store?
 	Has(context.Context, string) (bool, error)
+	// Get this object's backing bytes.
 	Get(context.Context, string) (io.ReadCloser, error)
+	// GetAttr looks up the Attributes of this object.
 	GetAttr(context.Context, string) (Attributes, error)
+	// Get this object's backing bytes.
 	GetAt(context.Context, string) (io.ReaderAt, error)
+	// Touch, like the usual *nix verb, touch(1), changes the object's modify time.
+	// Unlike touch(1), it does _not_ create an object if it doesn't exist.
 	Touch(context.Context, string) error
+	// Put writes bytes to a named object in the store.
 	Put(context.Context, string, io.Reader, bool) error
+	// Delete removes the specified object from the store.
+	// ??? design affordances re. versions? e.g. --
+	// - opt to remove all versons
+	// - opt (or different function elsewhere) to rollback to previous version?
 	Delete(context.Context, string) error
+	// ??? what's the intent of this function, again?
 	Clear(context.Context) error
 
 	// Keys returns all keys known to the store.
-	// Depending on the implementation, some limit may exist on the maximum number of such returned keys
+	// Depending on the implementation, some limit on the maximum number
+	// of such returned keys may exist.
 	Keys(context.Context) ([]string, error)
 
 	// KeyPrefix provides a paginated key iterator using "pageToken" as the next starting point
-	KeysPrefix(ctx context.Context, pageToken string, prefix string, delimiter string, count int) ([]string, string, error)
+	KeysPrefix(
+		ctx context.Context,
+		pageToken string,
+		prefix string,
+		delimiter string,
+		count int,
+	) ([]string, string, error)
 }
 
 // StoreCRC knows how to update an object with a computed CRC checksum
 type StoreCRC interface {
 	PutCRC(context.Context, string, io.Reader, bool, uint32) error
 }
+
+const (
+	// GcsSentinelVersion happens to be the sentinel value used by the google-cloud-go library,
+	// not a constant used by the GCS api.  Yet it is so named for consistency with datamon
+	// internal api and because, for cleaner seperation of concerns, the datamon codebase
+	// does not pre-suppose that this google-cloud-go-internal value will not change
+	// sometime in the future, although we wouldn't mind if the google-cloud-go library
+	// made the constant publicly visible.
+	GcsSentinelVersion = -1
+)
+
+type Version struct {
+	gcsGeneration int64
+}
+
+func (version *Version) String() string {
+	return strconv.FormatInt(version.gcsGeneration, 10)
+}
+
+func (version *Version) GcsVersion() int64 {
+	if version.gcsGeneration != 0 {
+		return version.gcsGeneration
+	}
+	return GcsSentinelVersion
+}
+
+type StoreVersioned interface {
+	// KeyVersions returns all versions of a given key
+	// operating assumptions:
+	// * versions are strings (likely true)
+	// * paging is unnecessary (likely false)
+	KeyVersions(context.Context, string) ([]Version, error)
+}
+
+func NewVersionGcs(gcsGeneration int64) Version {
+	return Version{
+		gcsGeneration: gcsGeneration,
+	}
+}
+
+type Settings struct {
+	Version Version
+}
+
+///
 
 // PipeIO copies data from a reader to a writer using io.Pipe
 func PipeIO(writer io.Writer, reader io.Reader) (n int64, err error) {


### PR DESCRIPTION
##### background on GCS versioning

since the WAL (#271), metadata (the stuff that bridges the CLI and CAFS) is stored in two GCS buckets, one with and one without [object versioning](https://cloud.google.com/storage/docs/object-versioning) activated.  what object versioning means is that GCS keeps track of everything (every object, a near synonym for file) that ever gets stored on it (unless the object is deleted).   that is, overwriting an object in a bucket with versioning activated doesn't delete the previous object.

i don't fully understand all the details of GCS versioning.  the upshot is that with versioning activated, every object _can_ be addressed by `(name, version)` instead of just `(name)`.  objects can still be addressed by name, and in this case the latest version is retrieved.  also instead of "version", the value used to address previous versions is called (by GCS), the "generation", a [non-negative] `int64` (`<rant>`following a common golang tendency, also not fully understood, to use signed integers when unsigned integers would not only suffice but also provide additional space.  neither @kerneltime nor myself grok this.`</rant>`)

----

anyway, the `label`s already familiar to datamon users wind up in the versioned metadata, not the unversioned metadata.  what this means is that we have track of every bundle a label has ever referred to already because GCS is storing that information.  what we need is a way to deliver a label's history to the user.

this patch updates `storage.Store`, datamon's internal interface to GCS, to support versions.  allowing datamon to support versions is a necessary (and obviously _not_ sufficient) condition for implementing something like

```
label list --repo <repo-name> --name <label-name>
```

at the command line interface.