### PR TITLE
mod tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,14 +205,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - pkg-cache-{{ checksum "go.sum" }}
-            - pkg-cache-
+            - go-mod-v1-{{ checksum "go.mod" }}
+            - go-mod-v1-
 
   put_cache:
     description: save golang modules cache
     steps:
       - save_cache:
-          key: pkg-cache-{{ checksum "go.sum" }}
+          key: go-mod-v1-{{ checksum "go.mod" }}
           paths:
             - "/home/circleci/go/pkg"
 

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ github.com/influxdata/influxdb v1.7.9 h1:uSeBTNO4rBkbp1Be5FKRsAmglM9nlx25TzVQRQt
 github.com/influxdata/influxdb v1.7.9/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f h1:X+tnaqoCcBgAwSTJtoYW6p0qKiuPyMfofEHEFUf2kdU=
 github.com/jacobsa/daemonize v0.0.0-20160101105449-e460293e890f/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
-github.com/jacobsa/fuse v0.0.0-20200128091008-ae5da07e4c80 h1:K9lTj2neg5ay8TiLL9TU3VZi9+9if/EzYRO02lrYNAQ=
-github.com/jacobsa/fuse v0.0.0-20200128091008-ae5da07e4c80/go.mod h1:9Aml1MG17JVeXrN4D2mtJvYHtHklJH5bESjCKNzVjFU=
 github.com/jacobsa/fuse v0.0.0-20200311085126-7d791d27a25d h1:4gaMlb9FOx56oj4XJaISZjPpVYWWk7+qkZ8gN4bWwXQ=
 github.com/jacobsa/fuse v0.0.0-20200311085126-7d791d27a25d/go.mod h1:9Aml1MG17JVeXrN4D2mtJvYHtHklJH5bESjCKNzVjFU=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=


### PR DESCRIPTION
in #419 , i'm noticing that some of `./.githooks/pre-commit/` aren't idempotent on `master` like i'd expect.  this is part of an effort to push some of those changes thu ci.