### PR TITLE
core pkg label versions

### DIFF
--- a/cmd/datamon/cmd/label_list.go
+++ b/cmd/datamon/cmd/label_list.go
@@ -46,7 +46,9 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT`,
 			wrapFatalln("create remote stores", err)
 			return
 		}
-		err = core.ListLabelsApply(datamonFlags.repo.RepoName, remoteStores, datamonFlags.label.Prefix, applyLabelTemplate,
+		err = core.ListLabelsApply(datamonFlags.repo.RepoName, remoteStores,
+			core.ApplyLabelFunc{ToLabel: applyLabelTemplate},
+			core.WithPrefix(datamonFlags.label.Prefix),
 			core.ConcurrentList(datamonFlags.core.ConcurrencyFactor),
 			core.BatchSize(datamonFlags.core.BatchSize),
 			core.WithMetrics(datamonFlags.root.metrics.IsEnabled()),

--- a/hack/build_artifacts.sh
+++ b/hack/build_artifacts.sh
@@ -1,0 +1,44 @@
+#! /bin/zsh
+
+setopt ERR_EXIT
+setopt PIPE_FAIL
+
+perhaps_module_dirs=(pkg/)
+
+for perhaps_module_dir in $perhaps_module_dirs; do
+    find $perhaps_module_dir -type d |while read pkg_dir; do
+        if find $pkg_dir -maxdepth 1 \
+                |grep -q '_test.go$'; then
+            print -- "building $pkg_dir test binary"
+            (cd $pkg_dir \
+                 && go test -c)
+        fi
+    done
+done
+
+# ./deploy ???
+perhaps_main_root_dirs=(cmd/ internal/ hack/ pkg/)
+
+typeset -a mains
+
+for perhaps_main_root_dir in $perhaps_main_root_dirs; do
+    find $perhaps_main_root_dir -type d \
+        |while read perhaps_main_dir; do
+        (cd $perhaps_main_dir \
+             && find $ -type f \
+                 |while read perhaps_main; do
+                 if cat $perhaps_main \
+                         |grep -q '^package\s*main'; then
+                     mains=($mains $perhaps_main)
+                 fi
+                 if [[ $#mains -eq 1 ]]; then
+                     print -- "attempting $$perhaps_main build"
+                     go build
+                 else
+                     if [[ $#mains -eq 0 ]]; then continue; fi
+                     print -- "unsure how to build multiple mains" \
+                           "in same directory $perhaps_main_dir build"
+                 fi
+             done)
+    done
+done

--- a/hack/go-generate.sh
+++ b/hack/go-generate.sh
@@ -7,6 +7,4 @@ cd "$(git rev-parse --show-toplevel)"
 mockDir="pkg/storage/mockstorage"
 mkdir -p ${mockDir}
 echo "package mockstorage" > ${mockDir}/store.go
-# moq -out pkg/storage/mockstorage/store.go -pkg mockstorage pkg/storage Store
-# moq -out pkg/storage/mockstorage/store_versioned.go -pkg mockstorage pkg/storage StoreVersioned Store
 moq -out pkg/storage/mockstorage/store_versioned.go -pkg mockstorage pkg/storage Store StoreVersioned

--- a/hack/go-generate.sh
+++ b/hack/go-generate.sh
@@ -7,4 +7,6 @@ cd "$(git rev-parse --show-toplevel)"
 mockDir="pkg/storage/mockstorage"
 mkdir -p ${mockDir}
 echo "package mockstorage" > ${mockDir}/store.go
-moq -out pkg/storage/mockstorage/store.go -pkg mockstorage pkg/storage Store
+# moq -out pkg/storage/mockstorage/store.go -pkg mockstorage pkg/storage Store
+# moq -out pkg/storage/mockstorage/store_versioned.go -pkg mockstorage pkg/storage StoreVersioned Store
+moq -out pkg/storage/mockstorage/store_versioned.go -pkg mockstorage pkg/storage Store StoreVersioned

--- a/pkg/core/bundle_list.go
+++ b/pkg/core/bundle_list.go
@@ -185,7 +185,11 @@ func listBundlesChan(repo string, stores context2.Stores, opts ...Option) (chan 
 	}
 	// starting keys retrieval
 	wg.Add(1)
-	go fetchKeys(iterator, keysChan, doneWithKeysChan, &wg) // scan for key batches
+	fetchKeysChans := fetchKeysChans{
+		keysChan:         keysChan,
+		doneWithKeysChan: doneWithKeysChan,
+	}
+	go fetchKeys(iterator, fetchKeysChans, &wg) // scan for key batches
 
 	// start bundle metadata retrieval
 	wg.Add(1)

--- a/pkg/core/diamond_list.go
+++ b/pkg/core/diamond_list.go
@@ -174,7 +174,11 @@ func listDiamondsChan(repo string, stores context2.Stores, opts ...Option) (chan
 
 	// starting keys retrieval
 	wg.Add(1)
-	go fetchKeys(iterator, unfilteredKeysChan, doneWithKeysChan, &wg) // scan for key batches
+	fetchKeysChans := fetchKeysChans{
+		keysChan:         unfilteredKeysChan,
+		doneWithKeysChan: doneWithKeysChan,
+	}
+	go fetchKeys(iterator, fetchKeysChans, &wg) // scan for key batches
 
 	// keys state filtering & merging
 	wg.Add(1)

--- a/pkg/core/label_list.go
+++ b/pkg/core/label_list.go
@@ -207,7 +207,7 @@ func listLabelsChan(repo string, stores context2.Stores, prefix string, opts ...
 			if versionsErr != nil {
 				return nil, "", versionsErr
 			}
-			versionStrings := make([]string, len(versions))
+			versionStrings := make([]string, 0, len(versions))
 			for _, ver := range versions {
 				versionStrings = append(versionStrings, ver.String())
 			}

--- a/pkg/core/label_list_test.go
+++ b/pkg/core/label_list_test.go
@@ -157,3 +157,7 @@ func TestListLabels(t *testing.T) {
 		}
 	}
 }
+
+func TestListLabelVersions(t *testing.T) {
+	t.Skip("tbd")
+}

--- a/pkg/core/label_list_test.go
+++ b/pkg/core/label_list_test.go
@@ -120,10 +120,10 @@ func testListLabels(t *testing.T, concurrency int, i int) {
 			//t.Parallel()
 			labels := make(model.LabelDescriptors, 0, typicalReposNum)
 			err := ListLabelsApply(testcase.repo, mockedLabelContextStores(testcase.name),
-				testcase.prefix, func(label model.LabelDescriptor) error {
+				ApplyLabelFunc{ToLabel: func(label model.LabelDescriptor) error {
 					labels = append(labels, label)
 					return nil
-				}, ConcurrentList(concurrency), BatchSize(testBatchSize))
+				}}, WithPrefix(testcase.prefix), ConcurrentList(concurrency), BatchSize(testBatchSize))
 			assertLabels(t, testcase, labels, err)
 		})
 	}
@@ -157,6 +157,70 @@ func TestListLabels(t *testing.T) {
 		}
 	}
 }
+
+///
+
+/*
+type labelVersionedFixture struct {
+	name          string
+	repo          string
+	expected      []storage.Version
+}
+
+func labelVersionedTestCases() []labelVersionedFixture {
+	return []labelVersionedFixture{
+		{
+			name:     happyPath,
+			repo:     "myRepo",
+			expected: []storage.Version{fakeLV(1), fakeLV(2)},
+		},
+	}
+}
+
+func mockedLabelVersionsStore(testcase string) storage.Store {
+	switch testcase {
+	case happyPath:
+		return &mockstorage.StoreVersionedMock{
+			HasFunc: goodHasFunc,
+			KeysPrefixFunc: func(_ context.Context, _ string, _ string, _ string, _ int) ([]string, string, error) {
+				return []string{fakeLabelPath("myRepo", "myLabel")}, "", nil
+			},
+			KeysFunc: goodKeysFunc,
+			GetFunc:  goodGetLabelFunc,
+			KeyVersionsFunc: func(_ context.Context, _ string) ([]storage.Version, error) {
+				return []storage.Version{}
+			},
+		}
+	default:
+		return nil
+	}
+}
+
+func mockedLabelVersionsContextStores(scenario string) context2.Stores {
+	mockStore := mockedLabelVersionsStore(scenario)
+	return context2.NewStores(nil, nil, nil, mockStore, mockStore)
+}
+
+func testListLabelVersions(t *testing.T, concurrency int, i int) {
+	defer goleak.VerifyNone(t,
+		// opencensus stats collection goroutine
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+	for _, testcase := range labelVersionedTestCases() {
+
+		t.Run(fmt.Sprintf("ListLabelsApply-%s-%d-%d", testcase.name, concurrency, i), func(t *testing.T) {
+			//t.Parallel()
+			versions := make(string, 0, typicalReposNum)
+			err := ListLabelsApply(testcase.repo, mockedLabelVersionsContextStores(testcase.name),
+				ApplyLabelFunc{ToVersion: func(version string) error {
+					versions = append(versions, version)
+					return nil
+				}}, WithPrefix(""), ConcurrentList(concurrency), BatchSize(testBatchSize))
+			assertLabels(t, testcase, labels, err)
+		})
+
+	}
+}
+*/
 
 func TestListLabelVersions(t *testing.T) {
 	t.Skip("tbd")

--- a/pkg/core/mock_test.go
+++ b/pkg/core/mock_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/oneconcern/datamon/pkg/model"
+	"github.com/oneconcern/datamon/pkg/storage"
 	"gopkg.in/yaml.v2"
 )
 
@@ -95,6 +96,10 @@ func fakeLD(label string) model.LabelDescriptor {
 			{Email: "test2@example.com"},
 		},
 	}
+}
+
+func fakeLV(gcsGeneration int64) storage.Version {
+	return storage.NewVersionGcs(gcsGeneration)
 }
 
 func buildBundleYaml(id string) string {

--- a/pkg/core/options.go
+++ b/pkg/core/options.go
@@ -17,11 +17,17 @@ type Settings struct {
 	profilingEnabled bool
 	memProfDir       string
 
-	prefix string
-	label  string
+	prefixIsSet bool
+	prefix      string
+	vLabel      string
 
 	metrics.Enable
 	//m *M // TODO(fred): enable metrics for list operations
+}
+
+func (settings *Settings) listLabelsValid() bool {
+	prefixOrLabel := (settings.vLabel == "" && settings.prefixIsSet) || (settings.vLabel != "" && !settings.prefixIsSet)
+	return prefixOrLabel
 }
 
 const (
@@ -83,7 +89,7 @@ func WithMetrics(enabled bool) Option {
 // Precisely one of these options is expected to be applied.
 func WithLabel(label string) Option {
 	return func(s *Settings) {
-		s.label = label
+		s.vLabel = label
 	}
 }
 
@@ -91,6 +97,7 @@ func WithLabel(label string) Option {
 // Precisely one of these options is expected to be applied.
 func WithPrefix(prefix string) Option {
 	return func(s *Settings) {
+		s.prefixIsSet = true
 		s.prefix = prefix
 	}
 }

--- a/pkg/core/options.go
+++ b/pkg/core/options.go
@@ -17,6 +17,9 @@ type Settings struct {
 	profilingEnabled bool
 	memProfDir       string
 
+	prefix string
+	label  string
+
 	metrics.Enable
 	//m *M // TODO(fred): enable metrics for list operations
 }
@@ -73,6 +76,22 @@ func WithMemProf(memProfDir string) Option {
 func WithMetrics(enabled bool) Option {
 	return func(s *Settings) {
 		s.EnableMetrics(enabled)
+	}
+}
+
+// WithLabel is an option for ListLabelsApply along with WithPrefix.
+// Precisely one of these options is expected to be applied.
+func WithLabel(label string) Option {
+	return func(s *Settings) {
+		s.label = label
+	}
+}
+
+// WithPrefix is an option for ListLabelsApply along with WithLabel.
+// Precisely one of these options is expected to be applied.
+func WithPrefix(prefix string) Option {
+	return func(s *Settings) {
+		s.prefix = prefix
 	}
 }
 

--- a/pkg/core/repo_list.go
+++ b/pkg/core/repo_list.go
@@ -170,7 +170,11 @@ func listReposChan(stores context2.Stores, opts ...Option) (chan reposEvent, *sy
 	}
 	// starting keys retrieval
 	wg.Add(1)
-	go fetchKeys(iterator, keysChan, doneWithKeysChan, &wg) // scan for key batches
+	fetchKeysChans := fetchKeysChans{
+		keysChan:         keysChan,
+		doneWithKeysChan: doneWithKeysChan,
+	}
+	go fetchKeys(iterator, fetchKeysChans, &wg) // scan for key batches
 
 	// start repo metadata retrieval
 	wg.Add(1)

--- a/pkg/core/split_list.go
+++ b/pkg/core/split_list.go
@@ -181,7 +181,11 @@ func listSplitsChan(repo, diamondID string, stores context2.Stores, opts ...Opti
 
 	// starting keys retrieval
 	wg.Add(1)
-	go fetchKeys(iterator, unfilteredKeysChan, doneWithKeysChan, &wg) // scan for key batches
+	fetchKeysChans := fetchKeysChans{
+		keysChan:         unfilteredKeysChan,
+		doneWithKeysChan: doneWithKeysChan,
+	}
+	go fetchKeys(iterator, fetchKeysChans, &wg) // scan for key batches
 
 	// keys state filtering & merging
 	wg.Add(1)

--- a/pkg/storage/gcs/options.go
+++ b/pkg/storage/gcs/options.go
@@ -1,6 +1,9 @@
 package gcs
 
-import "go.uber.org/zap"
+import (
+	"github.com/oneconcern/datamon/pkg/storage"
+	"go.uber.org/zap"
+)
 
 // Option is a functor to pass optional parameters to the gcs store
 type Option func(*gcs)
@@ -11,5 +14,11 @@ func Logger(logger *zap.Logger) Option {
 		if logger != nil {
 			g.l = logger
 		}
+	}
+}
+
+func WithVersion(version storage.Version) Option {
+	return func(g *gcs) {
+		g.s.Version = version
 	}
 }

--- a/pkg/storage/gcs/store.go
+++ b/pkg/storage/gcs/store.go
@@ -13,6 +13,7 @@ import (
 	gcsStorage "cloud.google.com/go/storage"
 
 	"github.com/oneconcern/datamon/pkg/dlogger"
+	"github.com/oneconcern/datamon/pkg/errors"
 	"github.com/oneconcern/datamon/pkg/storage"
 	storagestatus "github.com/oneconcern/datamon/pkg/storage/status"
 	"google.golang.org/api/option"
@@ -24,6 +25,7 @@ type gcs struct {
 	bucket         string
 	ctx            context.Context
 	l              *zap.Logger
+	s              storage.Settings
 }
 
 func clientOpts(readOnly bool, credentialFile string) []option.ClientOption {
@@ -39,11 +41,29 @@ func clientOpts(readOnly bool, credentialFile string) []option.ClientOption {
 	return opts
 }
 
-// New builds a new storage object from a bucket string
-func New(ctx context.Context, bucket string, credentialFile string, opts ...Option) (storage.Store, error) {
+// versionedObject wraps *BucketHandle.Object
+// towards canonicalization of object names.
+func versionedObject(
+	bucketHandle *gcsStorage.BucketHandle,
+	objectName string,
+) *gcsStorage.ObjectHandle {
+	return bucketHandle.Object(objectName)
+}
+
+// implNew provides stricter typing than New for package internal tests.
+// Akin to the impl* functions in pkg/core/bundle.go, this function is in place
+// in order to be extended with additional parameters and/or return values
+// independently of the public interface provided by New.
+func implNew(ctx context.Context, bucket string, credentialFile string, opts ...Option) (*gcs, error) {
 	googleStore := new(gcs)
 	for _, apply := range opts {
 		apply(googleStore)
+	}
+	{
+		generationNumber := googleStore.s.Version.GcsVersion()
+		if generationNumber < 0 && generationNumber != storage.GcsSentinelVersion {
+			return nil, errors.New("invalid version")
+		}
 	}
 	if googleStore.l == nil {
 		googleStore.l, _ = dlogger.GetLogger("info")
@@ -64,6 +84,11 @@ func New(ctx context.Context, bucket string, credentialFile string, opts ...Opti
 	return googleStore, nil
 }
 
+// New builds a new storage object from a bucket string
+func New(ctx context.Context, bucket string, credentialFile string, opts ...Option) (storage.Store, error) {
+	return implNew(ctx, bucket, credentialFile, opts...)
+}
+
 func (g *gcs) String() string {
 	return "gcs://" + g.bucket
 }
@@ -71,7 +96,7 @@ func (g *gcs) String() string {
 // Has this object in the store?
 func (g *gcs) Has(ctx context.Context, objectName string) (bool, error) {
 	client := g.readOnlyClient
-	_, err := client.Bucket(g.bucket).Object(objectName).Attrs(ctx)
+	_, err := versionedObject(client.Bucket(g.bucket), objectName).Attrs(ctx)
 	if err != nil {
 		if err == gcsStorage.ErrObjectNotExist {
 			return false, nil
@@ -110,8 +135,8 @@ func (r *gcsReader) ReadAt(p []byte, offset int64) (n int, err error) {
 	defer func() {
 		r.l.Debug("End ReadAt", zap.Int("chunk size", len(p)), zap.Int64("offset", offset), zap.Int("bytes read", n), zap.Error(err))
 	}()
-	objectReader, err := r.g.readOnlyClient.Bucket(r.g.bucket).Object(r.objectName).NewRangeReader(
-		r.g.ctx, offset, int64(len(p)))
+	objectReader, err := versionedObject(r.g.readOnlyClient.Bucket(r.g.bucket), r.objectName).
+		NewRangeReader(r.g.ctx, offset, int64(len(p)))
 	if err != nil {
 		return 0, toSentinelErrors(err)
 	}
@@ -120,7 +145,7 @@ func (r *gcsReader) ReadAt(p []byte, offset int64) (n int, err error) {
 
 func (g *gcs) Get(ctx context.Context, objectName string) (io.ReadCloser, error) {
 	g.l.Debug("Start Get", zap.String("objectName", objectName))
-	objectReader, err := g.readOnlyClient.Bucket(g.bucket).Object(objectName).NewReader(ctx)
+	objectReader, err := versionedObject(g.readOnlyClient.Bucket(g.bucket), objectName).NewReader(ctx)
 	g.l.Debug("End Get", zap.String("objectName", objectName), zap.Error(err))
 	if err != nil {
 		return nil, toSentinelErrors(err)
@@ -134,7 +159,7 @@ func (g *gcs) Get(ctx context.Context, objectName string) (io.ReadCloser, error)
 
 func (g *gcs) GetAttr(ctx context.Context, objectName string) (storage.Attributes, error) {
 	g.l.Debug("Start GetAttr", zap.String("objectName", objectName))
-	attr, err := g.readOnlyClient.Bucket(g.bucket).Object(objectName).Attrs(ctx)
+	attr, err := versionedObject(g.readOnlyClient.Bucket(g.bucket), objectName).Attrs(ctx)
 	g.l.Debug("End GetAttr", zap.String("objectName", objectName), zap.Error(err))
 	if err != nil {
 		return storage.Attributes{}, toSentinelErrors(err)
@@ -156,7 +181,8 @@ func (g *gcs) GetAt(ctx context.Context, objectName string) (io.ReaderAt, error)
 
 func (g *gcs) Touch(ctx context.Context, objectName string) error {
 	g.l.Debug("Start Touch", zap.String("objectName", objectName))
-	_, err := g.client.Bucket(g.bucket).Object(objectName).Update(ctx, gcsStorage.ObjectAttrsToUpdate{})
+	_, err := versionedObject(g.client.Bucket(g.bucket), objectName).
+		Update(ctx, gcsStorage.ObjectAttrsToUpdate{})
 	g.l.Debug("End touch", zap.String("objectName", objectName), zap.Error(err))
 	return toSentinelErrors(err)
 }
@@ -185,11 +211,11 @@ func (g *gcs) Put(ctx context.Context, objectName string, reader io.Reader, newO
 		b = true
 	}
 	if newObject {
-		writer = g.client.Bucket(g.bucket).Object(objectName).If(gcsStorage.Conditions{
+		writer = versionedObject(g.client.Bucket(g.bucket), objectName).If(gcsStorage.Conditions{
 			DoesNotExist: b,
 		}).NewWriter(ctx)
 	} else {
-		writer = g.client.Bucket(g.bucket).Object(objectName).NewWriter(ctx)
+		writer = versionedObject(g.client.Bucket(g.bucket), objectName).NewWriter(ctx)
 	}
 	g.l.Debug("Start Put PipeIO", zap.String("objectName", objectName))
 	_, err = storage.PipeIO(writer, readCloser{reader: reader})
@@ -209,11 +235,11 @@ func (g *gcs) PutCRC(ctx context.Context, objectName string, reader io.Reader, d
 	// Put if not present
 	var writer *gcsStorage.Writer
 	if doesNotExist {
-		writer = g.client.Bucket(g.bucket).Object(objectName).If(gcsStorage.Conditions{
+		writer = versionedObject(g.client.Bucket(g.bucket), objectName).If(gcsStorage.Conditions{
 			DoesNotExist: doesNotExist,
 		}).NewWriter(ctx)
 	} else {
-		writer = g.client.Bucket(g.bucket).Object(objectName).NewWriter(ctx)
+		writer = versionedObject(g.client.Bucket(g.bucket), objectName).NewWriter(ctx)
 	}
 	writer.CRC32C = crc
 	g.l.Debug("Start PutCRC PipeIO", zap.String("objectName", objectName))
@@ -228,7 +254,11 @@ func (g *gcs) PutCRC(ctx context.Context, objectName string, reader io.Reader, d
 
 func (g *gcs) Delete(ctx context.Context, objectName string) (err error) {
 	g.l.Debug("Start Delete", zap.String("objectName", objectName))
-	err = toSentinelErrors(g.client.Bucket(g.bucket).Object(objectName).Delete(ctx))
+	obj := versionedObject(g.client.Bucket(g.bucket), objectName)
+	if ver := g.s.Version.GcsVersion(); ver != storage.GcsSentinelVersion {
+		obj = obj.Generation(ver)
+	}
+	err = toSentinelErrors(obj.Delete(ctx))
 	g.l.Debug("End Delete", zap.String("objectName", objectName), zap.Error(err))
 	return
 }
@@ -257,21 +287,31 @@ func (g *gcs) Keys(ctx context.Context) (keys []string, err error) {
 	return keys, nil
 }
 
-func (g *gcs) KeysPrefix(ctx context.Context, pageToken string, prefix string, delimiter string, count int) (keys []string, next string, err error) {
-	g.l.Debug("Start KeysPrefix", zap.String("start", pageToken), zap.String("prefix", prefix))
+func (g *gcs) KeysPrefix(
+	ctx context.Context,
+	pageToken string,
+	prefix string,
+	delimiter string,
+	count int,
+) (keys []string, next string, err error) {
+	logger := g.l.With(
+		zap.String("start", pageToken),
+		zap.String("prefix", prefix),
+		zap.Int("keys", len(keys)),
+		zap.Error(err))
+	logger.Debug("Start KeysPrefix")
 	defer func() {
-		g.l.Debug("End KeysPrefix", zap.String("start", pageToken), zap.String("prefix", prefix), zap.Int("keys", len(keys)), zap.Error(err))
+		logger.Debug("End KeysPrefix")
 	}()
+
 	itr := g.readOnlyClient.Bucket(g.bucket).Objects(ctx, &gcsStorage.Query{Prefix: prefix, Delimiter: delimiter})
-
 	var objects []*gcsStorage.ObjectAttrs
-
-	keys = make([]string, 0, count)
 	next, err = iterator.NewPager(itr, count, pageToken).NextPage(&objects)
 	if err != nil {
 		return nil, "", toSentinelErrors(err)
 	}
 
+	keys = make([]string, 0, count)
 	for _, objAttrs := range objects {
 		if objAttrs.Prefix != "" {
 			keys = append(keys, objAttrs.Prefix)
@@ -280,6 +320,42 @@ func (g *gcs) KeysPrefix(ctx context.Context, pageToken string, prefix string, d
 		}
 	}
 	return
+}
+
+func (g *gcs) KeyVersions(ctx context.Context, key string) ([]storage.Version, error) {
+	//	var err error
+	logger := g.l.With(zap.String("key", key))
+	logger.Debug("start KeyVersions")
+
+	versionsPrefix := func(pageToken string) ([]storage.Version, string, error) {
+		const versionsPerPage = 100
+		itr := g.readOnlyClient.Bucket(g.bucket).Objects(ctx, &gcsStorage.Query{Prefix: key, Versions: true})
+		var objects []*gcsStorage.ObjectAttrs
+		nextPageToken, err := iterator.NewPager(itr, versionsPerPage, pageToken).NextPage(&objects)
+		if err != nil {
+			return nil, "", toSentinelErrors(err)
+		}
+		versions := make([]storage.Version, 0, versionsPerPage)
+		for _, objAttrs := range objects {
+			versions = append(versions, storage.NewVersionGcs(objAttrs.Generation))
+		}
+		return versions, nextPageToken, nil
+	}
+
+	pageToken := ""
+	versions := make([]storage.Version, 0)
+	for {
+		versionsCurr, pageToken, err := versionsPrefix(pageToken)
+		if err != nil {
+			return nil, toSentinelErrors(err)
+		}
+		versions = append(versions, versionsCurr...)
+		if pageToken == "" {
+			break
+		}
+	}
+
+	return versions, nil
 }
 
 func (g *gcs) Clear(context.Context) error {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -5,6 +5,7 @@ package storage
 import (
 	"context"
 	"io"
+	"strconv"
 	"time"
 )
 
@@ -33,27 +34,91 @@ type Attributes struct {
 // Implementations of this interface are assumed to be fairly simple.
 type Store interface {
 	String() string
+	// Has this object in the store?
 	Has(context.Context, string) (bool, error)
+	// Get this object's backing bytes.
 	Get(context.Context, string) (io.ReadCloser, error)
+	// GetAttr looks up the Attributes of this object.
 	GetAttr(context.Context, string) (Attributes, error)
+	// Get this object's backing bytes.
 	GetAt(context.Context, string) (io.ReaderAt, error)
+	// Touch, like the usual *nix verb, touch(1), changes the object's modify time.
+	// Unlike touch(1), it does _not_ create an object if it doesn't exist.
 	Touch(context.Context, string) error
+	// Put writes bytes to a named object in the store.
 	Put(context.Context, string, io.Reader, bool) error
+	// Delete removes the specified object from the store.
+	// ??? design affordances re. versions? e.g. --
+	// - opt to remove all versons
+	// - opt (or different function elsewhere) to rollback to previous version?
 	Delete(context.Context, string) error
+	// ??? what's the intent of this function, again?
 	Clear(context.Context) error
 
 	// Keys returns all keys known to the store.
-	// Depending on the implementation, some limit may exist on the maximum number of such returned keys
+	// Depending on the implementation, some limit on the maximum number
+	// of such returned keys may exist.
 	Keys(context.Context) ([]string, error)
 
 	// KeyPrefix provides a paginated key iterator using "pageToken" as the next starting point
-	KeysPrefix(ctx context.Context, pageToken string, prefix string, delimiter string, count int) ([]string, string, error)
+	KeysPrefix(
+		ctx context.Context,
+		pageToken string,
+		prefix string,
+		delimiter string,
+		count int,
+	) ([]string, string, error)
 }
 
 // StoreCRC knows how to update an object with a computed CRC checksum
 type StoreCRC interface {
 	PutCRC(context.Context, string, io.Reader, bool, uint32) error
 }
+
+const (
+	// GcsSentinelVersion happens to be the sentinel value used by the google-cloud-go library,
+	// not a constant used by the GCS api.  Yet it is so named for consistency with datamon
+	// internal api and because, for cleaner seperation of concerns, the datamon codebase
+	// does not pre-suppose that this google-cloud-go-internal value will not change
+	// sometime in the future, although we wouldn't mind if the google-cloud-go library
+	// made the constant publicly visible.
+	GcsSentinelVersion = -1
+)
+
+type Version struct {
+	gcsGeneration int64
+}
+
+func (version *Version) String() string {
+	return strconv.FormatInt(version.gcsGeneration, 10)
+}
+
+func (version *Version) GcsVersion() int64 {
+	if version.gcsGeneration != 0 {
+		return version.gcsGeneration
+	}
+	return GcsSentinelVersion
+}
+
+type StoreVersioned interface {
+	// KeyVersions returns all versions of a given key
+	// operating assumptions:
+	// * versions are strings (likely true)
+	// * paging is unnecessary (likely false)
+	KeyVersions(context.Context, string) ([]Version, error)
+}
+
+func NewVersionGcs(gcsGeneration int64) Version {
+	return Version{
+		gcsGeneration: gcsGeneration,
+	}
+}
+
+type Settings struct {
+	Version Version
+}
+
+///
 
 // PipeIO copies data from a reader to a writer using io.Pipe
 func PipeIO(writer io.Writer, reader io.Reader) (n int64, err error) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -9,8 +9,7 @@ import (
 	"time"
 )
 
-//go:generate moq -out ./mockstorage/store.go -pkg mockstorage . Store
-//go:generate moq -out ./mockstorage/store_versioned.go -pkg mockstorage . StoreVersioned Store
+//go:generate moq -out ./mockstorage/store.go -pkg mockstorage . Store StoreVersioned
 
 const (
 	// Adding these to make code more readable when looking at Put Call

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -10,6 +10,7 @@ import (
 )
 
 //go:generate moq -out ./mockstorage/store.go -pkg mockstorage . Store
+//go:generate moq -out ./mockstorage/store_versioned.go -pkg mockstorage . StoreVersioned Store
 
 const (
 	// Adding these to make code more readable when looking at Put Call


### PR DESCRIPTION
apply gcs version functionality from #419 to datamon labels, specifically, at the `pkg/core` level of abstraction, the layer nearest to and distinct from the ui
