### PR TITLE
feat(metrics): more configuration for metrics backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ jobs:
       - run:
           name: Run golang tests with metrics (1)
           command: |
-            gotestsum --junitfile /tmp/test-results/metrics/go-test-report-metrics.xml --format short-with-failures -- \
+            gotestsum --junitfile /tmp/test-results/metrics/go-test-report-metrics.xml --format standard-verbose -- \
               -tags influxdbintegration \
               -timeout 15m \
               -race -cover -covermode atomic -coverprofile /tmp/test-coverage/metrics/c_metrics.out \

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -351,7 +351,19 @@ func addMetricsFlag(cmd *cobra.Command) string {
 
 func addMetricsURLFlag(cmd *cobra.Command) string {
 	c := "metrics-url"
-	cmd.PersistentFlags().StringVar(&datamonFlags.root.metrics.URL, c, "", `Fully qualified URL to an influxdb metrics collector, with user and password`)
+	cmd.PersistentFlags().StringVar(&datamonFlags.root.metrics.URL, c, "", `Fully qualified URL to an influxdb metrics collector, with optional user and password`)
+	return c
+}
+
+func addMetricsUserFlag(cmd *cobra.Command) string {
+	c := "metrics-user"
+	cmd.PersistentFlags().StringVar(&datamonFlags.root.metrics.URL, c, "", `User to connect to the metrics collector backend. Overrides any user set in URL`)
+	return c
+}
+
+func addMetricsPasswordFlag(cmd *cobra.Command) string {
+	c := "metrics-password"
+	cmd.PersistentFlags().StringVar(&datamonFlags.root.metrics.URL, c, "", `Password to connect to the metrics collector backend. Overrides any password set in URL`)
 	return c
 }
 

--- a/cmd/datamon/cmd/metrics.go
+++ b/cmd/datamon/cmd/metrics.go
@@ -7,9 +7,11 @@ import (
 )
 
 type metricsFlags struct {
-	Enabled *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"` // pointer because we want to distinguish unset from false
-	URL     string `json:"url,omitempty" yaml:"url,omitempty"`
-	m       *M
+	Enabled  *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`   // pointer because we want to distinguish unset from false
+	URL      string `json:"url,omitempty" yaml:"url,omitempty"`           // fully qualified metrics endpoint - may embed user/password
+	User     string `json:"user,omitempty" yaml:"user,omitempty"`         // overrides URL user, if any
+	Password string `json:"password,omitempty" yaml:"password,omitempty"` // overrides URL password, if any
+	m        *M
 }
 
 func (m metricsFlags) IsEnabled() bool {

--- a/docs/usage/datamon.md
+++ b/docs/usage/datamon.md
@@ -18,14 +18,16 @@ your data buckets are organized in repositories of versioned and tagged bundles 
 ### Options
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --force                Forces upgrade even if the current version is not a released version
-  -h, --help                 help for datamon
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --force                     Forces upgrade even if the current version is not a released version
+  -h, --help                      help for datamon
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle.md
+++ b/docs/usage/datamon_bundle.md
@@ -24,12 +24,14 @@ together.
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_diff.md
+++ b/docs/usage/datamon_bundle_diff.md
@@ -26,13 +26,15 @@ datamon bundle diff [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_download.md
+++ b/docs/usage/datamon_bundle_download.md
@@ -45,13 +45,15 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_download_file.md
+++ b/docs/usage/datamon_bundle_download_file.md
@@ -36,13 +36,15 @@ datamon bundle download file [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_get.md
+++ b/docs/usage/datamon_bundle_get.md
@@ -27,13 +27,15 @@ datamon bundle get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_list.md
+++ b/docs/usage/datamon_bundle_list.md
@@ -33,13 +33,15 @@ datamon bundle list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_list_files.md
+++ b/docs/usage/datamon_bundle_list_files.md
@@ -38,13 +38,15 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_mount.md
+++ b/docs/usage/datamon_bundle_mount.md
@@ -33,13 +33,15 @@ datamon bundle mount [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_mount_new.md
+++ b/docs/usage/datamon_bundle_mount_new.md
@@ -28,13 +28,15 @@ datamon bundle mount new [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_update.md
+++ b/docs/usage/datamon_bundle_update.md
@@ -26,13 +26,15 @@ datamon bundle update [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_bundle_upload.md
+++ b/docs/usage/datamon_bundle_upload.md
@@ -42,13 +42,15 @@ set label 'init'
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_config.md
+++ b/docs/usage/datamon_config.md
@@ -23,12 +23,14 @@ You may force a specific local config file using the $DATAMON_CONFIG environment
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_config_set.md
+++ b/docs/usage/datamon_config_set.md
@@ -52,12 +52,14 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context.md
+++ b/docs/usage/datamon_context.md
@@ -18,12 +18,14 @@ Commands to manage contexts. A context is an instance of Datamon with set of rep
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_create.md
+++ b/docs/usage/datamon_context_create.md
@@ -26,13 +26,15 @@ datamon context create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_get.md
+++ b/docs/usage/datamon_context_get.md
@@ -21,13 +21,15 @@ datamon context get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_context_list.md
+++ b/docs/usage/datamon_context_list.md
@@ -21,13 +21,15 @@ datamon context list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label.md
+++ b/docs/usage/datamon_label.md
@@ -34,12 +34,14 @@ production
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label_get.md
+++ b/docs/usage/datamon_label_get.md
@@ -25,13 +25,15 @@ datamon label get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label_list.md
+++ b/docs/usage/datamon_label_list.md
@@ -34,13 +34,15 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label_set.md
+++ b/docs/usage/datamon_label_set.md
@@ -33,13 +33,15 @@ datamon label set [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo.md
+++ b/docs/usage/datamon_repo.md
@@ -24,12 +24,14 @@ They are versioned and managed via bundles.
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo_create.md
+++ b/docs/usage/datamon_repo_create.md
@@ -34,13 +34,15 @@ datamon repo create [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo_get.md
+++ b/docs/usage/datamon_repo_get.md
@@ -24,13 +24,15 @@ datamon repo get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_repo_list.md
+++ b/docs/usage/datamon_repo_list.md
@@ -30,13 +30,15 @@ fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_upgrade.md
+++ b/docs/usage/datamon_upgrade.md
@@ -24,12 +24,14 @@ datamon upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_usage.md
+++ b/docs/usage/datamon_usage.md
@@ -22,12 +22,14 @@ datamon usage [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_version.md
+++ b/docs/usage/datamon_version.md
@@ -27,12 +27,14 @@ datamon version [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_web.md
+++ b/docs/usage/datamon_web.md
@@ -23,12 +23,14 @@ datamon web [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (default "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
* added support for metrics config from env var (prioritized as: config < env < flags)
* added support for metrics backend config: user and password
* allowed overriding user or password separately from URL (i.e. leeway on how to manage secrets)

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>