### PR TITLE
Fix diamond metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,8 +241,11 @@ commands:
       - run:
           name: Add CircleCI IP to whitelist
           command: |
-            CIRCLE_CI_IP=$(curl -sSL https://checkip.amazonaws.com)
-            gcloud container clusters update --zone ${GOOGLE_COMPUTE_ZONE} ${CLUSTER} --enable-master-authorized-networks --master-authorized-networks ${ALLOWED_NETWORKS},$CIRCLE_CI_IP/32
+            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
+            ALREADY="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. == "'"${CIRCLE_CI_IP}"'/32"))|.[]')"
+            if [ -z "${ALREADY}" ] ; then
+              gcloud container clusters update --zone ${GOOGLE_COMPUTE_ZONE} ${CLUSTER} --enable-master-authorized-networks --master-authorized-networks ${ALLOWED_NETWORKS},$CIRCLE_CI_IP/32
+            fi
 
   remove_whitelist_ip:
     steps:
@@ -250,20 +253,7 @@ commands:
           name: Remove previously added CircleCI IP from whitelist
           command: |
             set -x -o pipefail
-            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
-            PREVIOUS="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. != "'"${CIRCLE_CI_IP}"'/32"))|tostring|sub("[\"\\[\\]]";"";"g")')"
-            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "$(eval echo "${PREVIOUS}")"
-
-  remove_whitelist_ip_on_fail:
-    steps:
-      - run:
-          when: on_fail
-          name: Remove previously added CircleCI IP from whitelist (when failed)
-          command: |
-            set -x -o pipefail
-            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
-            PREVIOUS="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. != "'"${CIRCLE_CI_IP}"'/32"))|tostring|sub("[\"\\[\\]]";"";"g")')"
-            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "$(eval echo "${PREVIOUS}")"
+            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "${ALLOWED_NETWORKS}"
 
 jobs:
   go_lint:
@@ -443,7 +433,6 @@ jobs:
           name: Delete k8s resources for sidecar demo
           command: |
             make clean-fuse-demo
-      - remove_whitelist_ip_on_fail
 
   pg_sidecar_test:
     executor: docker_builder
@@ -464,7 +453,6 @@ jobs:
           name: Delete k8s resources for sidecar demo
           command: |
             make clean-pg-demo
-      - remove_whitelist_ip_on_fail
 
   build_images:
     executor: docker_builder
@@ -556,7 +544,6 @@ jobs:
     steps:
       - setup_remote_docker:
           version: 18.09.3
-      - install_base
       - login_to_google
       - remove_whitelist_ip
 

--- a/cmd/datamon/cmd/diamond_cancel.go
+++ b/cmd/datamon/cmd/diamond_cancel.go
@@ -40,6 +40,7 @@ var CancelDiamondCmd = &cobra.Command{
 				model.DiamondClone(diamond),
 			)),
 			core.DiamondLogger(logger),
+			core.DiamondWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
 
 		err = d.Cancel()

--- a/cmd/datamon/cmd/diamond_commit.go
+++ b/cmd/datamon/cmd/diamond_commit.go
@@ -31,7 +31,9 @@ var CommitDiamondCmd = &cobra.Command{
 			return
 		}
 
-		diamond, err := core.GetDiamond(datamonFlags.repo.RepoName, datamonFlags.diamond.diamondID, remoteStores)
+		diamond, err := core.GetDiamond(datamonFlags.repo.RepoName, datamonFlags.diamond.diamondID, remoteStores,
+			core.DiamondLogger(logger),
+			core.DiamondWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 		if err != nil {
 			wrapFatalln("error retrieving diamond", err)
 			return
@@ -52,6 +54,7 @@ var CommitDiamondCmd = &cobra.Command{
 			core.DiamondConcurrentFileUploads(getConcurrencyFactor(fileUploadsByConcurrencyFactor)),
 			core.DiamondLogger(logger),
 			core.DiamondBundleID(datamonFlags.bundle.ID),
+			core.DiamondWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
 
 		err = d.Commit()

--- a/cmd/datamon/cmd/diamond_get.go
+++ b/cmd/datamon/cmd/diamond_get.go
@@ -29,8 +29,15 @@ exits with ENOENT status otherwise.`,
 			wrapFatalln("create remote stores", err)
 			return
 		}
+		logger, err := optionInputs.getLogger()
+		if err != nil {
+			wrapFatalln("get logger", err)
+			return
+		}
 
-		diamond, err := core.GetDiamond(datamonFlags.repo.RepoName, datamonFlags.diamond.diamondID, remoteStores)
+		diamond, err := core.GetDiamond(datamonFlags.repo.RepoName, datamonFlags.diamond.diamondID, remoteStores,
+			core.DiamondLogger(logger),
+			core.DiamondWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 		if err != nil {
 			if errors.Is(err, status.ErrNotFound) {
 				wrapFatalWithCodef(int(unix.ENOENT), "didn't find diamond %q", datamonFlags.diamond.diamondID)

--- a/cmd/datamon/cmd/diamond_initialize.go
+++ b/cmd/datamon/cmd/diamond_initialize.go
@@ -28,8 +28,15 @@ datamon diamond initialize --repo my-repo
 			wrapFatalln("create remote stores", err)
 			return
 		}
+		logger, err := optionInputs.getLogger()
+		if err != nil {
+			wrapFatalln("get logger", err)
+			return
+		}
 
-		diamond, err := core.CreateDiamond(datamonFlags.repo.RepoName, remoteStores)
+		diamond, err := core.CreateDiamond(datamonFlags.repo.RepoName, remoteStores,
+			core.DiamondLogger(logger),
+			core.DiamondWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 		if err != nil {
 			wrapFatalln("error creating diamond", err)
 			return

--- a/cmd/datamon/cmd/split_add.go
+++ b/cmd/datamon/cmd/split_add.go
@@ -98,11 +98,13 @@ my-pod
 			core.SplitKeyIterator(iterator),
 			core.SplitKeyFilter(filter),
 			core.SplitLogger(logger),
-			//core.SplitMustExist(datamonFlags.split.splitID != ""),
+			core.SplitWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
 
 		split, err := core.CreateSplit(datamonFlags.repo.RepoName, datamonFlags.diamond.diamondID, remoteStores,
 			core.SplitDescriptor(&s.SplitDescriptor),
+			core.SplitLogger(logger),
+			core.SplitWithMetrics(datamonFlags.root.metrics.IsEnabled()),
 		)
 		if err != nil {
 			wrapFatalln("split create", err)

--- a/cmd/datamon/cmd/split_get.go
+++ b/cmd/datamon/cmd/split_get.go
@@ -29,8 +29,15 @@ exits with ENOENT status otherwise.`,
 			wrapFatalln("create remote stores", err)
 			return
 		}
+		logger, err := optionInputs.getLogger()
+		if err != nil {
+			wrapFatalln("get logger", err)
+			return
+		}
 
-		split, err := core.GetSplit(datamonFlags.repo.RepoName, datamonFlags.diamond.diamondID, datamonFlags.split.splitID, remoteStores)
+		split, err := core.GetSplit(datamonFlags.repo.RepoName, datamonFlags.diamond.diamondID, datamonFlags.split.splitID, remoteStores,
+			core.SplitLogger(logger),
+			core.SplitWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 		if err != nil {
 			if errors.Is(err, status.ErrNotFound) {
 				wrapFatalWithCodef(int(unix.ENOENT), "didn't find split %q", datamonFlags.split.splitID)

--- a/pkg/core/diamond_options.go
+++ b/pkg/core/diamond_options.go
@@ -79,3 +79,10 @@ func DiamondBundleID(bundleID string) DiamondOption {
 		}
 	}
 }
+
+// DiamondWithMetrics toggles metrics on a core Diamond object
+func DiamondWithMetrics(enabled bool) DiamondOption {
+	return func(b *Diamond) {
+		b.EnableMetrics(enabled)
+	}
+}

--- a/pkg/core/index.go
+++ b/pkg/core/index.go
@@ -32,7 +32,7 @@ type fileIndex struct {
 
 func defaultFileIndex(stores context2.Stores) *fileIndex {
 	return &fileIndex{
-		metaObject:     defaultMetaObject(stores.VMetadata()), // TODO(fred): nice - when generalizing this to other objects, default may change
+		metaObject:     defaultMetaObject(GetDiamondStore(stores)), // TODO(fred): nice - when generalizing this to other objects, default may change
 		output:         make(chan bundleEntriesRes, bufferingFactor*defaultBundleEntriesPerFile),
 		concurrency:    100,
 		l:              dlogger.MustGetLogger("info"),

--- a/pkg/core/metrics.go
+++ b/pkg/core/metrics.go
@@ -2,14 +2,30 @@ package core
 
 import (
 	"github.com/oneconcern/datamon/pkg/metrics"
+	"go.opencensus.io/stats"
 )
 
 // M describes metrics for the core package
 type M struct {
 	Volume struct {
 		Bundles metrics.FilesMetrics `group:"bundles" description:"metrics about datasets (bundles)"`
+		IO      BundleIOMetrics      `group:"io" description:"metrics about bundle IO operations"`
 	} `group:"volumetry" description:""`
 	Usage metrics.UsageMetrics `group:"telemetry" description:"usage stats for the core package"`
 
 	// more metrics here
+}
+
+// BundleIOMetrics extends IOMetrics to capture bundle file count and metadata index files count
+type BundleIOMetrics struct {
+	metrics.IOMetrics
+	FileCount  *stats.Int64Measure `metric:"fileCount" description:"number of files in a bundle" tags:"kind,operation"`
+	IndexCount *stats.Int64Measure `metric:"indexCount" description:"number of metadata index files in a bundle" tags:"kind,operation"`
+}
+
+// BundleFiles recors metrics about files in a bundle
+func (b *BundleIOMetrics) BundleFiles(files, indices int64, operation string) {
+	tags := map[string]string{"kind": "io", "operation": operation}
+	metrics.Int64(b.FileCount, files, tags)
+	metrics.Int64(b.IndexCount, indices, tags)
 }

--- a/pkg/core/split_options.go
+++ b/pkg/core/split_options.go
@@ -80,3 +80,10 @@ func SplitKeyIterator(iterator KeyIterator) SplitOption {
 		}
 	}
 }
+
+// SplitWithMetrics toggles metrics on a core Split object
+func SplitWithMetrics(enabled bool) SplitOption {
+	return func(s *Split) {
+		s.EnableMetrics(enabled)
+	}
+}


### PR DESCRIPTION
fix(metrics): added metrics for diamonds and splits

Extra fixups:
* completed the replacement of direct stores.VMetadata() specification by the common GetDiamondStore()
* added some missing logger injections in datamon/cmd, which were missing on some new diamond/split commands
* updated generated usage doc

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>

fix(metrics): added metrics for bundle operations: throughput, size and number of files