### PR TITLE
feat: bundle upload from gcs bucket path

### DIFF
--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -722,20 +722,28 @@ func (in *cliOptionInputs) srcStore(ctx context.Context, create bool) (storage.S
 	}
 
 	if strings.HasPrefix(consumableStorePath, "gs://") {
-		infoLogger.Println(consumableStorePath[4:])
-		bucket := consumableStorePath[5:]
-		keyPrefix := ""
-		pathSepIndex := strings.Index(bucket, "/")
-		if pathSepIndex >= 0 {
-			bucket = bucket[:pathSepIndex]
-			keyPrefix = bucket[(pathSepIndex + 1):]
+		consumableStorePath = consumableStorePath[5:]
+		pathSepIndex := strings.Index(consumableStorePath, "/")
+
+		bucket := make([]string, 1)
+		keyPrefix := make([]string, 1)
+		if pathSepIndex > 0 {
+			bucket[0] = consumableStorePath[:pathSepIndex]
+			keyPrefix[0] = consumableStorePath[(pathSepIndex + 1):]
+		} else {
+			bucket[0] = consumableStorePath
+			keyPrefix[0] = ""
+		}
+		infoLogger.Printf("Bucket: %s", bucket[0])
+		if keyPrefix[0] != "" {
+			infoLogger.Printf("Key Prefix: %s", keyPrefix[0])
 		}
 		sourceStore, err = gcs.New(ctx,
-			bucket,
+			bucket[0],
 			in.config.Credential,
 			gcs.Logger(logger),
 			gcs.WithRetry(in.params.fs.WithRetry),
-			gcs.KeyPrefix(keyPrefix),
+			gcs.KeyPrefix(keyPrefix[0]),
 		)
 		if err != nil {
 			return sourceStore, err

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -723,11 +723,19 @@ func (in *cliOptionInputs) srcStore(ctx context.Context, create bool) (storage.S
 
 	if strings.HasPrefix(consumableStorePath, "gs://") {
 		infoLogger.Println(consumableStorePath[4:])
+		bucket := consumableStorePath[5:]
+		keyPrefix := ""
+		pathSepIndex := strings.Index(bucket, "/")
+		if pathSepIndex >= 0 {
+			bucket = bucket[:pathSepIndex]
+			keyPrefix = bucket[(pathSepIndex + 1):]
+		}
 		sourceStore, err = gcs.New(ctx,
-			consumableStorePath[5:],
+			bucket,
 			in.config.Credential,
 			gcs.Logger(logger),
 			gcs.WithRetry(in.params.fs.WithRetry),
+			gcs.KeyPrefix(keyPrefix),
 		)
 		if err != nil {
 			return sourceStore, err

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -728,6 +728,12 @@ func (in *cliOptionInputs) srcStore(ctx context.Context, create bool) (storage.S
 		bucket := make([]string, 1)
 		keyPrefix := make([]string, 1)
 		if pathSepIndex > 0 {
+			// Enforce all key prefixes to be suffixed with a "/" character.
+			// This makes us treat the key prefix as if it were a path within a file system and is
+			// consistent with how the "gsutil" CLI tool handles google storage URLs.
+			if !strings.HasSuffix(consumableStorePath, "/") {
+				consumableStorePath = consumableStorePath + "/"
+			}
 			bucket[0] = consumableStorePath[:pathSepIndex]
 			keyPrefix[0] = consumableStorePath[(pathSepIndex + 1):]
 		} else {

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -135,7 +135,11 @@ func addMountPathFlag(cmd *cobra.Command) string {
 func addPathFlag(cmd *cobra.Command) string {
 	const path = "path"
 	if cmd != nil {
-		cmd.Flags().StringVar(&datamonFlags.bundle.DataPath, path, "", "The path to the folder or bucket (gs://<bucket>) for the data")
+		cmd.Flags().StringVar(&datamonFlags.bundle.DataPath,
+			path,
+			"",
+			"The path to the folder or GCS URL (gs://<bucket></optional/path/>) for the data",
+		)
 	}
 	return path
 }

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -736,7 +736,7 @@ func (in *cliOptionInputs) srcStore(ctx context.Context, create bool) (storage.S
 			// This makes us treat the key prefix as if it were a path within a file system and is
 			// consistent with how the "gsutil" CLI tool handles google storage URLs.
 			if !strings.HasSuffix(consumableStorePath, "/") {
-				consumableStorePath = consumableStorePath + "/"
+				consumableStorePath += "/"
 			}
 			bucket[0] = consumableStorePath[:pathSepIndex]
 			keyPrefix[0] = consumableStorePath[(pathSepIndex + 1):]

--- a/cmd/sidecar_param/cmd/flags.go
+++ b/cmd/sidecar_param/cmd/flags.go
@@ -5,7 +5,7 @@ package cmd
 /*
 func addPathFlag(cmd *cobra.Command) string {
 	path := "path"
-	cmd.Flags().StringVar(&params.bundle.DataPath, path, "", "The path to the folder or bucket (gs://<bucket>) for the data")
+	cmd.Flags().StringVar(&params.bundle.DataPath, path, "", "The path to the folder or GCS URL (gs://<bucket></optional/path/>) for the data")
 	return path
 }
 */

--- a/docs/usage/datamon_bundle_upload.md
+++ b/docs/usage/datamon_bundle_upload.md
@@ -34,7 +34,7 @@ set label 'init'
   -h, --help                     help for upload
       --label string             The human-readable name of a label
       --message (*) string       The message describing the new bundle
-      --path (*) string          The path to the folder or bucket (gs://<bucket>) for the data
+      --path (*) string          The path to the folder or GCS URL (gs://<bucket></optional/path/>) for the data
       --repo (*) string          The name of this repository
       --skip-on-error            Skip files encounter errors while reading.The list of files is either generated or passed in. During upload files can be deleted or encounter an error. Setting this flag will skip those files. Default to false
 ```

--- a/docs/usage/datamon_diamond_split_add.md
+++ b/docs/usage/datamon_diamond_split_add.md
@@ -35,7 +35,7 @@ my-pod
       --files string             Text file containing list of files separated by newline.
   -h, --help                     help for add
       --name-filter string       A regular expression (RE2) to match names of bundle entries.
-      --path (*) string          The path to the folder or bucket (gs://<bucket>) for the data
+      --path (*) string          The path to the folder or GCS URL (gs://<bucket></optional/path/>) for the data
       --repo (*) string          The name of this repository
       --skip-on-error            Skip files encounter errors while reading.The list of files is either generated or passed in. During upload files can be deleted or encounter an error. Setting this flag will skip those files. Default to false
       --split string             The split to use

--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -217,6 +217,11 @@ func uploadBundle(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint
 	if err != nil {
 		return err
 	}
+
+	if len(files) == 0 {
+		bundle.l.Warn("Uploading bundle with 0 files")
+	}
+
 	cafsArchive, err := cafs.New(
 		cafs.LeafSize(bundle.BundleDescriptor.LeafSize),
 		cafs.Backend(bundle.BlobStore()),

--- a/pkg/storage/gcs/options.go
+++ b/pkg/storage/gcs/options.go
@@ -28,7 +28,11 @@ func WithRetry(enabled bool) Option {
 	}
 }
 
-// WithRetry enables exponential backoff retry logic to be enabled on put operations
+// KeyPrefix prepends all keys within the GCS bucket.
+// This option is used to treat a subset of keys within a GCS bucket as the contents of the gcs
+// store (essentially treating the prefix as a directory path within the bucket).
+// Objects names given as arguments and returned from the gcs store will be treated as being
+// relative to the KeyPrefix.
 func KeyPrefix(keyPrefix string) Option {
 	return func(g *gcs) {
 		g.keyPrefix = keyPrefix

--- a/pkg/storage/gcs/options.go
+++ b/pkg/storage/gcs/options.go
@@ -27,3 +27,10 @@ func WithRetry(enabled bool) Option {
 		g.retry = enabled
 	}
 }
+
+// WithRetry enables exponential backoff retry logic to be enabled on put operations
+func KeyPrefix(keyPrefix string) Option {
+	return func(g *gcs) {
+		g.keyPrefix = keyPrefix
+	}
+}

--- a/pkg/storage/gcs/store.go
+++ b/pkg/storage/gcs/store.go
@@ -129,7 +129,7 @@ func (r *gcsReader) ReadAt(p []byte, offset int64) (n int, err error) {
 	defer func() {
 		r.l.Debug("End ReadAt", zap.Int("chunk size", len(p)), zap.Int64("offset", offset), zap.Int("bytes read", n), zap.Error(err))
 	}()
-	objectReader, err := r.g.readOnlyClient.Bucket(r.g.bucket).Object(g.keyPrefix+r.objectName).NewRangeReader(
+	objectReader, err := r.g.readOnlyClient.Bucket(r.g.bucket).Object(r.g.keyPrefix+r.objectName).NewRangeReader(
 		r.g.ctx, offset, int64(len(p)))
 	if err != nil {
 		return 0, toSentinelErrors(err)

--- a/pkg/storage/gcs/store.go
+++ b/pkg/storage/gcs/store.go
@@ -308,9 +308,9 @@ func (g *gcs) KeysPrefix(ctx context.Context, pageToken string, prefix string, d
 
 	for _, objAttrs := range objects {
 		if objAttrs.Prefix != "" {
-			keys = append(keys, objAttrs.Prefix)
+			keys = append(keys, objAttrs.Prefix[len(g.keyPrefix):])
 		} else {
-			keys = append(keys, objAttrs.Name)
+			keys = append(keys, objAttrs.Name[len(g.keyPrefix):])
 		}
 	}
 	return

--- a/pkg/storage/gcs/store_test.go
+++ b/pkg/storage/gcs/store_test.go
@@ -27,7 +27,7 @@ func constStringWithIndex(i int) string {
 	return longPath + fmt.Sprint(i)
 }
 
-func setup(t testing.TB, numOfObjects int) (storage.Store, func()) {
+func setup(t testing.TB, numOfObjects int, keyPrefix string) (storage.Store, string, func()) {
 
 	ctx := context.Background()
 
@@ -39,7 +39,7 @@ func setup(t testing.TB, numOfObjects int) (storage.Store, func()) {
 	err = client.Bucket(bucket).Create(ctx, "onec-co", nil)
 	require.NoError(t, err, "Failed to create bucket:"+bucket)
 
-	gcs, err := New(context.TODO(), bucket, "") // Use GOOGLE_APPLICATION_CREDENTIALS env variable
+	gcs, err := New(context.TODO(), bucket, "", KeyPrefix(keyPrefix)) // Use GOOGLE_APPLICATION_CREDENTIALS env variable
 	require.NoError(t, err, "failed to create gcs client")
 	wg := sync.WaitGroup{}
 	create := func(i int, wg *sync.WaitGroup) {
@@ -83,13 +83,13 @@ func setup(t testing.TB, numOfObjects int) (storage.Store, func()) {
 		require.NoError(t, err, "Failed to delete bucket:"+bucket)
 	}
 
-	return gcs, cleanup
+	return gcs, bucket, cleanup
 }
 
 func TestGcs_Get(t *testing.T) {
 	ctx := context.Background()
 	count := 20
-	gcs, cleanup := setup(t, count)
+	gcs, _, cleanup := setup(t, count, "")
 	defer cleanup()
 	for i := 0; i < count; i++ {
 		rdr, err := gcs.Get(ctx, constStringWithIndex(i))
@@ -156,7 +156,7 @@ func TestGcs_Get(t *testing.T) {
 func TestGcs_Has(t *testing.T) {
 	ctx := context.Background()
 	count := 2
-	gcs, cleanup := setup(t, count)
+	gcs, _, cleanup := setup(t, count, "")
 	defer cleanup()
 
 	for i := 0; i < count; i++ {
@@ -174,7 +174,7 @@ func TestGcs_Has(t *testing.T) {
 func TestGcs_Put(t *testing.T) {
 	ctx := context.Background()
 	count := 3
-	gcs, cleanup := setup(t, 0)
+	gcs, _, cleanup := setup(t, 0, "")
 	defer cleanup()
 	for i := 0; i < count; i++ {
 		err := gcs.Put(ctx, constStringWithIndex(i), bytes.NewBufferString(constStringWithIndex(i)), storage.NoOverWrite)
@@ -195,7 +195,7 @@ func TestGcs_Put(t *testing.T) {
 func TestGcs_Keys(t *testing.T) {
 	ctx := context.Background()
 
-	gcs, cleanup := setup(t, 2)
+	gcs, _, cleanup := setup(t, 2, "")
 	defer cleanup()
 
 	key, err := gcs.Keys(ctx)
@@ -208,7 +208,7 @@ func TestGcs_Keys(t *testing.T) {
 func TestGcs_Delete(t *testing.T) {
 	ctx := context.Background()
 	count := 10
-	gcs, cleanup := setup(t, 0)
+	gcs, _, cleanup := setup(t, 0, "")
 	defer cleanup()
 
 	for i := 0; i < count; i++ {
@@ -231,7 +231,7 @@ func TestGcs_Delete(t *testing.T) {
 
 func TestGcs_CreateNew(t *testing.T) {
 	ctx := context.Background()
-	gcs, cleanup := setup(t, 0)
+	gcs, _, cleanup := setup(t, 0, "")
 	defer cleanup()
 
 	err := gcs.Put(ctx, constStringWithIndex(1), bytes.NewBufferString(constStringWithIndex(1)), storage.NoOverWrite)
@@ -252,7 +252,7 @@ func TestGcs_CreateNew(t *testing.T) {
 func TestGcs_KeysPrefix(t *testing.T) {
 	ctx := context.Background()
 	count := 124
-	gcs, cleanup := setup(t, count)
+	gcs, _, cleanup := setup(t, count, "")
 	defer cleanup()
 
 	fetch := count - 1
@@ -304,6 +304,85 @@ func listKeysBatch(gcs storage.Store, b *testing.B, count int, batch int) {
 	}
 }
 
+func TestGcs_KeyPrefixOption(t *testing.T) {
+	ctx := context.Background()
+	keyPrefix := "key/prefix/"
+	count := 0
+
+	gcsClient, err := gcsStorage.NewClient(ctx, option.WithScopes(gcsStorage.ScopeFullControl))
+	require.NoError(t, err)
+
+	gcs, bucket, cleanup := setup(t, count, keyPrefix)
+	defer cleanup()
+
+	objectName1 := "x/obj1"
+	objectName2 := "y/obj2"
+	err = gcs.Put(ctx, objectName1, bytes.NewBufferString("rawr"), storage.NoOverWrite)
+	require.NoError(t, err)
+	err = gcs.Put(ctx, objectName2, bytes.NewBufferString("rawr"), storage.NoOverWrite)
+	require.NoError(t, err)
+
+	// confirm the objects exist with the correct key prefix
+	_, err = gcsClient.Bucket(bucket).Object(keyPrefix + objectName1).Attrs(ctx)
+	require.NoError(t, err)
+	_, err = gcsClient.Bucket(bucket).Object(keyPrefix + objectName2).Attrs(ctx)
+	require.NoError(t, err)
+
+	// Has
+	has, err := gcs.Has(ctx, objectName1)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	// Keys
+	keys, err := gcs.Keys(ctx)
+	expectedKeys := []string{"x/obj1", "y/obj2"}
+	require.NoError(t, err)
+	require.Equal(t, expectedKeys, keys)
+
+	// KeyPrefix
+	keys, next, err := gcs.KeysPrefix(ctx, "", "x", "", 10)
+	expectedKeys = []string{"x/obj1"}
+	require.NoError(t, err)
+	require.Equal(t, expectedKeys, keys)
+	require.Equal(t, "", next)
+
+	// Get
+	rdr, err := gcs.Get(ctx, objectName1)
+	require.NoError(t, err)
+	b, err := ioutil.ReadAll(rdr)
+	require.NoError(t, err)
+	assert.Equal(t, "rawr", string(b))
+
+	// GetAt
+	_, err = gcs.GetAt(ctx, objectName1)
+	require.NoError(t, err)
+
+	// GetAttr
+	attrs, err := gcs.GetAttr(ctx, objectName1)
+	require.NoError(t, err)
+	updatedBefore := attrs.Updated
+
+	// Touch
+	err = gcs.Touch(ctx, objectName1)
+	require.NoError(t, err)
+	attrs, err = gcs.GetAttr(ctx, objectName1)
+	require.NoError(t, err)
+	updatedAfter := attrs.Updated
+	require.True(t, updatedAfter.After(updatedBefore))
+
+	// Delete removes the specified object from the store.
+	err = gcs.Delete(ctx, objectName1)
+	require.NoError(t, err)
+	err = gcs.Delete(ctx, objectName2)
+	require.NoError(t, err)
+
+	// confirm the objects were deleted
+	_, err = gcsClient.Bucket(bucket).Object(keyPrefix + objectName1).Attrs(ctx)
+	require.Error(t, err)
+	_, err = gcsClient.Bucket(bucket).Object(keyPrefix + objectName2).Attrs(ctx)
+	require.Error(t, err)
+}
+
 func keysPrefix100(b *testing.B, gcs storage.Store) {
 	listKeysBatch(gcs, b, TotalObjects, 100)
 }
@@ -320,7 +399,7 @@ func keysPrefix2000(b *testing.B, gcs storage.Store) {
 	listKeysBatch(gcs, b, TotalObjects, 2000)
 }
 func BenchmarkRun(b *testing.B) {
-	gcs, _ := setup(b, TotalObjects)
+	gcs, _, _ := setup(b, TotalObjects, "")
 	// defer cleanup()
 	run := func(fn func(b2 *testing.B, gcs storage.Store)) {
 		fn(b, gcs)

--- a/pkg/storage/gcs/store_test.go
+++ b/pkg/storage/gcs/store_test.go
@@ -27,7 +27,7 @@ func constStringWithIndex(i int) string {
 	return longPath + fmt.Sprint(i)
 }
 
-func setup(t testing.TB, numOfObjects int, keyPrefix string) (storage.Store, string, func()) { //nolint:ireturn
+func setup(t testing.TB, numOfObjects int, keyPrefix string) (storage.Store, string, func()) { //nolint:ireturn,varnamelen
 
 	ctx := context.Background()
 

--- a/pkg/storage/gcs/store_test.go
+++ b/pkg/storage/gcs/store_test.go
@@ -27,7 +27,7 @@ func constStringWithIndex(i int) string {
 	return longPath + fmt.Sprint(i)
 }
 
-func setup(t testing.TB, numOfObjects int, keyPrefix string) (storage.Store, string, func()) {
+func setup(t testing.TB, numOfObjects int, keyPrefix string) (storage.Store, string, func()) { //nolint:ireturn
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Allow uploading a subset of keys within a GCS bucket instead of the entire bucket contents.

- allow the `--path` option for `upload` to accept a GCS url in the format `gs://bucket/path/to/object/`
- upload all files from bucket that start with the prefix included in the URL path
  e.g. `path/to/object/`
- use file names in datamon that are relative to the given prefix
  e.g. `gs://bucket/path/to/object/is/here.tgz` -> `is/here.tgz`