### PR TITLE
Doc sidecar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,8 +241,11 @@ commands:
       - run:
           name: Add CircleCI IP to whitelist
           command: |
-            CIRCLE_CI_IP=$(curl -sSL https://checkip.amazonaws.com)
-            gcloud container clusters update --zone ${GOOGLE_COMPUTE_ZONE} ${CLUSTER} --enable-master-authorized-networks --master-authorized-networks ${ALLOWED_NETWORKS},$CIRCLE_CI_IP/32
+            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
+            ALREADY="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. == "'"${CIRCLE_CI_IP}"'/32"))|.[]')"
+            if [ -z "${ALREADY}" ] ; then
+              gcloud container clusters update --zone ${GOOGLE_COMPUTE_ZONE} ${CLUSTER} --enable-master-authorized-networks --master-authorized-networks ${ALLOWED_NETWORKS},$CIRCLE_CI_IP/32
+            fi
 
   remove_whitelist_ip:
     steps:
@@ -250,20 +253,7 @@ commands:
           name: Remove previously added CircleCI IP from whitelist
           command: |
             set -x -o pipefail
-            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
-            PREVIOUS="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. != "'"${CIRCLE_CI_IP}"'/32"))|tostring|sub("[\"\\[\\]]";"";"g")')"
-            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "$(eval echo "${PREVIOUS}")"
-
-  remove_whitelist_ip_on_fail:
-    steps:
-      - run:
-          when: on_fail
-          name: Remove previously added CircleCI IP from whitelist (when failed)
-          command: |
-            set -x -o pipefail
-            CIRCLE_CI_IP="$(curl -sSL https://checkip.amazonaws.com)"
-            PREVIOUS="$(gcloud container clusters describe --zone "${GOOGLE_COMPUTE_ZONE}" --format json "${CLUSTER}"|jq -c '{net: .masterAuthorizedNetworksConfig.cidrBlocks}|.net|map(.cidrBlock)|map(select(. != "'"${CIRCLE_CI_IP}"'/32"))|tostring|sub("[\"\\[\\]]";"";"g")')"
-            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "$(eval echo "${PREVIOUS}")"
+            gcloud container clusters update --zone "${GOOGLE_COMPUTE_ZONE}" "${CLUSTER}" --enable-master-authorized-networks --master-authorized-networks "${ALLOWED_NETWORKS}"
 
 jobs:
   go_lint:
@@ -443,7 +433,6 @@ jobs:
           name: Delete k8s resources for sidecar demo
           command: |
             make clean-fuse-demo
-      - remove_whitelist_ip_on_fail
 
   pg_sidecar_test:
     executor: docker_builder
@@ -464,7 +453,6 @@ jobs:
           name: Delete k8s resources for sidecar demo
           command: |
             make clean-pg-demo
-      - remove_whitelist_ip_on_fail
 
   build_images:
     executor: docker_builder
@@ -556,7 +544,6 @@ jobs:
     steps:
       - setup_remote_docker:
           version: 18.09.3
-      - install_base
       - login_to_google
       - remove_whitelist_ip
 

--- a/docs/proposals/sidecar-analysis.md
+++ b/docs/proposals/sidecar-analysis.md
@@ -1,4 +1,4 @@
-# Sidecar analyss 
+# Sidecar analysis
 
 ## Primer
 
@@ -10,7 +10,7 @@ Any of the implemented sidecars:
 * Only supports one linear workflow: load, update, save
 * Has most of its code and complexity for parameters handling
 * Is a zsh daemon shell script.
-  There is not real justification for using this uncommon shell. 
+  There is not real justification for using this uncommon shell.
   This seemed to boil down to the use of associative arrays, which also work in bash.
 * Relies on a central bourne shell script (wrapper) to operate the load/save workflow with datamon
 
@@ -39,7 +39,7 @@ Current fuse sicar:
 
 ## Short term corrective actions
 
-We cannot afford a full rewrite in the short term. 
+We cannot afford a full rewrite in the short term.
 We want to avoid altering the fuse sidecar as much as possible since that one is allegedly working.
 
 I want to alleviate much of our CI issues that come from the sidecar demos (long runs, CI credits consumption, unstable behavior)
@@ -50,11 +50,12 @@ Here are the many minor fixes brought by PR#428.
 * CI:
   * Overhauled Dockerfiles and image tagging: CI can build faster
   * All images are debian based, with same version ; postgres is installed locally from a debian package, not a docker image
-  * Convenience builder images are updated on a weekly basis
   * Removed redundant builds during CI jobs
   * Added trailing CI tasks to ensure k8s resources are relinquished
   * Changed the layout of the CI workflow to avoid starting the k8 jobs too early
   * Every CI run creates kubernetes resources which are unique to this run
+  * ~~Convenience builder images are updated on a weekly basis~~ (removed)
+  * added IP whitelisting to deploy k8s demos on 1C cluster
 
 * pg k8 demo
   * Replaced env-based parameterization by k8s configmap objects and YAML parsing inside the sidecar
@@ -76,9 +77,6 @@ Here are the many minor fixes brought by PR#428.
 * fuse sidecar
   * Adapted k8 template to use dedicated namespace and create k8 resources that are unique to a CI run
   * Phased out demo-specific sidecar image: demo runs on regular builds
-
-TODOs:
-  * [ ] Weekly builds should run the entire test suite to detect incompatible upgrades
 
 ## Longer term corrective actionss
 

--- a/docs/proposals/sidecar-analysis.md
+++ b/docs/proposals/sidecar-analysis.md
@@ -1,0 +1,92 @@
+# Sidecar analyss 
+
+## Primer
+
+Datamon sidecars come in two flavors: fuse mount and postgres.
+
+## Lessons learned
+
+Any of the implemented sidecars:
+* Only supports one linear workflow: load, update, save
+* Has most of its code and complexity for parameters handling
+* Is a zsh daemon shell script.
+  There is not real justification for using this uncommon shell. 
+  This seemed to boil down to the use of associative arrays, which also work in bash.
+* Relies on a central bourne shell script (wrapper) to operate the load/save workflow with datamon
+
+CI is also a concern:
+* These are very long to build (builds many times the same thing)
+* Sidecar "demo" jobs do not play well with CI (long builds, long runs, sensitive to parallel runs, possible infinite loops, does not relinquish k8s resources)
+* No linting job supported on zsh
+
+Current pg sidecar:
+* is essentially bereft of practical usage documentation
+* is _very_ difficult to parameterize, with no sensible default values
+* was designed to run _several_ databases in a single container
+* was made essentially for demo
+* the raw demo essentially does nothing and needs a lot of extra parameters to demonstrate anything useful
+* has many untested paths, which don't work
+* ignores most postgres utilities and manages processes directly
+* relies on datamon fuse mount (performance, and questionable support for all syscalls from the database)
+* makes up a tar archive of the raw dabase files, doubling the required storage to prepare an upload
+* the k8 demo parameterization job is basically a bespoke helm (e.g. replacing env in template)
+* contains a lot of stuff about running non-root, but this eventually doesn't work and is not used
+* is not aware of datamon changes regarding auth (email, user in config)
+* has no solution for database version upgrades
+
+Current fuse sicar:
+* relies on a specific binary sidecar_param, to unfold a yaml document as env variables
+
+## Short term corrective actions
+
+We cannot afford a full rewrite in the short term. 
+We want to avoid altering the fuse sidecar as much as possible since that one is allegedly working.
+
+I want to alleviate much of our CI issues that come from the sidecar demos (long runs, CI credits consumption, unstable behavior)
+AND to actually demonstrate a workable postgres sidecar. This lead to a couple thoughts described [here](sidecar-design.md).
+
+Here are the many minor fixes brought by PR#428.
+
+* CI:
+  * Overhauled Dockerfiles and image tagging: CI can build faster
+  * All images are debian based, with same version ; postgres is installed locally from a debian package, not a docker image
+  * Convenience builder images are updated on a weekly basis
+  * Removed redundant builds during CI jobs
+  * Added trailing CI tasks to ensure k8s resources are relinquished
+  * Changed the layout of the CI workflow to avoid starting the k8 jobs too early
+  * Every CI run creates kubernetes resources which are unique to this run
+
+* pg k8 demo
+  * Replaced env-based parameterization by k8s configmap objects and YAML parsing inside the sidecar
+  * Removed many demo-specific options
+
+* pg sidecar
+  * Ported all pg-related scripts to bash - these scripts are now covered by linter checks
+  * Introduced sensible defaults for most parameters (default to one single db, mount point, port number, locations, etc)
+  * Covered the use case of thrown away, read-only databases (you just don't specify any destination repo)
+  * Used standard postgres start/stop utilities. Removed the bespoke PID handling.
+  * Adapted to run as non-root, as initially intended, but unfinished
+  * Made any pg sidecar run only one database server (a server can publish several databases): parameterization is simpler
+  * Removed most of the pg parameterization logic and replaced this by a (publicly available) basic yaml parser for shell
+  * Adapted coordination logic to support several pg sidecars from the same application wrapper
+  * Removed fuse mount usage for postgres and replaced by download/upload
+  * Removed usage of tar and copy of database files: download/upload operations are carried out in place
+  * Introduced different test scenarios in the mock application
+
+* fuse sidecar
+  * Adapted k8 template to use dedicated namespace and create k8 resources that are unique to a CI run
+  * Phased out demo-specific sidecar image: demo runs on regular builds
+
+TODOs:
+  * [ ] Weekly builds should run the entire test suite to detect incompatible upgrades
+
+## Longer term corrective actionss
+
+Despite its weight, PR#428 has left behind quite a number of unsolved issues.
+
+* [ ] 12 factor-app parameterization, which is difficult to achieve in shell and easy in go (some would prefer python, though)
+* [ ] Sidecar_param binary is essentially overlapping with golang sp13/viper: a golang-based sidecar wouldn't need that, just viper
+* [ ] Adapt wrapper logic to support many sidecars, including a mix of fuse & postgres ones
+* [ ] Adapt wrapper logic to support other workflows, such as "only read, don't update"
+* [ ] Take actual provisions to handle postgres version migrations
+* [ ] Handle errors gracefully & allow for out of band signaling: the "application wrapper" should stop when sidecars fail

--- a/docs/sidecar-design.md
+++ b/docs/sidecar-design.md
@@ -1,0 +1,184 @@
+# Datamon sidecar design
+
+This document describes the current design of datamon sidecars.
+
+<!-- Ideas to improve this design may be found [here](proposals/sidecar-design.md) -->
+
+## Design
+
+The current design favors the sidecar container approach, with bespoke signaling between containers,
+over the CSI driver approach. Therefore,  datamon is not available as a kubernetes persistent volume plugin.
+
+This design choice stems from the current inability by Kubernetes CSI API to handle ephemeral volumes.
+Managing many short lived kubernetes volumes is at the moment not practical.
+
+Signaling is implemented with files on a shared volume.
+
+## Sidecar signaling
+
+We need some coordination between the different containers running in the pod.
+
+In particular, we need to keep the pod running and the sidecars to finish uploading
+results when the main ARGO workflow is done processing.
+
+Ensuring that data is ready for access (sidecar to main-container messaging)
+as well as notification that the data-science program has
+produced output data to upload (main-container to sidecar messaging),
+is the responsibility of a few shell scripts shipped as part and parcel of the
+Docker images that practicably constitute sidecars.
+
+The coordination signaling defines the following protocol:
+
+### File system mount (`fuse`)
+
+| main(`wrap_application.sh`) | sidecar (`wrap_datamon.sh`) | what happens |
+|-----------------------------|-----------------------------|--------------|
+|                | <= mountdone  | application waits for input bundles to be mounted |
+|                |               | (do some work...)                                 |
+| initupload  => |               | datamon starts running the upload commands        |
+|                | <= uploaddone | application waits until its output is archived    |
+
+### Postgres SQL
+
+A similar process is iterated through all configured datamon-postgres sidecars.
+
+| main(`wrap_application.sh`) | sidecar (`wrap_datamon_pg.sh`) | what happens |
+|-----------------------------|-----------------------------|--------------|
+|                 | <= dbstarted    | application waits for the DB instance to be ready |
+|                 |                 | (do some work...)                                 |
+| initdbupload => |                 | datamon archives the database as a bundle         |
+|                 | <= dbuploaddone | application waits until its output is archived    |
+
+<!-- Internal notes -->
+<!--
+ While there's precisely one application container per Argo node,
+a Kubernetes container created from an arbitrary image,
+sidecars are additional containers in the same Kubernetes pod
+-- or Argo DAG node, we can say, approximately synonymously --
+that concert datamon-based data-ferrying setups with the application container.
+
+> _Aside_: as additional kinds of data sources and sinks are added,
+> we may also refer to "sidecars" as "batteries," and so on as semantic drift
+> of the shell scripts shears away feature creep in the application binary.
+-->
+
+<!-- Internal notes -->
+<!--
+> _Aside_: historically, and in case it's necessary to roll back to an now-ancient
+> version of the sidecar image, releases were tagged in git without the `v` prefix,
+> and Docker tags prepended `v` to the git tag.
+> For instance, `0.4` is listed on the github releases page, while
+> the tag `v0.4` as in `gcr.io/onec-co/datamon-fuse-sidecar:v0.4` was used when writing
+> Dockerfiles or Kubernetes-like YAML to accesses the sidecar container image.
+-->
+
+## Sidecar usage
+
+Users need only place the `wrap_application.sh` script located in the root directory of the main container.
+This
+[can be accomplished](https://github.com/oneconcern/datamon/blob/master/hack/k8s/example-coord.template.yaml#L15-L24)
+via an `initContainer` without duplicating version of the Datamon sidecar
+image in both the main application Dockerfile as well as the YAML.
+When using a block-storage GCS product, we might've specified a data-science application's
+Argo DAG node with something like
+
+```yaml
+command: ["app"]
+args: ["param1", "param2"]
+```
+
+whereas with `wrap_application.sh` in place, this would be something to the effect of
+
+```yaml
+command: ["/path/to/wrap_application.sh"]
+args: ["-c", "/path/to/coordination_directory", "-b", "fuse", "--", "app", "param1", "param2"]
+```
+
+That is, `wrap_application.sh` has the following usage
+
+```shell
+wrap_application.sh -c <coordination_directory> -b <sidecar_kind> -- <application_command>
+```
+
+where
+* `<coordination_directory>` is an empty directory in a shared volume
+  (an
+  [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+  using memory-backed storage suffices).  each coordination directory (not necessarily the volume)
+  corresponds to a particular DAG node (i.e. Kubernetes pod) and vice-versa.
+* `<sidecar_kind>` is in correspondence with the containers specified in the YAML
+  and may be among
+  - `fuse`
+  - `postgres`
+* `<application_command>` is the data-science application command exactly as it
+  would appear without the wrapper script.  That is, the wrapper script, relies the
+  [conventional UNIX syntax](http://zsh.sourceforge.net/Guide/zshguide02.html#l11)
+  for stating that options to a command are done being declared.
+
+Meanwhile, each sidecar's datamon-specific batteries have their corresponding usages.
+
+##### `gcr.io/onec-co/datamon-fuse-sidecar` -- `wrap_datamon.sh`
+
+Provides filesystem representations (i.e. a folder) of [datamon bundles](#data-modeling).
+Since bundles' filelists are serialized filesystem representations,
+the `wrap_datamon.sh` interface is tightly coupled to that of the self-documenting
+`datamon` binary itself.
+
+```shell
+./wrap_datamon.sh -c <coord_dir> -d <bin_cmd_I> -d <bin_cmd_J> ...
+```
+
+* `-c` the same coordination directory passed to `wrap_application.sh`
+* `-d` all parameters, exactly as passed to the datamon binary, except as a
+  single scalar (quoted) parameter, for one of the following commands
+  - `config` sets user information associated with any bundles created by the node
+  - `bundle mount` provides sources for data-science applications
+  - `bundle upload` provides sinks for data-science applications
+
+Multiple (or none) `bundle mount` and `bundle upload` commands may be specified,
+and at most one `config` command is allowed so that an example `wrap_datamon.sh`
+YAML might be
+
+```yaml
+command: ["./wrap_datamon.sh"]
+args: ["-c", "/tmp/coord", "-d", "config create", "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo", "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream"]
+```
+
+or from the shell
+
+```shell
+./wrap_datamon.sh -c /tmp/coord -d 'config create' -d 'bundle upload --path /tmp/upload --message "result of container coordination demo" --repo ransom-datamon-test-repo --label coordemo' -d 'bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream'
+```
+
+----
+
+_Aside on serialization format_
+
+Each of these environment variables each contain a serialized dictionary
+according the the following format
+
+```
+<entry_sperator><key_value_seperator><entry_1><entry_seperator><entry_2>...
+```
+
+where `<entry_sperator>` and `<key_value_seperator>` are each a single
+character, anything other than a `.`, and each `<entry>` is of one of
+two forms, either `<option>` or `<option><key_value_seperator><arg>`.
+
+So for example
+
+```
+;:a;b:c
+```
+
+expresses something like a Python map
+
+```python
+{'a': True, 'b' : 'c'}
+```
+
+or shell option args
+
+```
+<argv0> -a -b c
+```

--- a/docs/sidecar-design.md
+++ b/docs/sidecar-design.md
@@ -9,10 +9,12 @@ This document describes the current design of datamon sidecars.
 The current design favors the sidecar container approach, with bespoke signaling between containers,
 over the CSI driver approach. Therefore,  datamon is not available as a kubernetes persistent volume plugin.
 
-This design choice stems from the current inability by Kubernetes CSI API to handle ephemeral volumes.
+This design choice stems from the current inability on GKE to handle Kubernetes ephemeral volumes
+([v1.16 feature](https://kubernetes.io/docs/concepts/storage/volumes/#csi-ephemeral-volumes)).
 Managing many short lived kubernetes volumes is at the moment not practical.
+When GKE eventually makes Kubernetes v1.16 available, we may revive our attempt to make a CSI driver for datamon.
 
-Signaling is implemented with files on a shared volume.
+The sidecar approach requires a coordination between containers. Signaling is implemented with files on a shared volume.
 
 ## Sidecar signaling
 

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -1,87 +1,692 @@
-# Kubernetes sidecar guide
+# Datamon sidecar guide
 
 ## Goal
 
-The objective is to expose persistent data at rest to a consuming application running in a kubernetes pod.
+The objective is to expose persistent data at rest to a consuming application running in a kubernetes pod,
+leveraging datamon's features:
+* data versioned and tags as whole consistent data sets
+* high throughput, with parallel I/Os
+* deduplicated storage, to further improve I/O performance
 
-Consumed inputs are dowloaded then mounted read-only. Producted outputs are uploaded in their archived state.
-
-## Design
+Consumed inputs are downloaded, then mounted as read-only volumes.
+After the application has produced its outputs, the sidecar container uploads the results to GCS as datamon bundles.
 
 This data presentation layer is part of the "batteries" feature.
 
-The current design favors the sidecar container approach, with bespoke signaling between containers,
-over the CSI driver approach. Therefore,  datamon is not available as a kubernetes persistent volume plugin.
+## Use-cases
 
-This design choice stems from the current inability by Kubernetes CSI API to handle ephemeral volumes.
-Managing many short lived kubernetes volumes is at the moment not practical.
+The sidecar implementation is primarily intended to be used by ARGO workflows.
 
-Signaling is implemented with files on a shared volume.
+* The ARGO controller starts a pod to run a data science application in the "main container".
+* Workflow settings specify some input and output volumes
+* When the application is done, the output is persisted
+* The controller stops the pod by signaling all containers
 
-## Datamon as a sidecar
+ARGO brings native support to carry out this process for `S3` and `GCS` storage buckets.
+The datamon sidecar feature is about augmenting this to support datamon-backed storage (e.g. on top of `GCS`),
+including database servers.
 
-We focus on the use case of some ARGO worflow running some data-science program in a pod,
-which both consumes and produces versioned data as datamon bundles.
+> **NOTE**: the sidecar utility does make any assumption about the pod's environment and may be used with any
+> containerized environment.
 
-Versioned data is available either as a file system mount or as a Postgres instance running in a _sidecar container_.
+### Working with data sets stored as plain files
 
-The main ARGO container communicates with the sidecar container via
-[shared volumes on the same pod](https://kubernetes.io/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/).
+This use case is addressed by the "datamon-fuse-sidecar" container.
 
-After this program has produced its outputs, the sidecar container uploads the results to GCS as datamon bundles.
+* Both inputs and outputs are specified as _volume mounts_ with their corresponding datamon location:
+  (context, repo, bundle or label)
+* Datamon mounts input as _read-only_ fuse file systems, exposed to all containers in the pod
+* Outputs are plain volumes (provisioned with sufficient local disk space) which are _uploaded_ by datamon upon
+  completion of the main application
 
-## Sidecar signaling
 
-We need some coordination between the different containers running in the pod.
+### Working with data sets stored in a Postgres RDBMS
 
-In particular, we need to keep the pod running and the sidecars to finish uploading
-results when the main ARGO workflow is done processing.
+This use case is addressed by the "datamon-pg-sidecar" container.
 
-Ensuring that data is ready for access (sidecar to main-container messaging)
-as well as notification that the data-science program has
-produced output data to upload (main-container to sidecar messaging),
-is the responsibility of a few shell scripts shipped as part and parcel of the
-Docker images that practicably constitute sidecars.
+* Both inputs and outputs are specified as _Postgres database servers_ (i.e a port)
+* Database files are first downloaded by datamon, then a Postgres server is spun up in the sidecar container
+* A staging volume has to be provisioned with sufficient local disk space to hold the database
+* When the main application completes, the sidecar takes over, shuts down the database then upload the files
+  to the target datamon location (context, repo[, label])
 
-The coordination signaling defines the following protocol:
+## Sidecars features and limitations
 
-### File system mount (`fuse`)
+More on the [design of datamon sidecars](sidecar-design.md).
 
-| main(`wrap_application.sh`) | sidecar (`wrap_datamon.sh`) | what happens |
-|-----------------------------|-----------------------------|--------------|
-|                | <= mountdone  | application waits for input bundles to be mounted |
-|                |               | (do some work...)                                 |
-| initupload  => |               | datamon starts running the upload commands        |
-|                | <= uploaddone | application waits until its output is archived    |
+### Application wrapper
 
-### Postgres SQL
+The application wrapper is a small Bourne shell script that wraps around your main application to do 3 things:
+1. Wait until all declared input data is available
+2. Run the application
+3. Wait until all declared output data is persisted
 
-| main(`wrap_application.sh`) | sidecar (`wrap_datamon_pg.sh`) | what happens |
-|-----------------------------|-----------------------------|--------------|
-|                 | <= dbstarted    | application waits for the DB instance to be ready |
-|                 |                 | (do some work...)                                 |
-| initdbupload => |                 | datamon archives the database as a bundle         |
-|                 | <= dbuploaddone | application waits until its output is archived    |
+The wrapper terminates when the last step is completed.
+This coordination is achieved thanks to "signaling files" written on a volume shared by all containers on the same pod.
 
-<!-- Internal notes -->
-<!--
- While there's precisely one application container per Argo node,
-a Kubernetes container created from an arbitrary image,
-sidecars are additional containers in the same Kubernetes pod
--- or Argo DAG node, we can say, approximately synonymously --
-that concert datamon-based data-ferrying setups with the application container.
+#### How to set up a wrapper?
 
-> _Aside_: as additional kinds of data sources and sinks are added,
-> we may also refer to "sidecars" as "batteries," and so on as semantic drift
-> of the shell scripts shears away feature creep in the application binary.
--->
+The wrapper script is available as a docker image `gcr.io/onec-co/datamon-wrapper`. The image is very small and contains just this script and
+a minimal alpine Linux distribution to be able to copy it.
+
+This script is typically retrieved using an `initContainer`, like this:
+```yaml
+  # The initContainer retrieves the wrap_application.sh script and makes it
+  # available to other application containers.
+  initContainers:
+    - name: init-application-wrap
+      image: "gcr.io/onec-co/datamon-wrapper:latest"
+      imagePullPolicy: Always
+      command: ["sh", "-c", "cp -a /.scripts/* /scripts"]
+      volumeMounts:
+        - mountPath: /scripts
+          name: application-wrapper
+```
+
+The main application container would then use the script like this:
+```yaml
+  containers:
+    - name: demo-app
+      image: "gcr.io/onec-co/my-app:latest"
+      imagePullPolicy: Always
+      command: ["/scripts/wrap_application.sh"]
+      args:
+        - "-c"  # specifies the location for coordination messages
+        - "/tmp/coord"
+        - "-b"  # specifies the coordination type used (fuse|postgres), each type following a specific coordination scheme
+        - "postgres"
+        - "-d"  # when postgres is used, specifies the databases to be waited for (space separated list of configured "names" for db server instances)
+        - "db1 db2 db3"
+        - "--"
+        - "mock_application_pg.sh"  # the application to be wrapped and its parameters (none for this mock)
+      volumeMounts:
+        - mountPath: /scripts
+          name: application-wrapper
+        - mountPath: /tmp/coord
+          name: container-coord
+```
+#### How does it work
+
+1. Coordination signals are received from the sidecars and waited for by the wrapper
+2. The wrapper waits for the application to terminate then signals the sidecars to start uploading
+3. Waits for sidecars to signal all uploads are complete
+
+#### Parameters
+
+| Argument flag | Default value   | Description                                                |
+|---------------|-----------------|------------------------------------------------------------|
+| `-c`          | N/A (required)  | Mount point for signaling files                            |
+| `-b`          | N/A (required)  | Coordination type (`fuse|postgres`)                        |
+| `-d`          | N/A             | Database server names - required when `-b postgres` is set |
+
+All flags after `--` are passed to the main application.
+
+### Fuse sidecar
+
+* a pod may start only one fuse sidecar, this sidecar may mount several read-only volumes
+*
+* for every read-only mounted volume
+#### Limitations
+* a single volume specification cannot specify both datamon source and destination
+
+### Postgres sidecar
+
+* a pod may start several Postgres sidecars, every sidecar will spin up a single Postgres database server
+* every database server _may_ expose several logical databases on the same port
+* every sidecar exposes a postgres port, accessible to all containers on the pod. Ports must be unique.
+* when several database servers are declared, all will be downloaded before the application actually starts
+* the application is free to access the database server as super-user (user `postgres`) or any predefined database user
+* a postgres sidecar without a source repo will create a new database from scratch
+* a postgres sidecar without a destination repo will skip the upload stage: any changes to data will be lost. This is useful to use read-only databases.
+
+#### Limitations
+
+* at the moment, the fuse sidecar only works with `streamed` fuse read-only mounts. This means that the mount is available very quickly and that files
+  are downloaded on demand, without any staging area to provision. Memory cache options in this mode are not configurable (default cache size: 50 MB per mounted volume).
+* we don't support fuse AND postgres coordination at the same time with a single wrapper (possible with nested wrappers)
+* we don't support running several databases in one single sidecar container
+* the staging area to download the database must be provisioned with sufficient disk to hold the data files
+* errors caught during the download or upload phases are not handled and result in the application waiting indefinitely
+* postgres databases are backed as plain files. This is way faster than carrying out a logical export but exposes us
+  to compatibility issues whenever a new major postgres version is issued. At this moment, sidecars work with Postgres 12.2,
+  meaning that a migration operation will have to be carried out when we want to upgrade the sidecar containers to Postgres 13.
+
+## Parameters and default values
+
+### Datamon parameters
+
+Sidecars run datamon the way you would use it locally: defining a local configuration file is strongly advised.
+The process runs as non-root use `developer`. The default location of the datamon config file is `/home/developer/.datamon2/datamon.yaml`
+
+Default settings point to the "workshop context" buckets. The sample pod specification below exhibits how to map a configuration for your datamon context.
+
+Another way of doing this is to use environment variables `DATAMON_GLOBAL_CONFIG` (location of the main metadata bucket) and `DATAMON_CONTEXT` (which context is used).
+
+Sample config resource for a pod:
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datamon-local-config
+  labels:
+    app: datamon-coord-pg-demo
+data:
+  # the buckets configuration (context) for datamon
+  datamon.yaml: |
+    config: workshop-config
+    context: dev
+```
+
+### fuse sidecar
+
+#### Parameters
+
+| Environment                     |   YAML key              | Default value          | Description                                                        |
+|---------------------------------|-------------------------|------------------------|--------------------------------------------------------------------|
+| `dm_fuse_params`                | N/A                     | N/A (require)          | Location of YAML config file for sidecar                           |
+
+> **NOTE**: it is possible to configure the sidecar via environment variables: this is reserved or internal and debug usage
+
+#### Sample configuration for fuse sidecar
+
+**Example:** 1 input (read-only), 1 output (to be saved)
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datamon-fuse-params
+  labels:
+    app: datamon-coord-fuse-demo
+data:
+  fuse-params.yaml: |
+    globalOpts:
+      coordPoint: /tmp/coord
+      # The ones below are no more used (see datamon.yaml above) but kept because of sidecar_param requirements
+      configBucketName: datamon-config-test-sdjfhga
+      contextName: datamon-sidecar-test
+    bundles:
+      - name: src
+        # mount point for the volume containing read-only data
+        srcPath: /tmp/mount
+        # datamon location specification: (repo, bundle|label)
+        srcRepo: ransom-datamon-test-repo
+        # identify the desired point in time with either label or bundleID (not both)
+        srcLabel: testlabel
+        srcBundle: ""
+      - name: dest
+        # mount point for the volume containing data to be saved
+        destPath: /tmp/upload
+        # datamon location specification on how to save data: (repo, bundle|label)
+        destRepo: ransom-datamon-test-repo
+        # the commit message for the saved bundle
+        destMessage: result of container coordination demo
+        destLabel: coordemo
+```
+
+### Postgres sidecar
+
+#### Parameters
+| Environment                     |   YAML key              | Default value          | Description                                                        |
+|---------------------------------|-------------------------|------------------------|--------------------------------------------------------------------|
+| `SIDECAR_CONFIG`                | N/A                     | `/config/pgparams.yaml`| Location of YAML config file for sidecar                           |
+| `SIDECAR_GLOBALOPTS_COORD_POINT`| `globalOpts.coordPoint` | `/tmp/coord`           | The mount point used for signaling                                 |
+| `SIDECAR_DATABASE_NAME`         | `database.name`         | `db`                   | db server name used to dispatch signals                            |
+| `SIDECAR_DATABASE_DATADIR`      | `database.dataDir`      | `/pg_stage`            | The mount point used to download the db                            |
+| `SIDECAR_DATABASE_PGPORT`       | `database.pgPort`       | `5432`                 | The postgres port exposed                                          |
+| `SIDECAR_DATABASE_SRCREPO`      | `database.srcRepo`      |                        | The repo the db is downloaded from (if none, a new db is created)  |
+| `SIDECAR_DATABASE_SRCBUNDLE`    | `database.srcBundle`    |                        | The bundle defining the point in time the db is downloaded from    |
+| `SIDECAR_DATABASE_SRCLABEL`     | `database.srcLabel`     |                        | The label defining the point in time the db is downloaded from     |
+| `SIDECAR_DATABASE_DESTREPO`     | `database.destRepo`     |                        | The repo the db is uploaded to (if none, the db is not saved)      |
+| `SIDECAR_DATABASE_DESTLABEL`    | `database.destLabel`    |                        | The label put on the uploaded db (optional)                        |
+| `SIDECAR_DATABASE_DESTMESSAGE`  | `database.destMessage`  |                        | The commit message for the saved bundle (required)                 |
+| `SIDECAR_DATABASE_OWNER`        | `database.owner`        |                        | When a database is created from scratch, user to create (optional) |
+
+> **NOTES**:
+> - for source specification, either bundle or label may be used, but not both
+> - for sidecar configuration as yaml, do not use inline comments (e.g. `mykey: value #<-- yaml comment`)
+> - the keys `globalOpts.sleepInsteadOfExit` (default: `"false"`) and `globalOpts.sleepTimeout` (default: `600` sec) are intended for internal use and debug only
+>   not for production usage (makes the sidecar sleep for a while after completion)
+
+#### Sample configurations for Postgres sidecar
+
+We strongly suggest that you use config map objects and declare parameters using this YAML config. Here are some examples. You may see these examples in action with our demo app.
+The full code of the working demo is available here: https://github.com/oneconcern/datamon/tree/master/hack/fuse-demo and here https://github.com/oneconcern/datamon/tree/master/hack/k8s
+
+**Example 1:**  write only db, created from scratch, then saved after the application completes
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datamon-pg-sidecar-config-1
+  labels:
+    app: datamon-coord-pg-demo
+data:
+  pgparams.yaml: |
+    globalOpts:
+      coordPoint: /tmp/coord
+    database:
+      name: db1
+      pgPort: "5430"
+      # sidecar will create dbuser with super-user privileges (alternative to user "postgres")
+      owner: dbuser
+      # no src: means we want to create this from scratch
+      # dest: means we want to save after our work is done
+      destRepo: example-repo
+      destMessage: postgres sidecar coordination example (write only)
+      destLabel: write only example
+```
+
+**Example 2:** retrieve db from an existing bundle then save changes as another bundle
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datamon-pg-sidecar-config
+  labels:
+    app: datamon-coord-pg-demo
+data:
+  pgparams.yaml: |
+    globalOpts:
+      coordPoint: /tmp/coord
+    database:
+      name: db2
+      pgPort: "5429"
+      srcRepo: example-repo
+      srcLabel: my-desired-point-in-time
+      destRepo: example-repo
+      destMessage: postgres sidecar coordination example (read-write)
+      destLabel: read-write example
+```
+
+**Example 3:** retrieve db from an existing bundle to use for reading only (no changes saved)
+
+Notice that the database is not really _read-only_: the application may indeed modify the db content. Changes will just not be saved after the app exits.
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datamon-pg-sidecar-config
+  labels:
+    app: datamon-coord-pg-demo
+data:
+  # - a read only instance created from existing bundle, then ditched
+  pgparams.yaml: |
+    globalOpts:
+      coordPoint: /tmp/coord
+    database:
+      name: db3
+      pgPort: "5428"
+      srcRepo: example-repo
+      srcLabel: another-desired-point-in-time
+      # no dest: means the upload signal just shuts down the db, and no upload is actually carried out
+```
+
+## Walking through a full example
+
+The full example is based on the demo. For fuse: [k8s spec](https://github.com/oneconcern/datamon/blob/master/hack/k8s/example-coord.template.yaml).
+For Postgres: [k8s spec](https://github.com/oneconcern/datamon/blob/master/hack/k8s/example-coord-pg.template.yaml).
+
+Notice that the demo templates introduce some variability to properly run on CI.
+
+Our demo uses a kubernetes `Deployment` to deploy a pod. This not a requirement, though, and you may use ARGO resources or kubernetes standard resources such
+as `jobs` or `statefulSets`.
+
+### Init container
+
+We need to retrieve the wrapper script into some shared volume.
+This step remains the same, whether you plan to use the fuse or postgres flavor of the sidecar.
+
+```yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  namespace: datamon-ci
+spec:
+  selector:
+    matchLabels:
+      app: datamon-coord-fuse-demo
+      instance: v0.0.0
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: datamon-coord-fuse-demo
+        instance: v0.0.0
+    spec:
+      initContainers:
+      - name: init-application-wrap
+        image: gcr.io/onec-co/datamon-wrapper:latest
+        imagePullPolicy: Always
+        command: ["sh", "-c", "cp -a /.scripts/* /scripts"]
+        volumeMounts:
+        - mountPath: /scripts
+          name: application-wrapper
+
+...
+
+      volumes:
+      - name: application-wrapper
+        emptyDir: {}
+```
+
+### Config maps
+
+Using config maps is the recommended way to setup datamon sidecars.
+We need:
+
+1. a config map to configure datamon (config bucket, context)
+2. plain files: a single config map to configure a datamon-fuse sidecar
+3. postgres: a config map for each datamon-pg sidecar
+
+See the examples provided above for these configs.
+
+Config maps are declared as volumes on the pod, like this.
+
+Fuse example (one single config):
+```yaml
+      volumes:
+      - name: application-wrapper
+        emptyDir: {}
+      - name: fuse-params
+        configMap:
+          name: datamon-fuse-params
+          defaultMode: 0555
+      - name: datamon-config
+        configMap:
+          name: datamon-local-config
+          defaultMode: 0555
+```
+
+Postgres example (deploys 3 different configs for this demo):
+```yaml
+      volumes:
+      - name: application-wrapper
+        emptyDir: {}
+      - name: pg-config-1
+        configMap:
+          name: datamon-pg-sidecar-config-1
+          defaultMode: 0555
+      - name: pg-config-2
+        configMap:
+          name: datamon-pg-sidecar-config-2
+          defaultMode: 0555
+      - name: pg-config-3
+        configMap:
+          name:datamon-pg-sidecar-config-3
+          defaultMode: 0555
+      - name: datamon-config
+        configMap:
+          name: datamon-local-config
+          defaultMode: 0555
+```
+
+### Planning for storage requirements
+
+> **NOTE**: this part is not included with the demo files, which use pod local storage only.
+
+#### Plain files: fuse sidecar
+We need to provision the storage needed before upload
+
+#### Database: Postgres sidecar
+We need to provision the storage needed before download (upload is carried out from the same volume)
+
+
+We do that with a `PersistentVolumeClaim` and a `PersistentVolume`.
+The volume will be relinquished by kubernetes when the pod exits.
+
+Declare as many claims and volumes as you need.
+
+#### Persistent volume claims
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-app-staging-claim
+spec:
+  storageClassName: ssd
+  persistentVolumeReclaimPolicy: Delete
+  finalizers: []
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: my-app-staging-volume
+  type: pd-ssd
+spec:
+  storageClassName: ssd
+  persistentVolumeReclaimPolicy: Delete
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+```
+
+### Wrapping the main application
+
+#### Plain files: fuse sidecar
+Let's assume your app is containerized. The upload staging volume is attached to the main application.
+
+Running the container with the wrapper looks something like this.
+
+```yaml
+      containers:
+      - name: demo-app
+        image: "gcr.io/onec-co/my-app:latest"
+        imagePullPolicy: Always
+        command: ["/scripts/wrap_application.sh"]
+        args:
+        - "-c"  # specifies the location for coordination messages
+        - "/tmp/coord"
+        - "-b"  # specifies the coordination type used (fuse|postgres), each type following a specific coordination scheme
+        - "fuse"
+        - "--"
+        - "mock_application.sh"
+        - "/tmp/mount"   # volume where the files are mounted (read-only)
+        - "/tmp/upload"  # staging area to upload
+        volumeMounts:
+        - mountPath: /scripts
+          name: application-wrapper
+        - mountPath: /tmp/coord
+          name: container-coord
+        - mountPath: /tmp/upload
+          name: upload-source
+        - mountPath: /tmp/mount
+          name: fuse-mountpoint
+
+...
+
+      volumes:
+      - name: application-wrapper
+        emptyDir: {}
+      - name: container-coord
+        emptyDir: {}
+      - name: upload-source
+        persistentVolumeClaim:
+          claimName: my-app-staging-claim
+```
+
+#### Database: Postgres sidecar
+
+The app container does not need to mount the staging volume: only a pg sidecar needs it.
+```yaml
+      volumes:
+      - name: application-wrapper
+        emptyDir: {}
+      - name: container-coord
+        emptyDir: {}
+      - name: staging-area-1         # database volume: provision sufficient disk for this operation
+        persistentVolumeClaim:
+          claimName: my-app-staging-claim-1
+      - name: staging-area-2         # database volume: provision sufficient disk for this operation
+        persistentVolumeClaim:
+          claimName: my-app-staging-claim-2
+      - name: staging-area-3         # database volume: provision sufficient disk for this operation
+        persistentVolumeClaim:
+          claimName: my-app-staging-claim-3
+```
+
+### Configuring sidecars
+
+#### Plain files: fuse sidecar
+The sidecar needs access to both the coordination mount point (read and written by the wrapper) and the upload volume (written by the app).
+
+```yaml
+      containers:
+....
+      - name: datamon-sidecar
+        image: "gcr.io/onec-co/datamon-fuse-sidecar:latest"
+        imagePullPolicy: Always
+        command: ["wrap_datamon.sh"]
+        args: []
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /tmp/upload
+          name: upload-source
+        - mountPath: /tmp/coord
+          name: container-coord
+        - mountPath: /tmp/mount
+          name: fuse-mountpoint
+          mountPropagation: "Bidirectional"
+        - mountPath: /tmp/gac
+          name: google-application-credentials
+        - mountPath: /config
+          name: fuse-params
+        - mountPath: /home/developer/.datamon2
+          name: datamon-config
+        env:
+        - name: dm_fuse_params
+          value: /config/fuse-params.yaml
+
+
+      volumes:
+      - name: fuse-mountpoint
+        emptyDir: {}
+      - name: application-wrapper
+        emptyDir: {}
+      - name: container-coord
+        emptyDir: {}
+      - name: upload-source
+        persistentVolumeClaim:
+          claimName: my-app-staging-claim
+      - name: fuse-params
+        configMap:
+          name: datamon-fuse-params
+          defaultMode: 0555
+      - name: datamon-config
+        configMap:
+          name: datamon-local-config
+          defaultMode: 0555
+```
+
+#### Database: Postgres sidecar
+The sidecar needs access to the staging volume.
+
+In this example, with spin up 3 sidecars, each illustrating a different use-case.
+
+```yaml
+      containers:
+...
+      # A datamon-pg-sidecar container spins up a postgres database retrieved from a datamon bundle
+      - name: datamon-sidecar-1
+        image: "gcr.io/onec-co/datamon-pg-sidecar:latest"
+        imagePullPolicy: Always
+        command: ["wrap_datamon_pg.sh"]
+        args: []
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /pg_stage
+          name: staging-area-1        # volume where the database is mounted
+        - mountPath: /tmp/coord
+          name: container-coord       # shared volume for coordination beetwen application and sidecar
+        - mountPath: /config          # sidecar parameters
+          name: pg-config-1
+        - mountPath: /home/developer/.datamon2
+          name: datamon-config
+
+      # Another database is spun, with a different use case
+      - name: datamon-sidecar-2
+        image: "gcr.io/onec-co/datamon-pg-sidecar:latest"
+        imagePullPolicy: Always
+        command: ["wrap_datamon_pg.sh"]
+        args: []
+        securityContext:
+          privileged: true            # the container runs as non-root but needs to perform some sudo operations
+        volumeMounts:
+        - mountPath: /pg_stage
+          name: staging-area-2        # volume where the database is mounted
+        - mountPath: /tmp/coord
+          name: container-coord       # shared volume for coordination beetwen application and sidecar
+        - mountPath: /config          # sidecar parameters
+          name: pg-config-2
+        - mountPath: /home/developer/.datamon2
+          name: datamon-config
+
+      # Another database is spun, with again a different use case
+      - name: datamon-sidecar-3
+        image: "gcr.io/onec-co/datamon-pg-sidecar:$SIDECAR_TAG"
+        imagePullPolicy: Always
+        command: ["wrap_datamon_pg.sh"]
+        args: []
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /pg_stage
+          name: staging-area-3        # volume where the database is mounted
+        - mountPath: /tmp/coord
+          name: container-coord       # shared volume for coordination beetwen application and sidecar
+        - mountPath: /config          # sidecar parameters
+          name: pg-config-3
+        - mountPath: /home/developer/.datamon2
+          name: datamon-config
+
+...
+
+      volumes:
+      - name: application-wrapper
+        emptyDir: {}
+      - name: container-coord
+        emptyDir: {}
+      - name: staging-area-1         # database volume: provision sufficient disk for this operation
+        persistentVolumeClaim:
+          claimName: my-app-staging-claim-1
+      - name: staging-area-2         # database volume: provision sufficient disk for this operation
+        persistentVolumeClaim:
+          claimName: my-app-staging-claim-2
+      - name: staging-area-3         # database volume: provision sufficient disk for this operation
+        persistentVolumeClaim:
+          claimName: my-app-staging-claim-3
+```
 
 ## Sidecar releases
+
+Sidecar containers follow the same release cycle as datamon.
 
 There are currently two sidecar images:
 
 * `gcr.io/onec-co/datamon-fuse-sidecar` provides hierarchical filesystem access
 * `gcr.io/onec-co/datamon-pg-sidecar` provides PostgreSQL database access
+
+At this moment, these images remain part of our private `gcr.io` repository. You may look at them from here: https://console.cloud.google.com/gcr/images
 
 Sidecars are versioned along with
 [github releases](https://github.com/oneconcern/datamon/releases/)
@@ -89,176 +694,14 @@ of the [desktop binary](install.md).
 
 Docker image tags follow the github releases.
 
-See latest release [here](https://github.com/oneconcern/datamon/releases/latest).
+See the latest release [here](https://github.com/oneconcern/datamon/releases/latest).
 
-You embed a datamon sidecar in your kuberbetes pod specification like this:
+You embed a datamon sidecar in your kubernetes pod specification like this:
 ```yaml
 spec:
   ...
   containers:
     - name: datamon-sidecar
-    - image: gcr.io/onec-co/datamon-fuse-sidecar:v1.0.0
+    - image: gcr.io/onec-co/datamon-fuse-sidecar:v2.1.0
   ...
 ```
-
-<!-- Internal notes -->
-<!--
-> _Aside_: historically, and in case it's necessary to roll back to an now-ancient
-> version of the sidecar image, releases were tagged in git without the `v` prefix,
-> and Docker tags prepended `v` to the git tag.
-> For instance, `0.4` is listed on the github releases page, while
-> the tag `v0.4` as in `gcr.io/onec-co/datamon-fuse-sidecar:v0.4` was used when writing
-> Dockerfiles or Kubernetes-like YAML to accesses the sidecar container image.
--->
-
-## Sidecar usage
-
-Users need only place the `wrap_application.sh` script located in the root directory
-of each of the sidecar containers within the main container.
-This
-[can be accomplished](https://github.com/oneconcern/datamon/blob/master/hack/k8s/example-coord.template.yaml#L15-L24)
-via an `initContainer` without duplicating version of the Datamon sidecar
-image in both the main application Dockerfile as well as the YAML.
-When using a block-storage GCS product, we might've specified a data-science application's
-Argo DAG node with something like
-
-```yaml
-command: ["app"]
-args: ["param1", "param2"]
-```
-
-whereas with `wrap_application.sh` in place, this would be something to the effect of
-
-```yaml
-command: ["/path/to/wrap_application.sh"]
-args: ["-c", "/path/to/coordination_directory", "-b", "fuse", "--", "app", "param1", "param2"]
-```
-
-That is, `wrap_application.sh` has the following usage
-
-```shell
-wrap_application.sh -c <coordination_directory> -b <sidecar_kind> -- <application_command>
-```
-
-where
-* `<coordination_directory>` is an empty directory in a shared volume
-  (an
-  [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
-  using memory-backed storage suffices).  each coordination directory (not necessarily the volume)
-  corresponds to a particular DAG node (i.e. Kubernetes pod) and vice-versa.
-* `<sidecar_kind>` is in correspondence with the containers specified in the YAML
-  and may be among
-  - `fuse`
-  - `postgres`
-* `<application_command>` is the data-science application command exactly as it
-  would appear without the wrapper script.  That is, the wrapper script, relies the
-  [conventional UNIX syntax](http://zsh.sourceforge.net/Guide/zshguide02.html#l11)
-  for stating that options to a command are done being declared.
-
-Meanwhile, each sidecar's datamon-specific batteries have their corresponding usages.
-
-##### `gcr.io/onec-co/datamon-fuse-sidecar` -- `wrap_datamon.sh`
-
-Provides filesystem representations (i.e. a folder) of [datamon bundles](#data-modeling).
-Since bundles' filelists are serialized filesystem representations,
-the `wrap_datamon.sh` interface is tightly coupled to that of the self-documenting
-`datamon` binary itself.
-
-```shell
-./wrap_datamon.sh -c <coord_dir> -d <bin_cmd_I> -d <bin_cmd_J> ...
-```
-
-* `-c` the same coordination directory passed to `wrap_application.sh`
-* `-d` all parameters, exactly as passed to the datamon binary, except as a
-  single scalar (quoted) parameter, for one of the following commands
-  - `config` sets user information associated with any bundles created by the node
-  - `bundle mount` provides sources for data-science applications
-  - `bundle upload` provides sinks for data-science applications
-
-Multiple (or none) `bundle mount` and `bundle upload` commands may be specified,
-and at most one `config` command is allowed so that an example `wrap_datamon.sh`
-YAML might be
-
-```yaml
-command: ["./wrap_datamon.sh"]
-args: ["-c", "/tmp/coord", "-d", "config create", "-d", "bundle upload --path /tmp/upload --message \"result of container coordination demo\" --repo ransom-datamon-test-repo --label coordemo", "-d", "bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream"]
-```
-
-or from the shell
-
-```shell
-./wrap_datamon.sh -c /tmp/coord -d 'config create' -d 'bundle upload --path /tmp/upload --message "result of container coordination demo" --repo ransom-datamon-test-repo --label coordemo' -d 'bundle mount --repo ransom-datamon-test-repo --label testlabel --mount /tmp/mount --stream'
-```
-
-##### `gcr.io/onec-co/datamon-pg-sidecar` -- `wrap_datamon_pg.sh`
-
-Provides Postgres databases as bundles and vice versa.
-Since the datamon binary does not include any Postgres-specific notions,
-the UI here is more decoupled than that of `wrap_datamon.sh`.
-The UI is specified via environment variables
-such that `wrap_datamon.sh` is invoked without parameters.
-
-The script looks for precisely one `dm_pg_opts` environment variable
-specifying global options for the entire script and any number of
-`dm_pg_db_<db_id>` variables, one per database.
-
-----
-
-_Aside on serialization format_
-
-Each of these environment variables each contain a serialized dictionary
-according the the following format
-
-```
-<entry_sperator><key_value_seperator><entry_1><entry_seperator><entry_2>...
-```
-
-where `<entry_sperator>` and `<key_value_seperator>` are each a single
-character, anything other than a `.`, and each `<entry>` is of one of
-two forms, either `<option>` or `<option><key_value_seperator><arg>`.
-
-So for example
-
-```
-;:a;b:c
-```
-
-expresses something like a Python map
-
-```python
-{'a': True, 'b' : 'c'}
-```
-
-or shell option args
-
-```
-<argv0> -a -b c
-```
-
-----
-
-Every database created in the sidecar corresponding to a `dm_pg_db_<db_id>`
-env var is uploaded to datamon and optionally initialized by a previously
-uploaded database.
-The opts in the above serialization format availble to specify are
-
-* `p` IP port used to connect to the database
-* `m` message written to the database's bundle
-* `l` label written to the bundle
-* `r` repo containing bundle
-* `sr` repo containing the source bundle
-* `sl` label of the source bundle
-* `sb` source bundle id
-
-
-that affect the availability of the database from the application container
-or the upload of the database to datamon are
-
-Meanwhile, `dm_pg_opts` uses options
-
-* `c` the `<coord_dir>` as in the FUSE sidecar
-* `V` whether to ignore postgres version mismatch,
-  either `true` or `false` (for internal use)
-* `S` without an `<arg>` is causes the wrapper script to sleep instead
-  of exiting, which can be useful for debug.
-


### PR DESCRIPTION
* rewrote user doc on sidecars, essentially a walk-through the examples
* moved the existing material as "sidecar design", which reflects the current design -- remove pg parts that are no more relevant
* introduced a new "analysis" document (could also have called this "impediments"), preliminary to the forthcoming design proposal -- basically challenging https://oneconcern.atlassian.net/browse/RES-1826

NOTE to reviewers: since this builds up on top of other PR you may see the actual changes
by jumping to that commit https://github.com/oneconcern/datamon/pull/433/commits/e94af91c77817294442c8cfbf34db8b518c46d9f
