### PR TITLE
regenerate docs

### DIFF
--- a/docs/usage/datamon.md
+++ b/docs/usage/datamon.md
@@ -19,7 +19,7 @@ your data buckets are organized in repositories of versioned and tagged bundles 
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --force                     Forces upgrade even if the current version is not a released version
   -h, --help                      help for datamon
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")

--- a/docs/usage/datamon_bundle.md
+++ b/docs/usage/datamon_bundle.md
@@ -25,7 +25,7 @@ together.
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_bundle_diff.md
+++ b/docs/usage/datamon_bundle_diff.md
@@ -27,7 +27,7 @@ datamon bundle diff [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_download.md
+++ b/docs/usage/datamon_bundle_download.md
@@ -46,7 +46,7 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_download_file.md
+++ b/docs/usage/datamon_bundle_download_file.md
@@ -37,7 +37,7 @@ datamon bundle download file [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_get.md
+++ b/docs/usage/datamon_bundle_get.md
@@ -28,7 +28,7 @@ datamon bundle get [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_list.md
+++ b/docs/usage/datamon_bundle_list.md
@@ -34,7 +34,7 @@ datamon bundle list [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_list_files.md
+++ b/docs/usage/datamon_bundle_list_files.md
@@ -39,7 +39,7 @@ name:bundle_upload.go, size:4021, hash:b9258e91eb29fe42c70262dd2da46dd71385995db
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_mount.md
+++ b/docs/usage/datamon_bundle_mount.md
@@ -34,7 +34,7 @@ datamon bundle mount [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_mount_new.md
+++ b/docs/usage/datamon_bundle_mount_new.md
@@ -29,7 +29,7 @@ datamon bundle mount new [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_update.md
+++ b/docs/usage/datamon_bundle_update.md
@@ -27,7 +27,7 @@ datamon bundle update [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_bundle_upload.md
+++ b/docs/usage/datamon_bundle_upload.md
@@ -43,7 +43,7 @@ set label 'init'
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_config.md
+++ b/docs/usage/datamon_config.md
@@ -24,7 +24,7 @@ You may force a specific local config file using the $DATAMON_CONFIG environment
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_config_set.md
+++ b/docs/usage/datamon_config_set.md
@@ -53,7 +53,7 @@ config file created in /Users/ritesh/.config/.datamon/config.yaml
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_context.md
+++ b/docs/usage/datamon_context.md
@@ -19,7 +19,7 @@ Commands to manage contexts. A context is an instance of Datamon with set of rep
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_context_create.md
+++ b/docs/usage/datamon_context_create.md
@@ -27,7 +27,7 @@ datamon context create [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_context_get.md
+++ b/docs/usage/datamon_context_get.md
@@ -22,7 +22,7 @@ datamon context get [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_context_list.md
+++ b/docs/usage/datamon_context_list.md
@@ -22,7 +22,7 @@ datamon context list [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_diamond.md
+++ b/docs/usage/datamon_diamond.md
@@ -18,12 +18,14 @@ A diamond is a parallel data upload operation, which ends up in a single bundle 
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_cancel.md
+++ b/docs/usage/datamon_diamond_cancel.md
@@ -24,13 +24,15 @@ datamon diamond cancel [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_commit.md
+++ b/docs/usage/datamon_diamond_commit.md
@@ -31,13 +31,15 @@ datamon diamond commit [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_get.md
+++ b/docs/usage/datamon_diamond_get.md
@@ -26,13 +26,15 @@ datamon diamond get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_initialize.md
+++ b/docs/usage/datamon_diamond_initialize.md
@@ -27,13 +27,15 @@ datamon diamond initialize [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_list.md
+++ b/docs/usage/datamon_diamond_list.md
@@ -24,13 +24,15 @@ datamon diamond list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_split.md
+++ b/docs/usage/datamon_diamond_split.md
@@ -17,13 +17,15 @@ A split is a part of a diamond, which may be used to upload data concurrently
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_split_add.md
+++ b/docs/usage/datamon_diamond_split_add.md
@@ -45,13 +45,15 @@ my-pod
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_split_get.md
+++ b/docs/usage/datamon_diamond_split_get.md
@@ -27,13 +27,15 @@ datamon diamond split get [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_diamond_split_list.md
+++ b/docs/usage/datamon_diamond_split_list.md
@@ -25,13 +25,15 @@ datamon diamond split list [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string       Set the context for datamon (default "dev")
-      --format string        Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
-      --loglevel string      The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
-      --metrics              Toggle telemetry and metrics collection
-      --metrics-url string   Fully qualified URL to an influxdb metrics collector, with user and password
-      --upgrade              Upgrades the current version then carries on with the specified command
+      --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
+      --context string            Set the context for datamon (defaults to "dev")
+      --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
+      --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
+      --metrics                   Toggle telemetry and metrics collection
+      --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL
+      --metrics-url string        Fully qualified URL to an influxdb metrics collector, with optional user and password
+      --metrics-user string       User to connect to the metrics collector backend. Overrides any user set in URL
+      --upgrade                   Upgrades the current version then carries on with the specified command
 ```
 
 ### SEE ALSO

--- a/docs/usage/datamon_label.md
+++ b/docs/usage/datamon_label.md
@@ -35,7 +35,7 @@ production
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_label_get.md
+++ b/docs/usage/datamon_label_get.md
@@ -26,7 +26,7 @@ datamon label get [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_label_list.md
+++ b/docs/usage/datamon_label_list.md
@@ -35,7 +35,7 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_label_set.md
+++ b/docs/usage/datamon_label_set.md
@@ -34,7 +34,7 @@ datamon label set [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_repo.md
+++ b/docs/usage/datamon_repo.md
@@ -25,7 +25,7 @@ They are versioned and managed via bundles.
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_repo_create.md
+++ b/docs/usage/datamon_repo_create.md
@@ -35,7 +35,7 @@ datamon repo create [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_repo_get.md
+++ b/docs/usage/datamon_repo_get.md
@@ -25,7 +25,7 @@ datamon repo get [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_repo_list.md
+++ b/docs/usage/datamon_repo_list.md
@@ -31,7 +31,7 @@ fred , test fred , Frédéric Bidon , frederic@oneconcern.com , 2019-12-05 14:01
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --format string             Pretty-print datamon objects using a Go template. Use '{{ printf "%#v" . }}' to explore available fields
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection

--- a/docs/usage/datamon_upgrade.md
+++ b/docs/usage/datamon_upgrade.md
@@ -25,7 +25,7 @@ datamon upgrade [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_usage.md
+++ b/docs/usage/datamon_usage.md
@@ -23,7 +23,7 @@ datamon usage [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_version.md
+++ b/docs/usage/datamon_version.md
@@ -28,7 +28,7 @@ datamon version [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL

--- a/docs/usage/datamon_web.md
+++ b/docs/usage/datamon_web.md
@@ -24,7 +24,7 @@ datamon web [flags]
 
 ```
       --config string             Set the config backend store to use (bucket name: do not set the scheme, e.g. 'gs://')
-      --context string            Set the context for datamon (default "dev")
+      --context string            Set the context for datamon (defaults to "dev")
       --loglevel string           The logging level. Levels by increasing order of verbosity: none, error, warn, info, debug (default "info")
       --metrics                   Toggle telemetry and metrics collection
       --metrics-password string   Password to connect to the metrics collector backend. Overrides any password set in URL


### PR DESCRIPTION
#419 includes some changes to the documentation strings.  meanwhile, the auto-generated documentation in `master` is out of sync with the source.  so this is a quick `.githooks/pre-commit/20-*` run to regenerate the documentation and get a more easily explainable diff by the time #419 is merged.