### PR TITLE
Version support for label get and label list

### DIFF
--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -75,6 +75,7 @@ type flagsT struct {
 		ConcurrencyFactor int
 		BatchSize         int
 		Template          string
+		WithLabelVersions bool
 	}
 	split struct {
 		splitID string
@@ -429,6 +430,14 @@ func addDiamondTagFlag(cmd *cobra.Command) string {
 	c := "diamond-tag"
 	if cmd != nil {
 		cmd.Flags().StringVar(&datamonFlags.diamond.tag, c, "", `A custom tag to identify your diamond in logs or datamon reports. Example: "coordinator-pod-A"`)
+	}
+	return c
+}
+
+func addLabelVersionsFlag(cmd *cobra.Command) string {
+	c := "with-versions"
+	if cmd != nil {
+		cmd.Flags().BoolVar(&datamonFlags.core.WithLabelVersions, c, false, `List all previous versions of labels`)
 	}
 	return c
 }

--- a/cmd/datamon/cmd/label_list.go
+++ b/cmd/datamon/cmd/label_list.go
@@ -46,10 +46,12 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT`,
 			wrapFatalln("create remote stores", err)
 			return
 		}
-		err = core.ListLabelsApply(datamonFlags.repo.RepoName, remoteStores, datamonFlags.label.Prefix, applyLabelTemplate,
+		err = core.ListLabelsApply(datamonFlags.repo.RepoName, remoteStores, applyLabelTemplate,
 			core.ConcurrentList(datamonFlags.core.ConcurrencyFactor),
 			core.BatchSize(datamonFlags.core.BatchSize),
 			core.WithMetrics(datamonFlags.root.metrics.IsEnabled()),
+			core.WithLabelPrefix(datamonFlags.label.Prefix),
+			core.WithLabelVersions(datamonFlags.core.WithLabelVersions),
 		)
 
 		if err != nil {
@@ -72,6 +74,7 @@ func init() {
 	addLabelPrefixFlag(LabelListCommand)
 	addCoreConcurrencyFactorFlag(LabelListCommand, 500)
 	addBatchSizeFlag(LabelListCommand)
+	addLabelVersionsFlag(LabelListCommand)
 
 	labelCmd.AddCommand(LabelListCommand)
 }

--- a/docs/usage/datamon_label_get.md
+++ b/docs/usage/datamon_label_get.md
@@ -17,9 +17,10 @@ datamon label get [flags]
 ### Options
 
 ```
-  -h, --help           help for get
-      --label string   The human-readable name of a label
-      --repo string    The name of this repository
+  -h, --help            help for get
+      --label string    The human-readable name of a label
+      --repo string     The name of this repository
+      --with-versions   List all previous versions of labels
 ```
 
 ### Options inherited from parent commands

--- a/docs/usage/datamon_label_list.md
+++ b/docs/usage/datamon_label_list.md
@@ -29,6 +29,7 @@ init , 1INzQ5TV4vAAfU2PbRFgPfnzEwR , 2019-03-12 22:10:24.159704 -0700 PDT
   -h, --help                     help for list
       --prefix string            List labels starting with a prefix.
       --repo string              The name of this repository
+      --with-versions            List all previous versions of labels
 ```
 
 ### Options inherited from parent commands

--- a/pkg/core/label_list_test.go
+++ b/pkg/core/label_list_test.go
@@ -113,17 +113,17 @@ func testListLabels(t *testing.T, concurrency int, i int) {
 		t.Run(fmt.Sprintf("ListLabels-%s-%d-%d", testcase.name, concurrency, i), func(t *testing.T) {
 			//t.Parallel() // too much resource w/ -race on CI
 			labels, err := ListLabels(testcase.repo, mockedLabelContextStores(testcase.name),
-				testcase.prefix, ConcurrentList(concurrency), BatchSize(testBatchSize))
+				WithLabelPrefix(testcase.prefix), ConcurrentList(concurrency), BatchSize(testBatchSize))
 			assertLabels(t, testcase, labels, err)
 		})
 		t.Run(fmt.Sprintf("ListLabelsApply-%s-%d-%d", testcase.name, concurrency, i), func(t *testing.T) {
 			//t.Parallel()
 			labels := make(model.LabelDescriptors, 0, typicalReposNum)
 			err := ListLabelsApply(testcase.repo, mockedLabelContextStores(testcase.name),
-				testcase.prefix, func(label model.LabelDescriptor) error {
+				func(label model.LabelDescriptor) error {
 					labels = append(labels, label)
 					return nil
-				}, ConcurrentList(concurrency), BatchSize(testBatchSize))
+				}, WithLabelPrefix(testcase.prefix), ConcurrentList(concurrency), BatchSize(testBatchSize))
 			assertLabels(t, testcase, labels, err)
 		})
 	}
@@ -156,4 +156,8 @@ func TestListLabels(t *testing.T) {
 			testListLabels(t, concurrency, i)
 		}
 	}
+}
+
+func TestListLabelVersions(t *testing.T) {
+	t.Skip("tbd")
 }

--- a/pkg/core/label_options.go
+++ b/pkg/core/label_options.go
@@ -20,3 +20,10 @@ func LabelWithMetrics(enabled bool) LabelOption {
 		l.EnableMetrics(enabled)
 	}
 }
+
+// LabelWithVersion indicates we want to retrieve a specific version of this label object
+func LabelWithVersion(version string) LabelOption {
+	return func(l *Label) {
+		l.version = version
+	}
+}

--- a/pkg/core/options.go
+++ b/pkg/core/options.go
@@ -17,6 +17,9 @@ type Settings struct {
 	profilingEnabled bool
 	memProfDir       string
 
+	labelPrefix   string
+	labelVersions bool
+
 	metrics.Enable
 	//m *M // TODO(fred): enable metrics for list operations
 }
@@ -59,7 +62,6 @@ func WithDoneChan(done chan struct{}) Option {
 }
 
 // WithMemProf enables profiling and sets the memory profile directory (defaults to the current working directory).
-// Currently, extra
 func WithMemProf(memProfDir string) Option {
 	return func(s *Settings) {
 		s.profilingEnabled = true
@@ -73,6 +75,20 @@ func WithMemProf(memProfDir string) Option {
 func WithMetrics(enabled bool) Option {
 	return func(s *Settings) {
 		s.EnableMetrics(enabled)
+	}
+}
+
+// WithLabelVersions makes ListLabels list all versions of labels (requires the vmedata bucket to enable versioning)
+func WithLabelVersions(enabled bool) Option {
+	return func(s *Settings) {
+		s.labelVersions = enabled
+	}
+}
+
+// WithLabelPrefix is an option for ListLabelsApply, to filter on labels with some given prefix
+func WithLabelPrefix(prefix string) Option {
+	return func(s *Settings) {
+		s.labelPrefix = prefix
 	}
 }
 

--- a/pkg/core/status/status.go
+++ b/pkg/core/status/status.go
@@ -62,4 +62,7 @@ var (
 
 	// ErrSplitUpdate tells there is an error when uploading a split descriptor the the vmetadata store
 	ErrSplitUpdate = errors.New("cannot update split descriptor")
+
+	// ErrVersionedStoreRequired indicates that a versioned store is required to operate on versioned objects (e.g. labels)
+	ErrVersionedStoreRequired = errors.New("versioned store is required")
 )

--- a/pkg/storage/gcs/store.go
+++ b/pkg/storage/gcs/store.go
@@ -18,6 +18,11 @@ import (
 	"google.golang.org/api/option"
 )
 
+var (
+	_ storage.Store    = &gcs{}
+	_ storage.StoreCRC = &gcs{}
+)
+
 type gcs struct {
 	client         *gcsStorage.Client
 	readOnlyClient *gcsStorage.Client

--- a/pkg/storage/gcs/versions.go
+++ b/pkg/storage/gcs/versions.go
@@ -1,0 +1,86 @@
+package gcs
+
+import (
+	"context"
+	"io"
+	"strconv"
+
+	gcsStorage "cloud.google.com/go/storage"
+	"github.com/oneconcern/datamon/pkg/storage"
+	"github.com/oneconcern/datamon/pkg/storage/status"
+	"go.uber.org/zap"
+	"google.golang.org/api/iterator"
+)
+
+var _ storage.VersionedStore = &gcs{}
+
+func (g *gcs) IsVersioned(ctx context.Context) (bool, error) {
+	attr, err := g.readOnlyClient.Bucket(g.bucket).Attrs(ctx)
+	if err != nil {
+		return false, err
+	}
+	return attr.VersioningEnabled, nil
+}
+
+// KeyVersions returns all versions of a given key
+func (g *gcs) KeyVersions(ctx context.Context, key string) ([]string, error) {
+	//      var err error
+	logger := g.l.With(zap.String("key", key))
+	logger.Debug("start KeyVersions")
+
+	versionsPrefix := func(pageToken string) ([]string, string, error) {
+		const versionsPerPage = 1024
+		itr := g.readOnlyClient.Bucket(g.bucket).Objects(ctx, &gcsStorage.Query{Prefix: key, Versions: true})
+		var objects []*gcsStorage.ObjectAttrs
+		nextPageToken, err := iterator.NewPager(itr, versionsPerPage, pageToken).NextPage(&objects)
+		if err != nil {
+			return nil, "", toSentinelErrors(err)
+		}
+		versions := make([]string, 0, len(objects))
+		for _, objAttrs := range objects {
+			versions = append(versions, strconv.FormatInt(objAttrs.Generation, 10))
+		}
+		return versions, nextPageToken, nil
+	}
+
+	var (
+		pageToken              string
+		err                    error
+		versions, versionsPage []string
+	)
+
+	for {
+		versionsPage, pageToken, err = versionsPrefix(pageToken)
+		if err != nil {
+			return nil, toSentinelErrors(err)
+		}
+		versions = append(versions, versionsPage...)
+		if pageToken == "" {
+			break
+		}
+	}
+
+	return versions, nil
+}
+
+// GetVersion returns a reader pointing to a specific version of a stored object
+func (g *gcs) GetVersion(ctx context.Context, objectName, version string) (io.ReadCloser, error) {
+	g.l.Debug("Start GetVersion", zap.String("objectName", objectName))
+	var err error
+	defer g.l.Debug("End GetVersion", zap.String("objectName", objectName), zap.Error(err))
+
+	gen, err := strconv.ParseInt(version, 10, 64)
+	if err != nil {
+		return nil, status.ErrInvalidVersion.Wrap(err)
+	}
+
+	objectReader, err := g.readOnlyClient.Bucket(g.bucket).Object(objectName).Generation(gen).NewReader(ctx)
+	if err != nil {
+		return nil, toSentinelErrors(err)
+	}
+	return &gcsReader{
+		g:            g,
+		objectReader: objectReader,
+		l:            g.l,
+	}, nil
+}

--- a/pkg/storage/gcs/versions_test.go
+++ b/pkg/storage/gcs/versions_test.go
@@ -1,0 +1,132 @@
+package gcs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"sync"
+	"testing"
+
+	gcsStorage "cloud.google.com/go/storage"
+	"github.com/oneconcern/datamon/internal/rand"
+	"github.com/oneconcern/datamon/pkg/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+func setupVersions(t testing.TB, numOfObjects, numOfVersions int) (*gcs, func()) {
+	ctx := context.Background()
+	bucket := "deleteme-datamontest-" + rand.LetterString(15)
+
+	client, err := gcsStorage.NewClient(context.TODO(), option.WithScopes(gcsStorage.ScopeFullControl))
+	require.NoError(t, err)
+
+	require.NoError(t,
+		client.Bucket(bucket).Create(ctx, "onec-co",
+			&gcsStorage.BucketAttrs{
+				VersioningEnabled: true,
+			}),
+		"Failed to create bucket:"+bucket)
+	t.Logf("Created versioned bucket %s ", bucket)
+
+	gcsStore, err := New(context.TODO(), bucket, "") // Use GOOGLE_APPLICATION_CREDENTIALS env variable
+	require.NoError(t, err, "failed to create gcs client")
+	gcsV := gcsStore.(*gcs)
+	wg := sync.WaitGroup{}
+	gcsPut := func(path string) error {
+		buf := bytes.NewBufferString(path)
+		return gcsV.Put(ctx, path, buf, storage.OverWrite)
+	}
+	create := func(i int, wg *sync.WaitGroup) {
+		defer wg.Done()
+		path := constStringWithIndex(i)
+		e := gcsPut(path)
+		require.NoError(t, e, "Index at: "+fmt.Sprint(i))
+	}
+	for i := 0; i < numOfObjects; i++ {
+		for j := 0; j < numOfVersions; j++ {
+			wg.Add(1)
+			go create(i, &wg)
+		}
+	}
+	wg.Wait()
+
+	cleanup := func() {
+		delete := func(key string, wg *sync.WaitGroup) {
+			defer wg.Done()
+			versions, err := gcsV.KeyVersions(ctx, key)
+			require.NoError(t, err, "couldn't list versions:"+key)
+			t.Logf("have versions %v\n", versions)
+			for _, version := range versions {
+				t.Logf("deleting version %q\n", version)
+				gen, _ := strconv.ParseInt(version, 10, 64)
+				require.NoError(t,
+					gcsV.client.Bucket(bucket).Object(key).Generation(gen).Delete(ctx),
+					"failed to delete:"+key+" at version:"+version)
+			}
+		}
+
+		wg := sync.WaitGroup{}
+		for i := 0; i < numOfObjects; i++ {
+			wg.Add(1)
+			path := constStringWithIndex(i)
+			delete(path, &wg)
+		}
+		wg.Wait()
+
+		// Delete any keys created outside of setup at the end of test.
+		var keys []string
+		keys, _ = gcsV.Keys(ctx)
+		for _, key := range keys {
+			wg.Add(1)
+			delete(key, &wg)
+		}
+
+		wg.Wait()
+		t.Logf("Delete bucket %s ", bucket)
+		err = client.Bucket(bucket).Delete(ctx)
+		require.NoError(t, err, "Failed to delete bucket:"+bucket)
+	}
+
+	return gcsV, cleanup
+}
+
+func TestGcs_KeyVersions(t *testing.T) {
+	ctx := context.Background()
+	const (
+		numOfObjects  = 4
+		numOfVersions = 3
+	)
+	gcsV, cleanup := setupVersions(t, numOfObjects, numOfVersions)
+	defer cleanup()
+
+	ok, err := gcsV.IsVersioned(ctx)
+	require.True(t, ok)
+	require.NoError(t, err)
+
+	keys, err := gcsV.Keys(ctx)
+	require.NoError(t, err, "list keys")
+
+	assert.Len(t, keys, numOfObjects)
+
+	for _, key := range keys {
+		versionSet := make(map[string]bool)
+		versions, err := gcsV.KeyVersions(ctx, key)
+		require.NoError(t, err, "list versions. key: "+key)
+		assert.Len(t, versions, numOfVersions)
+
+		for _, version := range versions {
+			require.False(t, versionSet[version], "versions expected to be unique")
+			versionSet[version] = true
+
+			reader, erg := gcsV.GetVersion(ctx, key, version)
+			require.NoError(t, erg)
+
+			_, erd := ioutil.ReadAll(reader)
+			require.NoError(t, erd)
+		}
+	}
+}

--- a/pkg/storage/status/status.go
+++ b/pkg/storage/status/status.go
@@ -42,4 +42,10 @@ var (
 
 	// ErrNotImplemented tells that this feature has not been implemented yet
 	ErrNotImplemented = errors.New("not implemented")
+
+	// ErrVersioningDisabled tells that this store doesn't support versioning
+	ErrVersioningDisabled = errors.New("versioning disabled")
+
+	// ErrInvalidVersion tells that the provided version is not valid
+	ErrInvalidVersion = errors.New("invalid version")
 )

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -33,17 +33,34 @@ type Attributes struct {
 // Implementations of this interface are assumed to be fairly simple.
 type Store interface {
 	String() string
+
+	// Has this object in the store?
 	Has(context.Context, string) (bool, error)
+
+	// Get this object's backing bytes.
 	Get(context.Context, string) (io.ReadCloser, error)
+
+	// GetAttr looks up the Attributes of this object.
 	GetAttr(context.Context, string) (Attributes, error)
+
+	// Get this object's backing bytes.
 	GetAt(context.Context, string) (io.ReaderAt, error)
+
+	// Touch, like the usual *nix verb, touch(1), changes the object's modify time.
+	// Unlike touch(1), it does _not_ create an object if it doesn't exist.
 	Touch(context.Context, string) error
+
+	// Put writes bytes to a named object in the store.
 	Put(context.Context, string, io.Reader, bool) error
+
+	// Delete removes the specified object from the store.
 	Delete(context.Context, string) error
+
 	Clear(context.Context) error
 
 	// Keys returns all keys known to the store.
-	// Depending on the implementation, some limit may exist on the maximum number of such returned keys
+	// Depending on the implementation, some limit on the maximum number
+	// of such returned keys may exist.
 	Keys(context.Context) ([]string, error)
 
 	// KeyPrefix provides a paginated key iterator using "pageToken" as the next starting point
@@ -53,6 +70,17 @@ type Store interface {
 // StoreCRC knows how to update an object with a computed CRC checksum
 type StoreCRC interface {
 	PutCRC(context.Context, string, io.Reader, bool, uint32) error
+}
+
+// VersionedStore knows how to retrieve versions of object keys and objects
+type VersionedStore interface {
+	IsVersioned(context.Context) (bool, error)
+
+	// KeyVersions returns all versions of a given key
+	KeyVersions(context.Context, string) ([]string, error)
+
+	// GetVersion is like Get, but with a specific version of the object
+	GetVersion(context.Context, string, string) (io.ReadCloser, error)
 }
 
 // PipeIO copies data from a reader to a writer using io.Pipe


### PR DESCRIPTION
My own take on the versioned labels feature, hopefully with minimal changes to the existing code base.

* This allows a user to find out which bundles a given label was previously assigned
* Requires enabled versioning on vmetadata store
* Only supported with GCS

TODO: unit testing has been overlooked - this feature has only been tested manually

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>