### PR TITLE
Upgrade CI sizing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
       - run:
           name: Run golang tests (1)
           command: |
-            gotestsum --junitfile /tmp/test-results/noncafs/go-test-report-noncafs.xml --format short-with-failures -- \
+            gotestsum --junitfile /tmp/test-results/noncafs/go-test-report-noncafs.xml --format standard-verbose -- \
               -timeout 15m \
               -race -cover -covermode atomic -coverprofile /tmp/test-coverage/noncafs/c_non_cafs.out \
               $(go list ./...|grep -v cafs)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     working_directory: ~/project
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
-    resource_class: 'medium+'
+    resource_class: 'large'
     docker:
       - image: circleci/golang
       - image: minio/minio
@@ -23,6 +23,7 @@ executors:
   # TODO(frederic): add builder for alpine and compare
   docker_builder:
     working_directory: ~/project
+    resource_class: 'small'
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
     docker:
@@ -30,6 +31,7 @@ executors:
 
   fuse_tester:
     working_directory: ~/project
+    resource_class: 'large'
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
       GOROOT: /usr/local/go
@@ -42,7 +44,7 @@ executors:
     working_directory: ~/project
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
-    resource_class: 'medium+'
+    resource_class: 'large'
     docker:
       - image: circleci/golang
       - image: minio/minio
@@ -210,7 +212,7 @@ commands:
 
 jobs:
   go_lint:
-    executor: docker_minio
+    executor: docker_builder
     steps:
       - install_base
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
   # TODO(frederic): add builder for alpine and compare
   docker_builder:
     working_directory: ~/project
-    resource_class: 'medium' # linter breaks on "small" instances
+    resource_class: 'medium+' # linter breaks on "small" instances and sometimes even on "medium" ones
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
       - run:
           name: Run golang tests (1)
           command: |
-            gotestsum --junitfile /tmp/test-results/noncafs/go-test-report-noncafs.xml --format standard-verbose -- \
+            gotestsum --junitfile /tmp/test-results/noncafs/go-test-report-noncafs.xml --format short-with-failures -- \
               -timeout 15m \
               -race -cover -covermode atomic -coverprofile /tmp/test-coverage/noncafs/c_non_cafs.out \
               $(go list ./...|grep -v cafs)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     working_directory: ~/project
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
-    resource_class: 'large'
+    resource_class: 'medium+'
     docker:
       - image: circleci/golang
       - image: minio/minio
@@ -23,7 +23,7 @@ executors:
   # TODO(frederic): add builder for alpine and compare
   docker_builder:
     working_directory: ~/project
-    resource_class: 'small'
+    resource_class: 'medium' # linter breaks on "small" instances
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
     docker:
@@ -31,7 +31,7 @@ executors:
 
   fuse_tester:
     working_directory: ~/project
-    resource_class: 'large'
+    resource_class: 'medium+'
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
       GOROOT: /usr/local/go
@@ -44,7 +44,7 @@ executors:
     working_directory: ~/project
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
-    resource_class: 'large'
+    resource_class: 'medium+'
     docker:
       - image: circleci/golang
       - image: minio/minio

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ executors:
     working_directory: ~/project
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
+    resource_class: 'medium+'
     docker:
       - image: circleci/golang
       - image: minio/minio
@@ -41,6 +42,7 @@ executors:
     working_directory: ~/project
     environment:
       GOOGLE_COMPUTE_ZONE: us-west2-c
+    resource_class: 'medium+'
     docker:
       - image: circleci/golang
       - image: minio/minio


### PR DESCRIPTION
This PR upgrades the resource class used to run our tests.
The default instance ("medium") is often failing on memory shortage or time outs.
Upgrading to "medium+" beefs up a bit the workflows, at marginal cost in circleci credits.
Testing with "large" instances did not improve things since the next bottleneck is the latency to gcs (this story shall also be told).