### PR TITLE
fix: detect and recover from corrupted blobs [HAZ-305]

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,9 @@ linters:
     - fsintegration
     - influxdbintegration
   disable:
+    - golint
+    - interfacer
+    - scopelint
     - maligned
     - lll
     - gochecknoinits
@@ -70,5 +73,6 @@ linters:
     - containedctx
     - errname
     - maintidx
+    - nosnakecase
 
 max-same-issues: 0

--- a/cmd/datamon/cmd/bundle_download.go
+++ b/cmd/datamon/cmd/bundle_download.go
@@ -84,6 +84,7 @@ Using bundle: 1UZ6kpHe3EBoZUTkKPHSf8s2beh
 		}
 		bundleOpts = append(bundleOpts, core.Logger(logger))
 		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
+		bundleOpts = append(bundleOpts, core.BundleWithVerifyHash(datamonFlags.fs.WithVerifyHash))
 
 		bundle := core.NewBundle(
 			bundleOpts...,
@@ -135,6 +136,7 @@ func init() {
 
 	addNameFilterFlag(BundleDownloadCmd)
 	addForceDestFlag(BundleDownloadCmd)
+	addVerifyHashFlag(BundleDownloadCmd)
 
 	bundleCmd.AddCommand(BundleDownloadCmd)
 }

--- a/cmd/datamon/cmd/bundle_mutable_mount.go
+++ b/cmd/datamon/cmd/bundle_mutable_mount.go
@@ -66,12 +66,15 @@ The destination path is a temporary staging area for write operations.`,
 		}
 		bundleOpts = append(bundleOpts, core.Logger(logger))
 		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
+		bundleOpts = append(bundleOpts, core.BundleWithVerifyHash(datamonFlags.fs.WithVerifyHash))
+		bundleOpts = append(bundleOpts, core.BundleWithVerifyBlobHash(datamonFlags.fs.WithVerifyBlobHash))
 
 		bundle := core.NewBundle(bundleOpts...)
 
 		var fsOpts []fuse.Option
 		fsOpts = append(fsOpts, fuse.Logger(logger))
 		fsOpts = append(fsOpts, fuse.WithMetrics(datamonFlags.root.metrics.IsEnabled()))
+		fsOpts = append(fsOpts, fuse.VerifyHash(datamonFlags.fs.WithVerifyHash))
 
 		fs, err := fuse.NewMutableFS(bundle, fsOpts...)
 		if err != nil {
@@ -131,6 +134,8 @@ func init() {
 	addDaemonizeFlag(mutableMountBundleCmd)
 	addDataPathFlag(mutableMountBundleCmd)
 	addLabelNameFlag(mutableMountBundleCmd)
+	addVerifyHashFlag(mutableMountBundleCmd)
+	addVerifyBlobHashFlag(mutableMountBundleCmd)
 
 	mountBundleCmd.AddCommand(mutableMountBundleCmd)
 }

--- a/cmd/datamon/cmd/bundle_upload.go
+++ b/cmd/datamon/cmd/bundle_upload.go
@@ -79,6 +79,8 @@ set label 'init'
 		bundleOpts = append(bundleOpts, core.Logger(logger))
 		bundleOpts = append(bundleOpts, core.BundleWithMetrics(datamonFlags.root.metrics.IsEnabled()))
 		bundleOpts = append(bundleOpts, core.BundleWithRetry(datamonFlags.fs.WithRetry))
+		bundleOpts = append(bundleOpts, core.BundleWithVerifyHash(datamonFlags.fs.WithVerifyHash))
+		bundleOpts = append(bundleOpts, core.BundleWithVerifyBlobHash(datamonFlags.fs.WithVerifyBlobHash))
 
 		// feature guard
 		if enableBundlePreserve {
@@ -163,6 +165,8 @@ func init() {
 	addSkipMissingFlag(uploadBundleCmd)
 	addConcurrencyFactorFlag(uploadBundleCmd, 100)
 	addRetryFlag(uploadBundleCmd)
+	addVerifyHashFlag(uploadBundleCmd)
+	addVerifyBlobHashFlag(uploadBundleCmd)
 
 	// feature guard
 	if enableBundlePreserve {

--- a/cmd/datamon/cmd/flags.go
+++ b/cmd/datamon/cmd/flags.go
@@ -40,12 +40,13 @@ type flagsT struct {
 		ForceDest         bool
 	}
 	fs struct {
-		MountPath      string
-		Stream         bool
-		CacheSize      flagext.ByteSize
-		WithPrefetch   int
-		WithVerifyHash bool
-		WithRetry      bool
+		MountPath          string
+		Stream             bool
+		CacheSize          flagext.ByteSize
+		WithPrefetch       int
+		WithVerifyHash     bool
+		WithVerifyBlobHash bool
+		WithRetry          bool
 	}
 	web struct {
 		port      int
@@ -407,7 +408,7 @@ func addPrefetchFlag(cmd *cobra.Command) string {
 func addVerifyHashFlag(cmd *cobra.Command) string {
 	const c = "verify-hash"
 	if cmd != nil {
-		cmd.Flags().BoolVar(&datamonFlags.fs.WithVerifyHash, c, true, "Enables hash verification on read blobs (requires Stream enabled)")
+		cmd.Flags().BoolVar(&datamonFlags.fs.WithVerifyHash, c, true, "Enables hash verification on read blobs and written root key (for mount, requires Stream enabled)")
 	}
 	return c
 }
@@ -561,6 +562,14 @@ func addRetryFlag(cmd *cobra.Command) string {
 	const c = "retry"
 	if cmd != nil {
 		cmd.Flags().BoolVar(&datamonFlags.fs.WithRetry, c, true, `Enables exponential backoff retry logic to be enabled on put operations`)
+	}
+	return c
+}
+
+func addVerifyBlobHashFlag(cmd *cobra.Command) string {
+	const c = "verify-blob-hash"
+	if cmd != nil {
+		cmd.Flags().BoolVar(&datamonFlags.fs.WithVerifyBlobHash, c, false, `Enable blob hash verification for each uploaded blob`)
 	}
 	return c
 }

--- a/pkg/cafs/cafs_options.go
+++ b/pkg/cafs/cafs_options.go
@@ -92,7 +92,8 @@ func Prefetch(ahead int) Option {
 	}
 }
 
-// VerifyHash enables hash verification on blob objects
+// VerifyHash enables hash verification on read blob objects and written root keys.
+// This is enabled by default.
 func VerifyHash(enabled bool) Option {
 	return func(w *defaultFs) {
 		w.withVerifyHash = enabled
@@ -116,8 +117,17 @@ func WithMetrics(enabled bool) Option {
 }
 
 // WithRetry enables exponential backoff retry logic to be enabled on put operations
+// This is disabled by default.
 func WithRetry(enabled bool) Option {
 	return func(w *defaultFs) {
 		w.withRetry = enabled
+	}
+}
+
+// VerifyBlobHash enables hash verification on all written blob objects.
+// This is enabled by default.
+func VerifyBlobHash(enabled bool) Option {
+	return func(w *defaultFs) {
+		w.withVerifyBlobHash = enabled
 	}
 }

--- a/pkg/cafs/check_blob.go
+++ b/pkg/cafs/check_blob.go
@@ -1,0 +1,92 @@
+package cafs
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+
+	"github.com/oneconcern/datamon/pkg/errors"
+	"github.com/oneconcern/datamon/pkg/storage"
+	"go.uber.org/zap"
+)
+
+// existsAndValidBlob verifies a blob chunk against its expected size and CRC32C hash, for stores that support CRC.
+func existsAndValidBlob(ctx context.Context, store storage.Store, pth string, data []byte, lg *zap.Logger) (found bool, overwrite bool) {
+	attr, err := store.GetAttr(ctx, pth)
+	found = err == nil
+
+	switch {
+	// edge cases detection: figure out possible corruptions
+	// this detects edge cases in which the blob has already been created by some previous upload.
+
+	case found && attr.Size == 0:
+		// the previous upload somehow that upload did not end up correctly: the object is there but empty.
+		// This is the simplest case, and easiest to detect. It is also the only case that we have been
+		// able to actually see over 4 years using cafs.
+		lg.Warn("cafs found the same root key for this hash blob, but it's empty! About to overwrite it")
+
+		overwrite = true
+
+	case found && attr.Size > 0 && attr.CRC32C > 0:
+		// inspect the CRC32C hash, for backends that support it (e.g. not local fs)
+		crc := crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli))
+		if crc != attr.CRC32C {
+			lg.Warn("cafs found the same root key for this hash blob, but the content's CRC32 hash doesn't match. About to overwrite it")
+
+			overwrite = true
+		}
+
+		// the previous upload somehow that upload did not end up correctly:
+		// 1. either we got an incomplete write.
+		// 2. or we got a hash collision: this key conflicts with some other data item. This is extremely unlikely
+		// unless we hit a bug in the Blake2D hashing function.
+		//
+		// (1) is unlikely but not impossible. (2) is so much more unlikely than (1) than we may consider it impossible, as compared to (1).
+		//
+		// NOTE(fred): a few thorough analysis papers study collisions when using Blake2B.
+		// https://eprint.iacr.org/2013/467.pdf.
+		// https://link.springer.com/content/pdf/10.1007/978-3-642-38980-1_8.pdf
+		// Collision probabilities indicated there are however super unlikely, e.g << 2^-480
+		// While this analysis is conducted in the context of attacking the hash function (i.e. finding the complexity of an algorithm that finds a collision),
+		// these metrics can be roughly used as a upper-bound for the probability of a random collision, which should be actually be much lower.
+	}
+
+	return found, overwrite
+}
+
+// verifyBlob verifies that a written blob is as expected.
+func verifyBlob(ctx context.Context, store storage.Store, pth string, data []byte, lg *zap.Logger) error {
+	attr, err := store.GetAttr(ctx, pth)
+	if err != nil {
+		return fmt.Errorf("could not retrieve blob key (%q): %w", pth, err)
+	}
+
+	if attr.Size != int64(len(data)) {
+		err = errors.New("verification of blob content failed: sizes differ")
+
+		lg.Error("cafs flush with root key error",
+			zap.Error(err),
+			zap.Int("written_size", len(data)),
+			zap.Int64("read_size", attr.Size),
+		)
+
+		return err
+	}
+
+	crc := crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli))
+	if attr.CRC32C > 0 && crc != attr.CRC32C {
+		err = errors.New("verification of blob content failed: CRC32 differ")
+
+		lg.Error("cafs flush with blob checksum error",
+			zap.Error(err),
+			zap.Int("expected_size", len(data)),
+			zap.Int64("reread_size", attr.Size),
+			zap.Uint32("expected_crc32", crc),
+			zap.Uint32("reread_crc32", attr.CRC32C),
+		)
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cafs/mocks_test.go
+++ b/pkg/cafs/mocks_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/oneconcern/datamon/pkg/storage"
 	"github.com/oneconcern/datamon/pkg/storage/localfs"
 	"github.com/spf13/afero"
+	"go.uber.org/zap"
 )
 
 const (
@@ -111,6 +112,12 @@ func setupTestData(dir string, files []testFile) (*testDataGenerator, storage.St
 	defer func() {
 		log.Printf("INFO: setup duration: %v", time.Since(t0).Truncate(time.Millisecond))
 	}()
+	var lg *zap.Logger
+	if os.Getenv("DEBUG_TEST") != "" {
+		lg = dlogger.MustGetLogger("debug")
+	} else {
+		lg = dlogger.MustGetLogger("warn")
+	}
 
 	_ = os.RemoveAll(dir)
 
@@ -119,7 +126,7 @@ func setupTestData(dir string, files []testFile) (*testDataGenerator, storage.St
 		LeafSize(leafSize),
 		Backend(blobs),
 		LeafTruncation(false),
-		Logger(dlogger.MustGetLogger("warn")),
+		Logger(lg),
 	)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/cafs/reader.go
+++ b/pkg/cafs/reader.go
@@ -119,6 +119,7 @@ func newReader(blobs storage.Store, hash Key, leafSize uint32, opts ...ReaderOpt
 	if c.MetricsEnabled() {
 		c.m = c.EnsureMetrics("cafs", &M{}).(*M)
 	}
+
 	return c, nil
 }
 

--- a/pkg/cafs/writer_options.go
+++ b/pkg/cafs/writer_options.go
@@ -48,3 +48,10 @@ func WriterWithMetrics(enabled bool) WriterOption {
 		}
 	}
 }
+
+// WriterWithVerifyHash enables hash verification on written blobs.
+func WriterWithVerifyHash(enabled bool) WriterOption {
+	return func(writer *fsWriter) {
+		writer.withVerifyHash = enabled
+	}
+}

--- a/pkg/core/bundle.go
+++ b/pkg/core/bundle.go
@@ -38,6 +38,8 @@ type Bundle struct {
 	concurrentFileUploads       int
 	concurrentFileDownloads     int
 	concurrentFilelistDownloads int
+	withVerifyHash              bool // When downloading file
+	withVerifyBlobHash          bool // When uploading files
 
 	metrics.Enable
 	m *M
@@ -132,6 +134,7 @@ func defaultBundle() *Bundle {
 		concurrentFileUploads:       20,
 		concurrentFileDownloads:     10,
 		concurrentFilelistDownloads: 10,
+		withVerifyHash:              true,
 		l:                           dlogger.MustGetLogger("info"),
 	}
 }
@@ -146,6 +149,10 @@ func NewBundle(opts ...BundleOption) *Bundle {
 	if b.MetricsEnabled() {
 		b.m = b.EnsureMetrics("core", &M{}).(*M)
 	}
+	if !b.withVerifyHash {
+		b.l.Warn("hash verification disabled")
+	}
+
 	return b
 }
 

--- a/pkg/core/bundle_options.go
+++ b/pkg/core/bundle_options.go
@@ -47,7 +47,7 @@ func BundleID(bID string) BundleOption {
 	}
 }
 
-// SkipMissing indicates that bundle retrieval errors should be ignored. Currently not implementated.
+// SkipMissing indicates that bundle retrieval errors should be ignored. Currently not implemented.
 func SkipMissing(s bool) BundleOption {
 	return func(b *Bundle) {
 		b.SkipOnError = s
@@ -93,5 +93,19 @@ func BundleWithMetrics(enabled bool) BundleOption {
 func BundleWithRetry(enabled bool) BundleOption {
 	return func(b *Bundle) {
 		b.Retry = enabled
+	}
+}
+
+// BundleWithVerifyHash toggles hash verification when downloading (enabled by default).
+func BundleWithVerifyHash(enabled bool) BundleOption {
+	return func(b *Bundle) {
+		b.withVerifyHash = enabled
+	}
+}
+
+// BundleWithVerifyBlob toggles root key verification when uploading (enabled by default).
+func BundleWithVerifyBlobHash(enabled bool) BundleOption {
+	return func(b *Bundle) {
+		b.withVerifyBlobHash = enabled
 	}
 }

--- a/pkg/core/bundle_pack.go
+++ b/pkg/core/bundle_pack.go
@@ -230,6 +230,8 @@ func uploadBundle(ctx context.Context, bundle *Bundle, bundleEntriesPerFile uint
 		cafs.Logger(bundle.l),
 		cafs.WithMetrics(bundle.MetricsEnabled()),
 		cafs.WithRetry(bundle.Retry),
+		cafs.VerifyHash(bundle.withVerifyHash),
+		cafs.VerifyBlobHash(bundle.withVerifyBlobHash),
 	)
 	if err != nil {
 		return err

--- a/pkg/core/bundle_unpack.go
+++ b/pkg/core/bundle_unpack.go
@@ -546,9 +546,9 @@ func unpackDataFiles(ctx context.Context, bundle *Bundle,
 		cafs.LeafTruncation(bundle.BundleDescriptor.Version < 1),
 		cafs.Backend(bundle.BlobStore()),
 		cafs.ReaderConcurrentChunkWrites(bundle.concurrentFileDownloads/fileDownloadsPerConcurrentChunks),
-		cafs.VerifyHash(true),
 		cafs.Logger(bundle.l),
 		cafs.WithMetrics(bundle.MetricsEnabled()),
+		cafs.VerifyHash(bundle.withVerifyHash),
 	)
 	if err != nil {
 		return err
@@ -611,6 +611,7 @@ func unpackDataFile(ctx context.Context, bundle *Bundle, file string) error {
 		cafs.Logger(bundle.l),
 		cafs.ReaderConcurrentChunkWrites(bundle.concurrentFileDownloads/fileDownloadsPerConcurrentChunks),
 		cafs.WithMetrics(bundle.MetricsEnabled()),
+		cafs.VerifyHash(bundle.withVerifyHash),
 	)
 	if err != nil {
 		return err

--- a/pkg/storage/gcs/store.go
+++ b/pkg/storage/gcs/store.go
@@ -178,6 +178,8 @@ func (g *gcs) GetAttr(ctx context.Context, objectName string) (storage.Attribute
 		Created: attr.Created,
 		Updated: attr.Updated,
 		Owner:   attr.Owner,
+		Size:    attr.Size,
+		CRC32C:  attr.CRC32C,
 	}, nil
 }
 

--- a/pkg/storage/localfs/store.go
+++ b/pkg/storage/localfs/store.go
@@ -400,14 +400,20 @@ func (l *localFS) GetAttr(ctx context.Context, objectName string) (storage.Attri
 	if err != nil {
 		return storage.Attributes{}, err
 	}
+
+	// do not block when UID is not available on local os
+	var owner string
 	sys, ok := stat.Sys().(syscall.Stat_t)
-	if !ok {
-		return storage.Attributes{}, fmt.Errorf("failed to convert sys to Stat_t for object:%s", objectName)
+	if ok {
+		owner = fmt.Sprint(sys.Uid)
 	}
+
 	return storage.Attributes{
 		Created: stat.ModTime(), // Fix me: need a platform independent way to extracting timestamps
 		Updated: stat.ModTime(),
-		Owner:   fmt.Sprint(sys.Uid),
+		Owner:   owner,
+		Size:    stat.Size(),
+		// CRC32C not supported on localfs
 	}, nil
 
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -25,6 +25,8 @@ type Attributes struct {
 	Created time.Time
 	Updated time.Time
 	Owner   string
+	Size    int64
+	CRC32C  uint32
 }
 
 // Store implementations know how to fetch and write entries from a and a K/V store.


### PR DESCRIPTION
On some rare but not impossible occasion, the written root key for a file may become corrupted.

In that case, if the blob has been written, it would never be overwritten again and it becomes impossible to recover that file, even after several subsequent uploads. What is worse, this situation goes completely undetected, and the corruption occurs silently until we attempt to read the corrupted file.

We think a similar situation may occur on any written blob.

This PR proposes a better handling of this situation, even though it remains impossible to totally guarantee against corruptions.

1. Every time we are about to write a root key blob (for each uploaded file), a checksum check is carried out _before_ we decide to skip the write. If the check is unsuccessful, this means that the existing key is corrupted: a warning is emitted and the key is overwritten.

2. Every time we write a root key blob (for each uploaded file), a checksum check is carried out _after_ the write. The upload fails if this is not successful (this check may be disabled with --verify-hash=false).

3. Paranoid mode enabled with --verify-blob-hash (disabled by default). Implement the same as above on all written blobs, not just root keys.

Signed-off-by: Frederic BIDON <frederic@oneconcern.com>