### PR TITLE
fix(metrics): timeout management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,8 +232,11 @@ commands:
       - run:
           name: Add CircleCI IP to whitelist
           command: |
-            CIRCLE_CI_IP=$(curl -sSL https://checkip.amazonaws.com)
-            gcloud container clusters update --zone ${GOOGLE_COMPUTE_ZONE} ${CLUSTER} --enable-master-authorized-networks --master-authorized-networks ${ALLOWED_NETWORKS},$CIRCLE_CI_IP/32
+            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
+            ALREADY="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. == "'"${CIRCLE_CI_IP}"'/32"))|.[]')"
+            if [ -z "${ALREADY}" ] ; then
+              gcloud container clusters update --zone ${GOOGLE_COMPUTE_ZONE} ${CLUSTER} --enable-master-authorized-networks --master-authorized-networks ${ALLOWED_NETWORKS},$CIRCLE_CI_IP/32
+            fi
 
   remove_whitelist_ip:
     steps:
@@ -241,20 +244,7 @@ commands:
           name: Remove previously added CircleCI IP from whitelist
           command: |
             set -x -o pipefail
-            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
-            PREVIOUS="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. != "'"${CIRCLE_CI_IP}"'/32"))|tostring|sub("[\"\\[\\]]";"";"g")')"
-            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "$(eval echo "${PREVIOUS}")"
-
-  remove_whitelist_ip_on_fail:
-    steps:
-      - run:
-          when: on_fail
-          name: Remove previously added CircleCI IP from whitelist (when failed)
-          command: |
-            set -x -o pipefail
-            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
-            PREVIOUS="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. != "'"${CIRCLE_CI_IP}"'/32"))|tostring|sub("[\"\\[\\]]";"";"g")')"
-            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "$(eval echo "${PREVIOUS}")"
+            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "${ALLOWED_NETWORKS}"
 
 jobs:
   go_lint:
@@ -435,7 +425,6 @@ jobs:
           name: Delete k8s resources for sidecar demo
           command: |
             make clean-fuse-demo
-      - remove_whitelist_ip_on_fail
 
   pg_sidecar_test:
     executor: docker_builder
@@ -456,7 +445,6 @@ jobs:
           name: Delete k8s resources for sidecar demo
           command: |
             make clean-pg-demo
-      - remove_whitelist_ip_on_fail
 
   build_images:
     executor: docker_builder
@@ -548,7 +536,6 @@ jobs:
     steps:
       - setup_remote_docker:
           version: 18.09.3
-      - install_base
       - login_to_google
       - remove_whitelist_ip
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,19 +70,10 @@ executors:
         auth:
           username: _json_key
           password: $GCLOUD_SERVICE_KEY
-      - image: minio/minio
-        environment:
-          MINIO_ACCESS_KEY: access-key
-          MINIO_SECRET_KEY: secret-key-thing
-          MINIO_BROWSER: "off"
-          MINIO_DOMAIN: s3.local
-          MINIO_HTTP_TRACE: /tmp/minio.log
-        command:
-          - server
-          - data
       - image: influxdb:1.7-alpine
         environment:
           INFLUXDB_DB: datamon
+          INFLUXDB_LOGGING_LEVEL: error
         command:
           - influxd
 
@@ -346,9 +337,10 @@ jobs:
       - run:
          name: Create influxdb test db
          command: |
-           curl --get http://localhost:8086/query --data-urlencode "q=CREATE DATABASE test"
+           curl http://localhost:8086/query --data-urlencode "q=CREATE DATABASE test"
       - run:
           name: Run golang tests with metrics (1)
+          no_output_timeout: 20m
           command: |
             gotestsum --junitfile /tmp/test-results/metrics/go-test-report-metrics.xml --format standard-verbose -- \
               -tags influxdbintegration \

--- a/cmd/datamon/cmd/root.go
+++ b/cmd/datamon/cmd/root.go
@@ -3,12 +3,14 @@
 package cmd
 
 import (
+	"crypto/tls"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
 	"sync/atomic"
+	"time"
 
 	"github.com/spf13/viper"
 
@@ -71,6 +73,11 @@ your data buckets are organized in repositories of versioned and tagged bundles 
 				influxdb.WithDatabase("datamon"),
 				influxdb.WithURL(datamonFlags.root.metrics.URL),
 				influxdb.WithNameAsTag("metrics"), // use metric name as an influxdb tag, with unique time series "metrics"
+				influxdb.WithTimeout(30 * time.Second),
+				influxdb.WithTLSConfig(&tls.Config{
+					NextProtos: []string{"h2", "http/1.1"},
+				}),
+				influxdb.WithInsecureSkipVerify(true),
 			}
 
 			// override credentials for metrics backend

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -47,6 +47,8 @@ type settings struct {
 	// a map of all registered modules
 	modules   map[string]interface{}
 	exclusive sync.Mutex
+
+	d time.Duration
 }
 
 // defaultSettings define an exporter to a local influxDB backend store
@@ -54,6 +56,7 @@ func defaultSettings() *settings {
 	return &settings{
 		modules:   make(map[string]interface{}),
 		contexter: context.Background,
+		// default reporting period is left to the default from opencensus exporter (10s)
 	}
 }
 
@@ -126,6 +129,9 @@ func (s *settings) Flush() {
 func (s *settings) RegisterExporter() {
 	if s.exporter != nil {
 		view.RegisterExporter(s.exporter)
+		if s.d >= time.Second {
+			view.SetReportingPeriod(s.d)
+		}
 	}
 }
 

--- a/pkg/metrics/options.go
+++ b/pkg/metrics/options.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"time"
 
 	"go.opencensus.io/stats/view"
 )
@@ -31,5 +32,13 @@ func WithExporter(exporter view.Exporter) Option {
 		if exporter != nil {
 			m.exporter = flusher(exporter)
 		}
+	}
+}
+
+// WithReportingPeriod configures how often the exporter is going to upload metrics.
+// Durations under 1 sec do not have any effect. The default is 10s.
+func WithReportingPeriod(d time.Duration) Option {
+	return func(m *settings) {
+		m.d = d
 	}
 }


### PR DESCRIPTION
* removed unused minio container from metrics executor
* allowed metrics test to keep mute for the duration of the test
* added support for configurable opencensus reporting period
* added default 30 s timeout on metrics write operations
* added some TLS options for https influxdb backends

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>